### PR TITLE
Fix building on win32 if _UNICODE is defined

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -749,7 +749,7 @@ typedef BOOLEAN (APIENTRY *RTLGENRANDOM_FUNC)(PVOID, ULONG);
 static int
 writeRandomBytes_RtlGenRandom(void * target, size_t count) {
   int success = 0;  /* full count bytes written? */
-  const HMODULE advapi32 = LoadLibrary("ADVAPI32.DLL");
+  const HMODULE advapi32 = LoadLibraryA("ADVAPI32.DLL");
 
   if (advapi32) {
     const RTLGENRANDOM_FUNC RtlGenRandom


### PR DESCRIPTION
Explicitly use `LoadLibraryA()` instead of the `LoadLibrary()` macro, which may expand to `LoadLibraryW()` depending on build configuration. This is of course non-issue for Expat's own build system, but OTOH, it impacts embedded copies and it's also arguably cleaner code to either explicitly use the ANSI functions or use string macros for arguments (`_T("ADVAPI32.DLL")`).

It's also worth nothing that Visual Studio doesn't error out on this, but products only a warning in C:

```
lib\xmlparse.c(752): warning C4133:
'function': incompatible types - from 'char [13]' to 'LPCWSTR'
```

The consequences of passing `char*` instead of `wchar_t*` to the function are of course disastrous, and warnings may be overlooked. 