### PR TITLE
Add means to avoid downloading xmlts.zip in coverage tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
   apt:
     packages:
       - docbook2x
+      - dos2unix
 
 script:
   - cd expat

--- a/expat/Makefile.in
+++ b/expat/Makefile.in
@@ -181,8 +181,11 @@ run-benchmark: tests/benchmark/benchmark
 	tests/benchmark/benchmark@EXEEXT@ -n $(top_srcdir)/../testdata/largefiles/recset.xml 65535 3
 
 tests/xmlts.zip:
-	wget --output-document=tests/xmlts.zip \
-		https://www.w3.org/XML/Test/xmlts20080827.zip
+	if test "$(XMLTS_DIR)" = ""; \
+		then wget --output-document=tests/xmlts.zip \
+			https://www.w3.org/XML/Test/xmlts20080827.zip; \
+		else cp $(XMLTS_DIR)/xmlts.zip tests/xmlts.zip; \
+	fi
 
 tests/xmlconf: tests/xmlts.zip
 	cd tests && unzip -q xmlts.zip

--- a/expat/Makefile.in
+++ b/expat/Makefile.in
@@ -181,10 +181,11 @@ run-benchmark: tests/benchmark/benchmark
 	tests/benchmark/benchmark@EXEEXT@ -n $(top_srcdir)/../testdata/largefiles/recset.xml 65535 3
 
 tests/xmlts.zip:
-	if test "$(XMLTS_DIR)" = ""; \
-		then wget --output-document=tests/xmlts.zip \
+	if test "$(XMLTS_ZIP)" = ""; then \
+		wget --output-document=tests/xmlts.zip \
 			https://www.w3.org/XML/Test/xmlts20080827.zip; \
-		else cp $(XMLTS_DIR)/xmlts.zip tests/xmlts.zip; \
+	else \
+		cp $(XMLTS_ZIP) tests/xmlts.zip; \
 	fi
 
 tests/xmlconf: tests/xmlts.zip


### PR DESCRIPTION
Modifies tests/xmlts.zip so that if the environment variable `XMLTS_DIR` is set, the file xmlts.zip will be copied from there rather than downloaded again from xml.org.  I currently need this because I have a very limited internet connection.