### PR TITLE
use GRND_NONBLOCK of getrandom call

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -21,6 +21,7 @@
 #include <sys/time.h>                   /* gettimeofday() */
 #include <sys/types.h>                  /* getpid() */
 #include <unistd.h>                     /* getpid() */
+#include <linux/random.h>		/* GRND_NONBLOCK */
 #endif
 
 #define XML_BUILDING_EXPAT 1
@@ -754,7 +755,7 @@ static int
 writeRandomBytes_getrandom(void * target, size_t count) {
   int success = 0;  /* full count bytes written? */
   size_t bytesWrittenTotal = 0;
-  const unsigned int getrandomFlags = 0;
+  const unsigned int getrandomFlags = GRND_NONBLOCK;
 
   do {
     void * const currentTarget = (void*)((char*)target + bytesWrittenTotal);
@@ -772,7 +773,7 @@ writeRandomBytes_getrandom(void * target, size_t count) {
       if (bytesWrittenTotal >= count)
         success = 1;
     }
-  } while (! success && (errno == EINTR || errno == EAGAIN));
+  } while (! success && (errno == EINTR));
 
   return success;
 }


### PR DESCRIPTION
Since the getrandom syscall patch(f356fb56fb9e Detect and support
syscall(SYS_getrandom, [..]) as well), some arm machine stuck during
systemd boot because the dbus uses the expat library and it hangs
inside the writeRandomBytes_getrandom function. Without the
GRND_NONBLOCK flag, the kernel will wait until the nonblocking_pool has
been initialized(See the getrandom syscall of the
linux/drivers/char/random.c). To prevent the blocking, we can add the
GRND_NONBLOCK flag and omit the comparison of the EAGAIN return.

Signed-off-by: Chanho Park <chanho61.park@samsung.com>