### PR TITLE
xmlparse.c: pacify C compiler warning

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -729,7 +729,14 @@ generate_hash_secret_salt(XML_Parser parser)
   /* Process ID is 0 bits entropy if attacker has local access
    * XML_Parser address is few bits of entropy if attacker has local access */
   const unsigned long entropy =
-      gather_time_entropy() ^ getpid() ^ (unsigned long)parser;
+      gather_time_entropy() ^ getpid() ^
+#if defined( _WIN64 ) && defined( __GNUC__ )
+      (unsigned long)(unsigned long long)parser;
+#elif defined( _WIN64 )
+      (unsigned long)(unsigned __int64)parser;
+#else
+      (unsigned long)parser;
+#endif
 
   /* Factors are 2^31-1 and 2^61-1 (Mersenne primes M31 and M61) */
   if (sizeof(unsigned long) == 4) {


### PR DESCRIPTION
when built in 64-bit mode using mingw:
```
../../../xmlparse.c: In function ‘generate_hash_secret_salt’:
../../../xmlparse.c:725:42: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
       gather_time_entropy() ^ getpid() ^ (unsigned long)parser;
                                          ^
```
Silence the similar potential warning on other Windows 64-bit C compilers.