### PR TITLE
LoadLibrary() call to work correctly regardless of _UNICODE setting

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -749,7 +749,7 @@ typedef BOOLEAN (APIENTRY *RTLGENRANDOM_FUNC)(PVOID, ULONG);
 static int
 writeRandomBytes_RtlGenRandom(void * target, size_t count) {
   int success = 0;  /* full count bytes written? */
-  const HMODULE advapi32 = LoadLibraryA("ADVAPI32.DLL");
+  const HMODULE advapi32 = LoadLibrary(TEXT("ADVAPI32.DLL"));
 
   if (advapi32) {
     const RTLGENRANDOM_FUNC RtlGenRandom


### PR DESCRIPTION
This solution allows the build system to chose whichever mode, instead
of forcing the "ANSI" flavour of the API.