### PR TITLE
xmlparse.c: Avoid warning in projects defining _GNU_SOURCE via autoconf

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -4,7 +4,7 @@
    cd4063469a95eab9a93001afb109e3dee122cdda4635bbec36257fc01c327348 (2.2.2+)
 */
 
-#define _GNU_SOURCE                     /* syscall prototype */
+#define _GNU_SOURCE 1                   /* syscall prototype */
 
 #include <stddef.h>
 #include <string.h>                     /* memset(), memcpy() */


### PR DESCRIPTION
Another one from CPython (Which vendors expat). CPython's configure (autoconf) defines:
```c
#define _GNU_SOURCE 1
```

While xmlparse.c defines:
```c
#define _GNU_SOURCE
```

Which triggers a silly warning about macro redefinition.