### PR TITLE
xmlparse.c: omit unused functions

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -854,7 +854,7 @@ gather_time_entropy(void)
   return tv.tv_usec;
 #endif
 }
-#endif /* ! defined(HAVE_ARC4RANDOM_BUF) */
+#endif  /* ! defined(HAVE_ARC4RANDOM_BUF) */
 
 static unsigned long
 ENTROPY_DEBUG(const char * label, unsigned long entropy) {

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -773,7 +773,7 @@ writeRandomBytes_getrandom(void * target, size_t count) {
 #endif  /* defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM) */
 
 
-#if !(defined(HAVE_ARC4RANDOM_BUF) || defined(__CloudABI__))
+#if ! defined(HAVE_ARC4RANDOM_BUF)
 #ifdef _WIN32
 
 typedef BOOLEAN (APIENTRY *RTLGENRANDOM_FUNC)(PVOID, ULONG);
@@ -829,7 +829,7 @@ gather_time_entropy(void)
   return tv.tv_usec;
 #endif
 }
-#endif
+#endif /* ! defined(HAVE_ARC4RANDOM_BUF) */
 
 static unsigned long
 ENTROPY_DEBUG(const char * label, unsigned long entropy) {
@@ -848,7 +848,7 @@ generate_hash_secret_salt(XML_Parser parser)
 {
   unsigned long entropy;
   (void)parser;
-#if defined(HAVE_ARC4RANDOM_BUF) || defined(__CloudABI__)
+#if defined(HAVE_ARC4RANDOM_BUF)
   arc4random_buf(&entropy, sizeof(entropy));
   return ENTROPY_DEBUG("arc4random_buf", entropy);
 #else

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -773,6 +773,7 @@ writeRandomBytes_getrandom(void * target, size_t count) {
 #endif  /* defined(HAVE_GETRANDOM) || defined(HAVE_SYSCALL_GETRANDOM) */
 
 
+#if !(defined(HAVE_ARC4RANDOM_BUF) || defined(__CloudABI__))
 #ifdef _WIN32
 
 typedef BOOLEAN (APIENTRY *RTLGENRANDOM_FUNC)(PVOID, ULONG);
@@ -828,6 +829,7 @@ gather_time_entropy(void)
   return tv.tv_usec;
 #endif
 }
+#endif
 
 static unsigned long
 ENTROPY_DEBUG(const char * label, unsigned long entropy) {
@@ -847,7 +849,6 @@ generate_hash_secret_salt(XML_Parser parser)
   unsigned long entropy;
   (void)parser;
 #if defined(HAVE_ARC4RANDOM_BUF) || defined(__CloudABI__)
-  (void)gather_time_entropy;
   arc4random_buf(&entropy, sizeof(entropy));
   return ENTROPY_DEBUG("arc4random_buf", entropy);
 #else


### PR DESCRIPTION
`gather_time_entropy()` and `writeRandomBytes_RtlGenRandom()` static functions
aren't used when `HAVE_ARC4RANDOM_BUF` is defined (f.e. when the host application
provides its own `arc4random_buf()` implementation on Windows), so they can be safely
omitted, when this build-time condition is present.
