### PR TITLE
Use more sources of high quality entropy (Linux, BSD, Windows)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -3,12 +3,11 @@ Release ??????????
                   CVE-2016-9063 -- Detect integer overflow
              #25  More integer overflow detection (function poolGrow)
                   Use high quality entropy for hash initialization:
-                    * arc4random_buf on BSD, systems with libbsd, CloudABI
+                    * arc4random_buf on BSD, systems with libbsd
+                      (when configured with --with-libbsd), CloudABI
                     * RtlGenRandom on Windows XP / Server 2003 and later
                     * getrandom on Linux 3.17+
                   In a way, that's still part of CVE-2016-5300.
-                  For packaging, feel free to configure using
-                  --(with|without)-libbsd to bypass auto-detection.
                   For run-time debug output, EXPAT_ENTROPY_DEBUG=1 can be used.
 
         Bug fixes:

--- a/expat/Changes
+++ b/expat/Changes
@@ -9,6 +9,7 @@ Release ??????????
                   In a way, that's still part of CVE-2016-5300.
                   For packaging, feel free to configure using
                   --(with|without)-libbsd to bypass auto-detection.
+                  For run-time debug output, EXPAT_ENTROPY_DEBUG=1 can be used.
 
         Bug fixes:
             #539  Fix regression from fix to CVE-2016-0718 cutting off

--- a/expat/Changes
+++ b/expat/Changes
@@ -5,7 +5,7 @@ Release ??????????
                   Use high quality entropy for hash initialization:
                     * arc4random_buf on BSD, systems with libbsd, CloudABI
                     * RtlGenRandom on Windows XP / Server 2003 and later
-                    * getrandom on glic 2.25+ Linux 3.17+
+                    * getrandom on Linux 3.17+
                   In a way, that's still part of CVE-2016-5300.
                   For packaging, feel free to configure using
                   --(with|without)-libbsd to bypass auto-detection.

--- a/expat/Changes
+++ b/expat/Changes
@@ -7,6 +7,8 @@ Release ??????????
                     * RtlGenRandom on Windows XP / Server 2003 and later
                     * getrandom on glic 2.25+ Linux 3.17+
                   In a way, that's still part of CVE-2016-5300.
+                  For packaging, feel free to configure using
+                  --(with|without)-libbsd to bypass auto-detection.
 
         Bug fixes:
             #539  Fix regression from fix to CVE-2016-0718 cutting off

--- a/expat/Changes
+++ b/expat/Changes
@@ -2,6 +2,11 @@ Release ??????????
         Security fixes:
                   CVE-2016-9063 -- Detect integer overflow
              #25  More integer overflow detection (function poolGrow)
+                  Use high quality entropy for hash initialization:
+                    * arc4random_buf on BSD, systems with libbsd, CloudABI
+                    * RtlGenRandom on Windows XP / Server 2003 and later
+                    * getrandom on glic 2.25+ Linux 3.17+
+                  In a way, that's still part of CVE-2016-5300.
 
         Bug fixes:
             #539  Fix regression from fix to CVE-2016-0718 cutting off

--- a/expat/Makefile.in
+++ b/expat/Makefile.in
@@ -124,7 +124,7 @@ LTFLAGS = --verbose
 COMPILE = $(CC) $(INCLUDES) $(CFLAGS) $(DEFS) $(CPPFLAGS)
 CXXCOMPILE = $(CXX) $(INCLUDES) $(CXXFLAGS) $(DEFS) $(CPPFLAGS)
 LTCOMPILE = $(LIBTOOL) $(LTFLAGS) --mode=compile $(COMPILE)
-LINK_LIB = $(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) -no-undefined $(VSNFLAG) -rpath $(libdir) $(LDFLAGS) -o $@
+LINK_LIB = $(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) -no-undefined $(VSNFLAG) -rpath $(libdir) $(LDFLAGS) @LIBS@ -o $@
 LINK_EXE = $(LIBTOOL) $(LTFLAGS) --mode=link $(COMPILE) $(LDFLAGS) -o $@
 LINK_CXX_EXE = $(LIBTOOL) $(LTFLAGS) --mode=link $(CXXCOMPILE) $(LDFLAGS) -o $@
 

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -100,7 +100,16 @@ AC_TYPE_SIZE_T
 AC_CHECK_FUNCS(memmove bcopy)
 
 
-AC_CHECK_LIB([bsd], [arc4random_buf])
+AC_ARG_WITH([libbsd], [
+AS_HELP_STRING([--with-libbsd], [enforce use of libbsd])
+AS_HELP_STRING([--without-libbsd], [prohibit use of libbsd])])
+AS_IF([test "x${with_libbsd}" != xno], [
+  AC_CHECK_LIB([bsd], [arc4random_buf], [], [
+    AS_IF([test "x${with_libbsd}" = xyes], [
+      AC_MSG_ERROR([Enforced use of libbsd cannot be satisfied.])
+    ])
+  ])
+])
 AC_MSG_CHECKING([for arc4random_buf (BSD or libbsd)])
 AC_LINK_IFELSE([AC_LANG_SOURCE([
   #include <stdlib.h>  /* for arc4random_buf on BSD, for NULL */

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -99,6 +99,23 @@ AC_C_CONST
 AC_TYPE_SIZE_T
 AC_CHECK_FUNCS(memmove bcopy)
 
+
+AC_MSG_CHECKING([for getrandom (Linux 3.17+, glibc 2.25+)])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+  #include <stdlib.h>  /* for NULL */
+  #include <sys/random.h>
+  int main() {
+    return getrandom(NULL, 0U, 0U);
+  }
+])], [
+    AC_DEFINE([HAVE_GETRANDOM], [1],
+        [Define to 1 if you have the `getrandom' function.])
+    AC_MSG_RESULT([yes])
+], [
+    AC_MSG_RESULT([no])
+])
+
+
 dnl Only needed for xmlwf:
 AC_CHECK_HEADERS(fcntl.h unistd.h)
 AC_TYPE_OFF_T

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -101,8 +101,8 @@ AC_CHECK_FUNCS(memmove bcopy)
 
 
 AC_ARG_WITH([libbsd], [
-AS_HELP_STRING([--with-libbsd], [enforce use of libbsd])
-AS_HELP_STRING([--without-libbsd], [prohibit use of libbsd])])
+AS_HELP_STRING([--with-libbsd], [utilize libbsd (for arc4random_buf)])
+], [], [with_libbsd=no])
 AS_IF([test "x${with_libbsd}" != xno], [
   AC_CHECK_LIB([bsd], [arc4random_buf], [], [
     AS_IF([test "x${with_libbsd}" = xyes], [

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -100,6 +100,26 @@ AC_TYPE_SIZE_T
 AC_CHECK_FUNCS(memmove bcopy)
 
 
+AC_CHECK_LIB([bsd], [arc4random_buf])
+AC_MSG_CHECKING([for arc4random_buf (BSD or libbsd)])
+AC_LINK_IFELSE([AC_LANG_SOURCE([
+  #include <stdlib.h>  /* for arc4random_buf on BSD, for NULL */
+  #if defined(HAVE_LIBBSD)
+  # include <bsd/stdlib.h>
+  #endif
+  int main() {
+    arc4random_buf(NULL, 0U);
+    return 0;
+  }
+])], [
+    AC_DEFINE([HAVE_ARC4RANDOM_BUF], [1],
+        [Define to 1 if you have the `arc4random_buf' function.])
+    AC_MSG_RESULT([yes])
+], [
+    AC_MSG_RESULT([no])
+])
+
+
 AC_MSG_CHECKING([for getrandom (Linux 3.17+, glibc 2.25+)])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([
   #include <stdlib.h>  /* for NULL */

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -142,6 +142,23 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([
     AC_MSG_RESULT([yes])
 ], [
     AC_MSG_RESULT([no])
+
+    AC_MSG_CHECKING([for syscall SYS_getrandom (Linux 3.17+)])
+    AC_LINK_IFELSE([AC_LANG_SOURCE([
+      #include <stdlib.h>  /* for NULL */
+      #include <unistd.h>  /* for syscall */
+      #include <sys/syscall.h>  /* for SYS_getrandom */
+      int main() {
+        syscall(SYS_getrandom, NULL, 0, 0);
+        return 0;
+      }
+    ])], [
+        AC_DEFINE([HAVE_SYSCALL_GETRANDOM], [1],
+            [Define to 1 if you have `syscall' and `SYS_getrandom'.])
+        AC_MSG_RESULT([yes])
+    ], [
+        AC_MSG_RESULT([no])
+    ])
 ])
 
 

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -786,14 +786,6 @@ gather_time_entropy(void)
 static unsigned long
 generate_hash_secret_salt(XML_Parser parser)
 {
-#if defined(__UINTPTR_TYPE__)
-# define PARSER_CAST(p)  (__UINTPTR_TYPE__)(p)
-#elif defined(_WIN64) && defined(_MSC_VER)
-# define PARSER_CAST(p)  (unsigned __int64)(p)
-#else
-# define PARSER_CAST(p)  (p)
-#endif
-
 #if defined(HAVE_ARC4RANDOM_BUF) || defined(__CloudABI__)
   unsigned long entropy;
   (void)parser;
@@ -815,10 +807,8 @@ generate_hash_secret_salt(XML_Parser parser)
 #endif
   /* .. and self-made low quality for backup: */
 
-  /* Process ID is 0 bits entropy if attacker has local access
-   * XML_Parser address is few bits of entropy if attacker has local access */
-  entropy =
-      gather_time_entropy() ^ getpid() ^ (unsigned long)PARSER_CAST(parser);
+  /* Process ID is 0 bits entropy if attacker has local access */
+  entropy = gather_time_entropy() ^ getpid();
 
   /* Factors are 2^31-1 and 2^61-1 (Mersenne primes M31 and M61) */
   if (sizeof(unsigned long) == 4) {

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -779,6 +779,10 @@ gather_time_entropy(void)
 #endif
 }
 
+#if defined(HAVE_ARC4RANDOM_BUF) && defined(HAVE_LIBBSD)
+# include <bsd/stdlib.h>
+#endif
+
 static unsigned long
 generate_hash_secret_salt(XML_Parser parser)
 {
@@ -790,7 +794,7 @@ generate_hash_secret_salt(XML_Parser parser)
 # define PARSER_CAST(p)  (p)
 #endif
 
-#ifdef __CloudABI__
+#if defined(HAVE_ARC4RANDOM_BUF) || defined(__CloudABI__)
   unsigned long entropy;
   (void)parser;
   (void)gather_time_entropy;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2,6 +2,8 @@
    See the file COPYING for copying permission.
 */
 
+#define _GNU_SOURCE                     /* syscall prototype */
+
 #include <stddef.h>
 #include <string.h>                     /* memset(), memcpy() */
 #include <assert.h>

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -786,15 +786,13 @@ gather_time_entropy(void)
 static unsigned long
 generate_hash_secret_salt(XML_Parser parser)
 {
-#if defined(HAVE_ARC4RANDOM_BUF) || defined(__CloudABI__)
   unsigned long entropy;
   (void)parser;
+#if defined(HAVE_ARC4RANDOM_BUF) || defined(__CloudABI__)
   (void)gather_time_entropy;
   arc4random_buf(&entropy, sizeof(entropy));
   return entropy;
 #else
-  unsigned long entropy;
-
   /* Try high quality providers first .. */
 #ifdef _WIN32
   if (writeRandomBytes_RtlGenRandom((void *)&entropy, sizeof(entropy))) {


### PR DESCRIPTION
Hi!

I have applied care but it's the first take and I wasn't able to test on all involved platforms, especially not Windows.
So I value your review, testing, anything!

For Windows, @catalinr, @vszakats, @tbeu, @kwaclaw I would be grateful for your help.
@EdSchouten have a minute to see if the `libbsd`/`arc4random_buf` use and integration make sense? Does CloudABI support still work?
@hannob, @RMJ10 see anything wrong here?

Many thanks in advance!


Sebastian

PS: I'm looking for help/mentoring on porting the new detection bits from Autoconf to CMake as well. If you known anyone, please send him/her my way.