### PR TITLE
Check for possibly undefined SIPHASH_MAIN using #ifdef

### DIFF
--- a/expat/lib/siphash.h
+++ b/expat/lib/siphash.h
@@ -350,7 +350,7 @@ static int sip24_valid(void) {
 } /* sip24_valid() */
 
 
-#if SIPHASH_MAIN
+#ifdef SIPHASH_MAIN
 
 #include <stdio.h>
 


### PR DESCRIPTION
"#if SIPHASH_MAIN" results in -Wundef warning with recent gcc/clang and
this change suppresses it.

---

Maybe this testing code should be removed completely instead? For now I just made the smallest possible change to avoid the warning.