### PR TITLE
lib/xmlparse.c: Fix dangling pointer caused by use of realloc

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -6691,6 +6691,7 @@ poolGrow(STRING_POOL *pool)
     BLOCK *temp;
     int blockSize = (int)((unsigned)(pool->end - pool->start)*2U);
     size_t bytesToAllocate;
+    const ptrdiff_t ptrMinusStart = pool->ptr - pool->start;
 
     if (blockSize < 0)
       return XML_FALSE;
@@ -6705,7 +6706,7 @@ poolGrow(STRING_POOL *pool)
       return XML_FALSE;
     pool->blocks = temp;
     pool->blocks->size = blockSize;
-    pool->ptr = pool->blocks->s + (pool->ptr - pool->start);
+    pool->ptr = pool->blocks->s + ptrMinusStart;
     pool->start = pool->blocks->s;
     pool->end = pool->start + blockSize;
   }


### PR DESCRIPTION
Variables `pool->ptr` and `pool->start` point to addresses that may have been freed if realloc chose the path of a new base address.  So we do the math on these pointers while they are not dangling, yet.

For a related article:
http://trust-in-soft.com/dangling-pointer-indeterminate/

----
@pascal-cuoq have a minute for review?
PS: [Here's that `realloc`](https://github.com/libexpat/libexpat/blob/0aecedf3acffa0d8e8535dd4263f471340f76fcc/expat/lib/xmlparse.c#L6704) that the diff doesn't show