### PR TITLE
[rfc] Improve on current use of LoadLibrary (rather than LoadLibraryEx)

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -740,6 +740,10 @@ writeRandomBytes_getrandom(void * target, size_t count) {
 
 typedef BOOLEAN (APIENTRY *RTLGENRANDOM_FUNC)(PVOID, ULONG);
 
+#ifndef LOAD_LIBRARY_SEARCH_SYSTEM32
+# define LOAD_LIBRARY_SEARCH_SYSTEM32  0x00000800
+#endif
+
 /* Obtain entropy on Windows XP / Windows Server 2003 and later.
  * Hint on RtlGenRandom and the following article from libsodioum.
  *
@@ -749,7 +753,7 @@ typedef BOOLEAN (APIENTRY *RTLGENRANDOM_FUNC)(PVOID, ULONG);
 static int
 writeRandomBytes_RtlGenRandom(void * target, size_t count) {
   int success = 0;  /* full count bytes written? */
-  const HMODULE advapi32 = LoadLibrary(TEXT("ADVAPI32.DLL"));
+  const HMODULE advapi32 = LoadLibraryEx(TEXT("ADVAPI32.DLL"), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
   if (advapi32) {
     const RTLGENRANDOM_FUNC RtlGenRandom


### PR DESCRIPTION
* also enable LOAD_LIBRARY_SEARCH_SYSTEM32 flag to ensure that
ADVAPI32.DLL gets loaded from the system32 directory on Windows
versions that support this flag.

From https://msdn.microsoft.com/library/windows/desktop/ms684179:
> "If this value is used, %windows%\system32 is searched for the DLL and its dependencies.
> Directories in the standard search path are not searched. This value cannot be combined with
> LOAD_WITH_ALTERED_SEARCH_PATH.
> Windows 7, Windows Server 2008 R2, Windows Vista and Windows Server 2008:  This value requires > KB2533623 to be installed.
> Windows Server 2003 and Windows XP:  This value is not supported."
