### PR TITLE
Fix conftools/get-version.sh per Gentoo bug 622360

### DIFF
--- a/expat/conftools/get-version.sh
+++ b/expat/conftools/get-version.sh
@@ -32,15 +32,4 @@ MAJOR_VERSION="`sed -n -e '/MAJOR_VERSION/s/[^0-9]*//gp' $hdr`"
 MINOR_VERSION="`sed -n -e '/MINOR_VERSION/s/[^0-9]*//gp' $hdr`"
 MICRO_VERSION="`sed -n -e '/MICRO_VERSION/s/[^0-9]*//gp' $hdr`"
 
-# Determine how to tell echo not to print the trailing \n. This is
-# similar to Autoconf's @ECHO_C@ and @ECHO_N@; however, we don't
-#  generate this file via autoconf (in fact, get-version.sh is used
-# to *create* ./configure), so we just do something similar inline.
-case `echo "testing\c"; echo 1,2,3`,`echo -n testing; echo 1,2,3` in
-  *c*,-n*) ECHO_N= ECHO_C='
-' ;;
-  *c*,*  ) ECHO_N=-n ECHO_C= ;;
-  *)      ECHO_N= ECHO_C='\c' ;;
-esac
-
-echo $ECHO_N "$MAJOR_VERSION.$MINOR_VERSION.$MICRO_VERSION$ECHO_C"
+printf '%s.%s.%s' "$MAJOR_VERSION" "$MINOR_VERSION" "$MICRO_VERSION"

--- a/expat/conftools/get-version.sh
+++ b/expat/conftools/get-version.sh
@@ -28,8 +28,8 @@ if test ! -r "$hdr"; then
   exit 1
 fi
 
-MAJOR_VERSION="`sed -n -e '/MAJOR_VERSION/s/[^0-9]*//gp' $hdr`"
-MINOR_VERSION="`sed -n -e '/MINOR_VERSION/s/[^0-9]*//gp' $hdr`"
-MICRO_VERSION="`sed -n -e '/MICRO_VERSION/s/[^0-9]*//gp' $hdr`"
+MAJOR_VERSION=$(sed -n -e '/MAJOR_VERSION/s/[^0-9]*//gp' "$hdr")
+MINOR_VERSION=$(sed -n -e '/MINOR_VERSION/s/[^0-9]*//gp' "$hdr")
+MICRO_VERSION=$(sed -n -e '/MICRO_VERSION/s/[^0-9]*//gp' "$hdr")
 
 printf '%s.%s.%s' "$MAJOR_VERSION" "$MINOR_VERSION" "$MICRO_VERSION"


### PR DESCRIPTION
Note: I didn't bother expanding the variables with curly braces because:

- the braces are not required
- the other expansions do not use braces
- the aesthetics have been improved by not mashing the version component expansions together

Additionally, I fixed three unsafe expansions of $hdr.