### PR TITLE
64 bit constants must be ULL

### DIFF
--- a/expat/lib/siphash.h
+++ b/expat/lib/siphash.h
@@ -170,10 +170,10 @@ static void sip_round(struct siphash *H, const int rounds) {
 
 
 static struct siphash *sip24_init(struct siphash *H, const struct sipkey *key) {
-	H->v0 = 0x736f6d6570736575UL ^ key->k[0];
-	H->v1 = 0x646f72616e646f6dUL ^ key->k[1];
-	H->v2 = 0x6c7967656e657261UL ^ key->k[0];
-	H->v3 = 0x7465646279746573UL ^ key->k[1];
+	H->v0 = 0x736f6d6570736575ULL ^ key->k[0];
+	H->v1 = 0x646f72616e646f6dULL ^ key->k[1];
+	H->v2 = 0x6c7967656e657261ULL ^ key->k[0];
+	H->v3 = 0x7465646279746573ULL ^ key->k[1];
 
 	H->p = H->buf;
 	H->c = 0;

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -247,7 +247,7 @@ START_TEST(test_siphash_spec)
     const char message[] = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09"
             "\x0a\x0b\x0c\x0d\x0e";
     const size_t len = sizeof(message) - 1;
-    const uint64_t expected = 0xa129ca6149be45e5U;
+    const uint64_t expected = 0xa129ca6149be45e5ULL;
     struct siphash state;
     struct sipkey key;
     (void)sip_tobin;


### PR DESCRIPTION
On OpenBSD i386 compiling libexpat produced warnings and compiling
the C++ test runtestspp.cpp failed with "integer constant is too
large for 'unsigned long' type".
