### PR TITLE
Update coverage tests

### DIFF
--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11713,15 +11713,9 @@ START_TEST(test_nsalloc_realloc_long_context_in_dtd)
         { NULL, NULL }
     };
     int i;
-#define MAX_REALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_REALLOC_COUNT 20
 
     for (i = 0; i < MAX_REALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat allocation caching */
-        if (i == 2 && repeat < 11) {
-            i--;
-            repeat++;
-        }
         reallocation_count = i;
         XML_SetUserData(parser, options);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -11729,7 +11723,9 @@ START_TEST(test_nsalloc_realloc_long_context_in_dtd)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing reallocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -7972,25 +7972,17 @@ START_TEST(test_alloc_parse_pi_2)
         "<?pi unknown?>\n"
         "</doc>";
     int i;
-    int repeat = 0;
-#define MAX_ALLOC_COUNT 10
+#define MAX_ALLOC_COUNT 15
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
         allocation_count = i;
-        /* Repeat some counts because of cached memory */
-        if (i == 2 && repeat == 1) {
-            i -= 2;
-            repeat++;
-        } else if ((i == 1 && repeat < 1) ||
-                   (i == 1 && repeat > 1 && repeat < 4)) {
-            i--;
-            repeat++;
-        }
         XML_SetProcessingInstructionHandler(parser, dummy_pi_handler);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8725,20 +8725,9 @@ START_TEST(test_alloc_public_entity_value)
         " '%e1;'>\n"
         "%e1;\n";
     int i;
-#define MAX_ALLOC_COUNT 25
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 50
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat certain counts to defeat cached allocations */
-        if ((i == 2 && repeat < 2) ||
-            (i == 3 && repeat == 2) ||
-            (i == 8 && repeat == 3) ||
-            (i == 9 && repeat == 4) ||
-            (i == 18 && repeat == 5) ||
-            (i == 19 && repeat == 6)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         dummy_handler_flags = 0;
         XML_SetUserData(parser, dtd_text);
@@ -8749,7 +8738,9 @@ START_TEST(test_alloc_public_entity_value)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocation");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -10169,22 +10169,9 @@ START_TEST(test_alloc_long_notation)
         { NULL, NULL }
     };
     int i;
-#define MAX_ALLOC_COUNT 20
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 40
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if (i == 5 && repeat == 5) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 3) ||
-                 (i == 3 && (repeat == 3 || repeat == 4)) ||
-                 (i == 4 && repeat == 6) ||
-                 (i == 5 && repeat == 7)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetUserData(parser, options);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -10193,8 +10180,9 @@ START_TEST(test_alloc_long_notation)
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
 
-        XML_ParserFree(parser);
-        parser = XML_ParserCreate(NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9095,13 +9095,16 @@ START_TEST(test_alloc_realloc_implied_attribute)
         "]><doc/>";
     int i;
 #define MAX_REALLOC_COUNT 10
+
     for (i = 0; i < MAX_REALLOC_COUNT; i++) {
         reallocation_count = i;
         XML_SetAttlistDeclHandler(parser, dummy_attlist_decl_handler);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing reallocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8042,25 +8042,17 @@ START_TEST(test_alloc_parse_comment)
         "<!-- Test parsing this comment -->"
         "<doc>Hi</doc>";
     int i;
-    int repeat = 0;
-#define MAX_ALLOC_COUNT 10
+#define MAX_ALLOC_COUNT 15
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts because of cached memory */
-        if (i == 2 && repeat == 2) {
-            i -= 2;
-            repeat++;
-        } else if ((i == 1 && repeat < 2) ||
-                   (i == 1 && repeat > 2 && repeat < 5)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetCommentHandler(parser, dummy_comment_handler);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8805,7 +8805,9 @@ START_TEST(test_alloc_realloc_subst_public_entity_value)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing reallocation");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8626,21 +8626,25 @@ START_TEST(test_alloc_ext_entity_realloc_buffer)
         "]>\n"
         "<doc>&en;</doc>";
     int i;
+#define MAX_REALLOC_COUNT 10
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < MAX_REALLOC_COUNT; i++) {
         XML_SetExternalEntityRefHandler(parser,
                                         external_entity_reallocator);
         XML_SetUserData(parser, (void *)(intptr_t)i);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) == XML_STATUS_OK)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Succeeded with no reallocations");
-    if (i == 10)
-        fail("Failed with 10 reallocations");
+    if (i == MAX_REALLOC_COUNT)
+        fail("Failed with max reallocations");
 }
+#undef MAX_REALLOC_COUNT
 END_TEST
 
 /* Test elements with many attributes are handled correctly */

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9352,15 +9352,9 @@ START_TEST(test_alloc_nested_groups)
         "<doc><e/></doc>";
     CharData storage;
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 20
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to allow for cached allocations */
-        if ((i == 2 && repeat < 3) || (i == 3 && repeat == 3)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         CharData_Init(&storage);
         XML_SetElementDeclHandler(parser, dummy_element_decl_handler);
@@ -9370,7 +9364,9 @@ START_TEST(test_alloc_nested_groups)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
 
     if (i == 0)

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -339,16 +339,16 @@ external_entity_optioner(XML_Parser parser,
 
     while (options->parse_text != NULL) {
         if (!strcmp(systemId, options->system_id)) {
+            enum XML_Status rc;
             ext_parser =
                 XML_ExternalEntityParserCreate(parser, context, NULL);
             if (ext_parser == NULL)
                 return XML_STATUS_ERROR;
-            if (_XML_Parse_SINGLE_BYTES(ext_parser, options->parse_text,
-                                        strlen(options->parse_text),
-                                        XML_TRUE) == XML_STATUS_ERROR)
-                return XML_STATUS_ERROR;
+            rc = _XML_Parse_SINGLE_BYTES(ext_parser, options->parse_text,
+                                         strlen(options->parse_text),
+                                         XML_TRUE);
             XML_ParserFree(ext_parser);
-            return XML_STATUS_OK;
+            return rc;
         }
         options++;
     }

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9607,26 +9607,16 @@ START_TEST(test_alloc_attribute_whitespace)
 {
     const char *text = "<doc a=' '></doc>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 15
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if (i == 3 && repeat == 1) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 &&
-                  (repeat == 0 || repeat == 2 || repeat == 3)) ||
-                 (i == 3 && repeat == 4)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9826,7 +9826,9 @@ START_TEST(test_alloc_realloc_param_entity_newline)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing reallocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11222,33 +11222,16 @@ START_TEST(test_nsalloc_less_long_namespace)
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012345678"
         ":e>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 40
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if ((i == 4 && (repeat == 3 || repeat == 5)) ||
-            (i == 7 && repeat == 10)) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 2) ||
-                 (i == 3 && (repeat == 2 ||
-                             repeat == 4 ||
-                             repeat == 6)) ||
-                 (i == 4 && repeat == 7) ||
-                 (i == 5 && (repeat == 8 ||
-                             repeat == 9)) ||
-                 (i == 6 && (repeat == 11 || repeat == 12)) ||
-                 (i == 7 && repeat == 13)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9438,24 +9438,18 @@ START_TEST(test_alloc_large_group)
         "<a1/>\n"
         "</doc>\n";
     int i;
-#define MAX_ALLOC_COUNT 45
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 50
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if ((i == 2 && repeat < 3) ||
-            (i == 3 && repeat == 3) ||
-            (i == 37 && repeat == 4)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetElementDeclHandler(parser, dummy_element_decl_handler);
         dummy_handler_flags = 0;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -7912,27 +7912,18 @@ START_TEST(test_alloc_parse_xdecl_2)
         "'?>"
         "<doc>Hello, world</doc>";
     int i;
-    int repeat = 0;
-#define MAX_ALLOC_COUNT 10
+#define MAX_ALLOC_COUNT 20
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat counts to defeat cached allocations */
-        if (i == 4 && repeat == 3) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 3) ||
-                 (i == 3 && repeat > 3)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetXmlDeclHandler(parser, dummy_xdecl_handler);
         XML_SetUnknownEncodingHandler(parser, long_encoding_handler, NULL);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8842,20 +8842,9 @@ START_TEST(test_alloc_parse_public_doctype)
         "' 'test'>\n"
         "<doc></doc>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 25
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat certain counts to defeat cached allocations */
-        if (i == 4 && repeat == 5) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 3) ||
-            (i == 3 && repeat < 5)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         dummy_handler_flags = 0;
         XML_SetDoctypeDeclHandler(parser,
@@ -8864,7 +8853,9 @@ START_TEST(test_alloc_parse_public_doctype)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9912,7 +9912,9 @@ START_TEST(test_alloc_realloc_attributes)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
 
     if (i == 0)

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9993,21 +9993,9 @@ START_TEST(test_alloc_long_base)
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789A/"
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789A/";
     int i;
- #define MAX_ALLOC_COUNT 20
-    int repeat = 0;
+ #define MAX_ALLOC_COUNT 25
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if (i == 4 && repeat == 4) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 4) ||
-                 (i == 3 && repeat == 5) ||
-                 (i == 4 && repeat == 6)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetUserData(parser, entity_text);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -10019,7 +10007,9 @@ START_TEST(test_alloc_long_base)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -10830,26 +10830,9 @@ START_TEST(test_nsalloc_long_element)
         "http://example.org/ a bar"
     };
     int i;
-#define MAX_ALLOC_COUNT 15
-    int repeated = 0;
+#define MAX_ALLOC_COUNT 30
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some allocation counts because some allocations
-         * get cached across XML_ParserReset() called.
-         */
-        if ((i == 4 && (repeated == 3 || repeated == 5)) ||
-            (i == 7 && repeated == 8) ||
-            (i == 10 && repeated == 9)) {
-            i -= 2;
-            repeated++;
-        }
-        else if ((i == 2 && repeated < 2) ||
-                 (i == 3 &&
-                  (repeated == 2 || repeated == 4 || repeated == 6)) ||
-                 (i == 5 && repeated == 7)) {
-            i--;
-            repeated++;
-        }
         allocation_count = i;
         XML_SetReturnNSTriplet(parser, XML_TRUE);
         XML_SetUserData(parser, elemstr);
@@ -10859,7 +10842,9 @@ START_TEST(test_nsalloc_long_element)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing reallocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -7610,9 +7610,10 @@ START_TEST(test_misc_alloc_create_parser)
 {
     XML_Memory_Handling_Suite memsuite = { duff_allocator, realloc, free };
     unsigned int i;
+#define MAX_ALLOC_COUNT 10
 
     /* Something this simple shouldn't need more than 10 allocations */
-    for (i = 0; i < 10; i++)
+    for (i = 0; i < MAX_ALLOC_COUNT; i++)
     {
         allocation_count = i;
         parser = XML_ParserCreate_MM(NULL, &memsuite, NULL);
@@ -7621,9 +7622,10 @@ START_TEST(test_misc_alloc_create_parser)
     }
     if (i == 0)
         fail("Parser unexpectedly ignored failing allocator");
-    else if (i == 10)
-        fail("Parser not created with allocation count 10");
+    else if (i == MAX_ALLOC_COUNT)
+        fail("Parser not created with max allocation count");
 }
+#undef MAX_ALLOC_COUNT
 END_TEST
 
 /* Test memory allocation failures for a parser with an encoding */

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11838,23 +11838,9 @@ START_TEST(test_nsalloc_long_systemid_in_ext)
         { NULL, NULL }
     };
     int i;
-#define MAX_ALLOC_COUNT 30
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 55
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to allow for cached allocations */
-        if ((i == 4 && repeat == 3) || (i == 10 && repeat == 8)) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 2) ||
-                 (i == 3 && (repeat == 2 || repeat == 4 || repeat == 5)) ||
-                 (i == 4 && repeat == 6) ||
-                 (i == 5 && repeat == 7) ||
-                 (i == 9 && repeat == 8)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetUserData(parser, options);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -11863,8 +11849,9 @@ START_TEST(test_nsalloc_long_systemid_in_ext)
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
 
-        XML_ParserFree(parser);
-        parser = XML_ParserCreate(NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8544,17 +8544,19 @@ START_TEST(test_alloc_set_base)
 {
     const XML_Char *new_base = "/local/file/name.xml";
     int i;
+#define MAX_ALLOC_COUNT 5
 
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < MAX_ALLOC_COUNT; i++) {
         allocation_count = i;
         if (XML_SetBase(parser, new_base) == XML_STATUS_OK)
             break;
     }
     if (i == 0)
         fail("Base set despite failing allocator");
-    else if (i == 5)
-        fail("Base not set with allocation count 5");
+    else if (i == MAX_ALLOC_COUNT)
+        fail("Base not set with max allocation count");
 }
+#undef MAX_ALLOC_COUNT
 END_TEST
 
 /* Test buffer extension in the face of a duff reallocator */

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9677,22 +9677,16 @@ START_TEST(test_alloc_long_attr_default_with_char_ref)
         "&#x31;'>]>\n"
         "<doc/>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 20
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if ((i == 2 && repeat < 3) ||
-            (i == 3 && repeat == 3) ||
-            (i == 4 && repeat == 4)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9050,7 +9050,9 @@ START_TEST(test_alloc_realloc_attribute_enum_value)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing reallocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8015,16 +8015,17 @@ START_TEST(test_alloc_parse_pi_3)
         "ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP"
         "Q?><doc/>";
     int i;
-#define MAX_ALLOC_COUNT 10
+#define MAX_ALLOC_COUNT 20
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Every allocation bar the last is cached */
-        allocation_count = (i == 0) ? 0 : 1;
+        allocation_count = i;
         XML_SetProcessingInstructionHandler(parser, dummy_pi_handler);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8565,15 +8565,10 @@ START_TEST(test_alloc_realloc_buffer)
     const char *text = get_buffer_test_text;
     void *buffer;
     int i;
-    int repeat = 0;
+#define MAX_REALLOC_COUNT 10
 
     /* Get a smallish buffer */
-    for (i = 0; i < 10; i++) {
-        /* Repeat some indexes for cached allocations */
-        if (repeat < 6 && i == 2) {
-            i--;
-            repeat++;
-        }
+    for (i = 0; i < MAX_REALLOC_COUNT; i++) {
         reallocation_count = i;
         buffer = XML_GetBuffer(parser, 1536);
         if (buffer == NULL)
@@ -8582,14 +8577,17 @@ START_TEST(test_alloc_realloc_buffer)
         if (XML_ParseBuffer(parser, strlen(text),
                             XML_FALSE) == XML_STATUS_OK)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     reallocation_count = -1;
     if (i == 0)
         fail("Parse succeeded with no reallocation");
-    else if (i == 10)
-        fail("Parse failed with reallocation count 10");
+    else if (i == MAX_REALLOC_COUNT)
+        fail("Parse failed with max reallocation count");
 }
+#undef MAX_REALLOC_COUNT
 END_TEST
 
 /* Same test for external entity parsers */

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8943,19 +8943,9 @@ START_TEST(test_alloc_set_foreign_dtd)
         "<doc>&entity;</doc>";
     char text2[] = "<!ELEMENT doc (#PCDATA)*>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 25
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to deal with cached allocations */
-        if (i == 9 && repeat == 2) {
-            i -= 2;
-            repeat++;
-        }
-        else if (i == 2 && repeat < 2) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
         XML_SetUserData(parser, &text2);
@@ -8965,7 +8955,9 @@ START_TEST(test_alloc_set_foreign_dtd)
         if (_XML_Parse_SINGLE_BYTES(parser, text1, strlen(text1),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -10046,21 +10046,9 @@ START_TEST(test_alloc_long_public_id)
         "<doc>&e;</doc>";
     char entity_text[] = "Hello world";
     int i;
-#define MAX_ALLOC_COUNT 20
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 40
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat certain counts to defeat allocation caching */
-        if (i == 4 && repeat == 4) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 3) ||
-                 (i == 3 && (repeat == 3 || repeat == 5)) ||
-                 (i == 4 && repeat == 6)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetUserData(parser, entity_text);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -10068,7 +10056,9 @@ START_TEST(test_alloc_long_public_id)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9315,23 +9315,18 @@ START_TEST(test_alloc_system_notation)
         "<!ELEMENT doc EMPTY>\n"
         "]>\n<doc/>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 20
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to allow for cached allocations */
-        if ((i == 2 && repeat < 5) ||
-            (i == 3 && repeat == 5)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         dummy_handler_flags = 0;
         XML_SetNotationDeclHandler(parser, dummy_notation_decl_handler);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite allocation failures");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -10960,12 +10960,13 @@ START_TEST(test_nsalloc_realloc_long_prefix)
 #define MAX_REALLOC_COUNT 12
 
     for (i = 0; i < MAX_REALLOC_COUNT; i++) {
-        /* Every reallocation bar the last is cached */
-        reallocation_count = (i == 0) ? 0 : 1;
+        reallocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing reallocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11766,23 +11766,9 @@ START_TEST(test_nsalloc_long_default_in_ext)
         { NULL, NULL }
     };
     int i;
-#define MAX_ALLOC_COUNT 30
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 50
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat allocation caching */
-        if ((i == 4 && repeat == 3) || (i == 8 && repeat == 9)) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 2) ||
-                 (i == 3 && (repeat == 2 || repeat == 4 || repeat == 5)) ||
-                 (i == 4 && repeat == 6) ||
-                 (i == 5 && repeat == 7) ||
-                 (i == 6 && repeat == 8)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetUserData(parser, options);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -11791,8 +11777,9 @@ START_TEST(test_nsalloc_long_default_in_ext)
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
 
-        XML_ParserFree(parser);
-        parser = XML_ParserCreate(NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9211,15 +9211,9 @@ START_TEST(test_alloc_notation)
         "<!ELEMENT doc EMPTY>\n"
         "]>\n<doc/>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 20
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to allow for cached allocations */
-        if ((i == 2 && repeat < 4) || (i == 3)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         dummy_handler_flags = 0;
         XML_SetNotationDeclHandler(parser, dummy_notation_decl_handler);
@@ -9227,7 +9221,9 @@ START_TEST(test_alloc_notation)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite allocation failures");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8979,22 +8979,9 @@ START_TEST(test_alloc_attribute_enum_value)
         "<!ELEMENT a EMPTY>\n"
         "<!ATTLIST animal xml:space (default|preserve) 'preserve'>";
     int i;
-#define MAX_ALLOC_COUNT 20
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 30
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to allow for cached allocations */
-        if (i == 13 && repeat == 5) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 2) ||
-                 (i == 3 && repeat == 2) ||
-                 (i == 8 && repeat == 3) ||
-                 (i == 9 && repeat == 4)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetExternalEntityRefHandler(parser, external_entity_alloc);
         XML_SetUserData(parser, dtd_text);
@@ -9004,7 +8991,9 @@ START_TEST(test_alloc_attribute_enum_value)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -7943,25 +7943,17 @@ START_TEST(test_alloc_parse_pi)
         "Hello, world"
         "</doc>";
     int i;
-    int repeat = 0;
-#define MAX_ALLOC_COUNT 10
+#define MAX_ALLOC_COUNT 15
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
         allocation_count = i;
-        /* Repeat some counts because of cached memory */
-        if (i == 2 && repeat == 2) {
-            i -= 2;
-            repeat++;
-        } else if ((i == 1 && repeat < 2) ||
-                   (i == 1 && repeat > 2 && repeat < 5)) {
-            i--;
-            repeat++;
-        }
         XML_SetProcessingInstructionHandler(parser, dummy_pi_handler);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8071,25 +8071,17 @@ START_TEST(test_alloc_parse_comment_2)
         "<!-- Parse this comment too -->"
         "</doc>";
     int i;
-    int repeat = 0;
-#define MAX_ALLOC_COUNT 10
+#define MAX_ALLOC_COUNT 15
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
         allocation_count = i;
-        /* Repeat some counts because of cached memory */
-        if (i == 2 && repeat == 1) {
-            i -= 2;
-            repeat++;
-        } else if ((i == 1 && repeat < 1) ||
-                   (i == 1 && repeat > 1 && repeat < 4)) {
-            i--;
-            repeat++;
-        }
         XML_SetCommentHandler(parser, dummy_comment_handler);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9508,26 +9508,18 @@ START_TEST(test_alloc_pi_in_epilog)
         "<doc></doc>\n"
         "<?pi in epilog?>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 15
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat certain counts to allow for cached allocations */
-        if (i == 3 && repeat == 1) {
-            i -= 2;
-            repeat++;
-        }
-        else if (i == 2 && repeat < 4 && repeat != 1) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetProcessingInstructionHandler(parser, dummy_pi_handler);
         dummy_handler_flags = 0;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse completed despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11275,26 +11275,9 @@ START_TEST(test_nsalloc_long_context)
         { NULL, NULL }
     };
     int i;
-#define MAX_ALLOC_COUNT 40
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 70
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat allocation caching */
-        if ((i == 4 && repeat == 3) ||
-            (i == 13 && repeat == 9) ||
-            (i == 14 && repeat == 10)) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 2) ||
-                 (i == 3 && (repeat == 2 || repeat == 4 || repeat == 5)) ||
-                 (i == 4 && repeat == 6) ||
-                 (i == 5 && repeat == 7) ||
-                 (i == 7 && repeat == 8) ||
-                 (i == 13 && repeat == 11)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetUserData(parser, options);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -11303,8 +11286,9 @@ START_TEST(test_nsalloc_long_context)
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
 
-        XML_ParserFree(parser);
-        parser = XML_ParserCreate(NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8524,17 +8524,19 @@ END_TEST
 START_TEST(test_alloc_explicit_encoding)
 {
     int i;
+#define MAX_ALLOC_COUNT 5
 
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < MAX_ALLOC_COUNT; i++) {
         allocation_count = i;
         if (XML_SetEncoding(parser, "us-ascii") == XML_STATUS_OK)
             break;
     }
     if (i == 0)
         fail("Encoding set despite failing allocator");
-    else if (i == 5)
-        fail("Encoding not set at allocation count 5");
+    else if (i == MAX_ALLOC_COUNT)
+        fail("Encoding not set at max allocation count");
 }
+#undef MAX_ALLOC_COUNT
 END_TEST
 
 /* Test robustness of XML_SetBase against a failing allocator */

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9264,23 +9264,18 @@ START_TEST(test_alloc_public_notation)
         "<!ELEMENT doc EMPTY>\n"
         "]>\n<doc/>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 20
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to allow for cached allocations */
-        if ((i == 2 && repeat < 5) ||
-            (i == 3 && repeat == 5)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         dummy_handler_flags = 0;
         XML_SetNotationDeclHandler(parser, dummy_notation_decl_handler);
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite allocation failures");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11302,7 +11302,7 @@ END_TEST
  * returns normally it must have succeeded.
  */
 static void
-context_realloc_test(XML_Parser parser, const char *text)
+context_realloc_test(const char *text)
 {
     ExtOption options[] = {
         { "foo", "<!ELEMENT e EMPTY>"},
@@ -11320,7 +11320,9 @@ context_realloc_test(XML_Parser parser, const char *text)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing reallocations");
@@ -11357,7 +11359,7 @@ START_TEST(test_nsalloc_realloc_long_context)
         "&en;"
         "</doc>";
 
-    context_realloc_test(parser, text);
+    context_realloc_test(text);
 }
 END_TEST
 
@@ -11389,7 +11391,7 @@ START_TEST(test_nsalloc_realloc_long_context_2)
         "&en;"
         "</doc>";
 
-    context_realloc_test(parser, text);
+    context_realloc_test(text);
 }
 END_TEST
 
@@ -11421,7 +11423,7 @@ START_TEST(test_nsalloc_realloc_long_context_3)
         "&en;"
         "</doc>";
 
-    context_realloc_test(parser, text);
+    context_realloc_test(text);
 }
 END_TEST
 
@@ -11453,7 +11455,7 @@ START_TEST(test_nsalloc_realloc_long_context_4)
         "&en;"
         "</doc>";
 
-    context_realloc_test(parser, text);
+    context_realloc_test(text);
 }
 END_TEST
 
@@ -11485,7 +11487,7 @@ START_TEST(test_nsalloc_realloc_long_context_5)
         "&en;"
         "</doc>";
 
-    context_realloc_test(parser, text);
+    context_realloc_test(text);
 }
 END_TEST
 
@@ -11516,7 +11518,7 @@ START_TEST(test_nsalloc_realloc_long_context_6)
         "&en;"
         "</doc>";
 
-    context_realloc_test(parser, text);
+    context_realloc_test(text);
 }
 END_TEST
 
@@ -11548,7 +11550,7 @@ START_TEST(test_nsalloc_realloc_long_context_7)
         "&en;"
         "</doc>";
 
-    context_realloc_test(parser, text);
+    context_realloc_test(text);
 }
 END_TEST
 

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9537,26 +9537,18 @@ START_TEST(test_alloc_comment_in_epilog)
         "<doc></doc>\n"
         "<!-- comment in epilog -->";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 15
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat certain counts to allow for cached allocations */
-        if (i == 3 && repeat == 1) {
-            i -= 2;
-            repeat++;
-        }
-        else if (i == 2 && repeat < 4 && repeat != 1) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetCommentHandler(parser, dummy_comment_handler);
         dummy_handler_flags = 0;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse completed despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8314,23 +8314,9 @@ START_TEST(test_alloc_external_entity)
         "&en;\n"
         "</doc>";
     int i;
-    int repeat = 0;
 #define ALLOC_TEST_MAX_REPEATS 50
 
     for (i = 0; i < ALLOC_TEST_MAX_REPEATS; i++) {
-        /* Some allocation counts need to be repeated to follow all
-         * the failure paths, given some allocations are cached.
-         */
-        if (i == 11 && repeat == 7) {
-            i -= 2;
-            repeat++;
-        } else if ((i == 1 && repeat < 2) ||
-                   (i == 2 && repeat < 4) ||
-                   (repeat < 7 && i == repeat+2) ||
-                   (i == 10 && repeat == 8)) {
-            i--;
-            repeat++;
-        }
         allocation_count = -1;
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
         XML_SetExternalEntityRefHandler(parser,
@@ -8340,7 +8326,9 @@ START_TEST(test_alloc_external_entity)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) == XML_STATUS_OK)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     allocation_count = -1;
     if (i == 0)

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8377,17 +8377,9 @@ START_TEST(test_alloc_ext_entity_set_encoding)
         "]>\n"
         "<doc>&en;</doc>";
     int i;
-    int repeat = 0;
-#define MAX_ALLOCATION_COUNT 20
+#define MAX_ALLOCATION_COUNT 30
 
     for (i = 0; i < MAX_ALLOCATION_COUNT; i++) {
-        /* Repeat some counts to get round caching */
-        if ((i == 2 && repeat < 3) ||
-            (i == 3 && repeat < 6) ||
-            (i == 4 && repeat == 6)) {
-            i--;
-            repeat++;
-        }
         XML_SetExternalEntityRefHandler(parser,
                                         external_entity_alloc_set_encoding);
         allocation_count = i;
@@ -8395,7 +8387,9 @@ START_TEST(test_alloc_ext_entity_set_encoding)
                                     XML_TRUE) == XML_STATUS_OK)
             break;
         allocation_count = -1;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Encoding check succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9947,21 +9947,16 @@ START_TEST(test_alloc_long_doc_name)
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789AZ"
         " a='1'/>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 20
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat certain counts to defeat cached allocations */
-        if ((i == 2 && repeat < 4) ||
-            (i == 3 && repeat < 6)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing reallocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9723,23 +9723,16 @@ START_TEST(test_alloc_long_attr_value)
         "'>]>\n"
         "<test a='&foo;'/>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 25
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if ((i == 2 && repeat < 3) ||
-            (i == 3 && repeat < 6) ||
-            (i == 4 && repeat == 6) ||
-            (i == 5 && repeat == 7)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8104,9 +8104,10 @@ external_entity_duff_loader(XML_Parser parser,
 {
     XML_Parser new_parser;
     unsigned int i;
+#define MAX_ALLOC_COUNT 10
 
     /* Try a few different allocation levels */
-    for (i = 0; i < 10; i++)
+    for (i = 0; i < MAX_ALLOC_COUNT; i++)
     {
         allocation_count = i;
         new_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
@@ -8118,14 +8119,15 @@ external_entity_duff_loader(XML_Parser parser,
     }
     if (i == 0)
         fail("External parser creation ignored failing allocator");
-    else if (i == 10)
-        fail("Extern parser not created with allocation count 10");
+    else if (i == MAX_ALLOC_COUNT)
+        fail("Extern parser not created with max allocation count");
 
     /* Make sure other random allocation doesn't now fail */
     allocation_count = ALLOC_ALWAYS_SUCCEED;
 
     /* Make sure the failure code path is executed too */
     return XML_STATUS_ERROR;
+#undef MAX_ALLOC_COUNT
 }
 
 /* Test that external parser creation running out of memory is

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8468,18 +8468,9 @@ START_TEST(test_alloc_dtd_default_handling)
     const char *expected = "\n\n\n\n\n\n\n\n\n<doc>text in doc</doc>";
     CharData storage;
     int i;
-#define MAX_ALLOC_COUNT 15
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 25
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to catch cached allocations */
-        if ((repeat < 4 && i == 2) ||
-            (repeat == 4 && i == 4) ||
-            (repeat == 5 && i == 5) ||
-            (repeat == 6 && i == 8)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         dummy_handler_flags = 0;
         XML_SetDefaultHandler(parser, accumulate_characters);
@@ -8504,7 +8495,9 @@ START_TEST(test_alloc_dtd_default_handling)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Default DTD parsed despite allocation failures");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8156,8 +8156,9 @@ START_TEST(test_alloc_run_external_parser)
     char foo_text[] =
         "<!ELEMENT doc (#PCDATA)*>";
     unsigned int i;
+#define MAX_ALLOC_COUNT 15
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < MAX_ALLOC_COUNT; i++) {
         XML_SetParamEntityParsing(parser,
                                   XML_PARAM_ENTITY_PARSING_ALWAYS);
         XML_SetUserData(parser, foo_text);
@@ -8166,14 +8167,16 @@ START_TEST(test_alloc_run_external_parser)
         allocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text), XML_TRUE) != XML_STATUS_ERROR)
             break;
-        /* Re-use the parser */
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parsing ignored failing allocator");
-    else if (i == 10)
+    else if (i == MAX_ALLOC_COUNT)
         fail("Parsing failed with allocation count 10");
 }
+#undef MAX_ALLOC_COUNT
 END_TEST
 
 

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8893,20 +8893,9 @@ START_TEST(test_alloc_parse_public_doctype_long_name)
         "'>\n"
         "<doc></doc>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 25
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if (i == 4 && repeat == 6) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 3) ||
-                 (i == 3 && repeat < 6)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetDoctypeDeclHandler(parser,
                                   dummy_start_doctype_decl_handler,
@@ -8914,7 +8903,9 @@ START_TEST(test_alloc_parse_public_doctype_long_name)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9591,7 +9591,9 @@ START_TEST(test_alloc_realloc_long_attribute_value)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing reallocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8197,6 +8197,7 @@ external_entity_dbl_handler(XML_Parser parser,
     const char *text;
     XML_Parser new_parser;
     int i;
+#define MAX_ALLOC_COUNT 20
 
     if (callno == 0) {
         /* First time through, check how many calls to malloc occur */
@@ -8215,7 +8216,7 @@ external_entity_dbl_handler(XML_Parser parser,
         text = ("<?xml version='1.0' encoding='us-ascii'?>"
                 "<e/>");
         /* Try at varying levels to exercise more code paths */
-        for (i = 0; i < 20; i++) {
+        for (i = 0; i < MAX_ALLOC_COUNT; i++) {
             allocation_count = callno + i;
             new_parser = XML_ExternalEntityParserCreate(parser,
                                                         context,
@@ -8228,7 +8229,7 @@ external_entity_dbl_handler(XML_Parser parser,
             XML_ParserFree(new_parser);
             return XML_STATUS_ERROR;
         }
-        else if (i == 20) {
+        else if (i == MAX_ALLOC_COUNT) {
             fail("Second external parser not created");
             return XML_STATUS_ERROR;
         }
@@ -8241,6 +8242,7 @@ external_entity_dbl_handler(XML_Parser parser,
     }
     XML_ParserFree(new_parser);
     return XML_STATUS_OK;
+#undef MAX_ALLOC_COUNT
 }
 
 /* Test that running out of memory in dtdCopy is correctly reported.

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9406,7 +9406,9 @@ START_TEST(test_alloc_realloc_nested_groups)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
 
     if (i == 0)

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9875,7 +9875,9 @@ START_TEST(test_alloc_realloc_ce_extends_pe)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing reallocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -10096,22 +10096,9 @@ START_TEST(test_alloc_long_entity_value)
         "<doc>&e2;</doc>";
     char entity_text[] = "Hello world";
     int i;
-#define MAX_ALLOC_COUNT 20
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 40
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat certain counts to defeat cached allocations */
-        if (i == 5 && repeat == 4) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 3) ||
-                 (i == 3 && repeat == 3) ||
-                 (i == 4 && repeat == 5) ||
-                 (i == 5 && repeat == 6)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetUserData(parser, entity_text);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -10119,7 +10106,9 @@ START_TEST(test_alloc_long_entity_value)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9488,7 +9488,9 @@ START_TEST(test_alloc_realloc_group_choice)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing reallocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8683,7 +8683,9 @@ START_TEST(test_alloc_realloc_many_attributes)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite no reallocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9154,7 +9154,9 @@ START_TEST(test_alloc_realloc_default_attribute)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing reallocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11147,34 +11147,16 @@ START_TEST(test_nsalloc_long_namespace)
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789AZ"
         ":e>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 40
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if ((i == 4 && (repeat == 3 || repeat == 6)) ||
-            (i == 7 && repeat == 11)) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 2) ||
-                 (i == 3 && (repeat == 2 ||
-                             repeat == 4 ||
-                             repeat == 5 ||
-                             repeat == 7 ||
-                             repeat == 8)) ||
-                 (i == 5 && (repeat == 9 ||
-                             repeat == 10)) ||
-                 (i == 6 && repeat == 12) ||
-                 (i == 7 && repeat == 13)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing allocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -7633,9 +7633,10 @@ START_TEST(test_misc_alloc_create_parser_with_encoding)
 {
     XML_Memory_Handling_Suite memsuite = { duff_allocator, realloc, free };
     unsigned int i;
+#define MAX_ALLOC_COUNT 10
 
     /* Try several levels of allocation */
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < MAX_ALLOC_COUNT; i++) {
         allocation_count = i;
         parser = XML_ParserCreate_MM("us-ascii", &memsuite, NULL);
         if (parser != NULL)
@@ -7643,9 +7644,10 @@ START_TEST(test_misc_alloc_create_parser_with_encoding)
     }
     if (i == 0)
         fail("Parser ignored failing allocator");
-    else if (i == 10)
-        fail("Parser not created with allocation count 10");
+    else if (i == MAX_ALLOC_COUNT)
+        fail("Parser not created with max allocation count");
 }
+#undef MAX_ALLOC_COUNT
 END_TEST
 
 /* Test that freeing a NULL parser doesn't cause an explosion.

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11605,15 +11605,9 @@ START_TEST(test_nsalloc_realloc_long_ge_name)
         { NULL, NULL }
     };
     int i;
-#define MAX_REALLOC_COUNT 5
-    int repeat = 0;
+#define MAX_REALLOC_COUNT 10
 
     for (i = 0; i < MAX_REALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat caching */
-        if (i == 2 && repeat < 3) {
-            i--;
-            repeat++;
-        }
         reallocation_count = i;
         XML_SetUserData(parser, options);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -11621,7 +11615,9 @@ START_TEST(test_nsalloc_realloc_long_ge_name)
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing reallocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11880,25 +11880,9 @@ START_TEST(test_nsalloc_prefixed_element)
         { NULL, NULL }
     };
     int i;
-#define MAX_ALLOC_COUNT 40
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 70
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if ((i == 4 && repeat == 3) ||
-            (i == 14 && repeat == 9) ||
-            (i == 15 && repeat == 10)) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 && repeat < 2) ||
-                 (i == 3 && (repeat == 2 || repeat == 4 || repeat == 5)) ||
-                 (i == 4 && repeat == 6) ||
-                 (i == 6 && repeat == 7) ||
-                 (i == 8 && repeat == 8)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         XML_SetUserData(parser, options);
         XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
@@ -11907,8 +11891,9 @@ START_TEST(test_nsalloc_prefixed_element)
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
 
-        XML_ParserFree(parser);
-        parser = XML_ParserCreate(NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Success despite failing allocator");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -11038,12 +11038,13 @@ START_TEST(test_nsalloc_realloc_longer_prefix)
 #define MAX_REALLOC_COUNT 12
 
     for (i = 0; i < MAX_REALLOC_COUNT; i++) {
-        /* Every reallocation bar the last is cached */
-        reallocation_count = (i == 0) ? 0 : 1;
+        reallocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_nsalloc_xmlns() */
+        nsalloc_teardown();
+        nsalloc_setup();
     }
     if (i == 0)
         fail("Parsing worked despite failing reallocations");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -9630,26 +9630,16 @@ START_TEST(test_alloc_attribute_predefined_entity)
 {
     const char *text = "<doc a='&amp;'></doc>";
     int i;
-#define MAX_ALLOC_COUNT 10
-    int repeat = 0;
+#define MAX_ALLOC_COUNT 15
 
     for (i = 0; i < MAX_ALLOC_COUNT; i++) {
-        /* Repeat some counts to defeat cached allocations */
-        if (i == 3 && repeat == 1) {
-            i -= 2;
-            repeat++;
-        }
-        else if ((i == 2 &&
-                  (repeat == 0 || repeat == 2 || repeat == 3)) ||
-                 (i == 3 && repeat == 4)) {
-            i--;
-            repeat++;
-        }
         allocation_count = i;
         if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                                     XML_TRUE) != XML_STATUS_ERROR)
             break;
-        XML_ParserReset(parser, NULL);
+        /* See comment in test_alloc_parse_xdecl() */
+        alloc_teardown();
+        alloc_setup();
     }
     if (i == 0)
         fail("Parse succeeded despite failing allocator");


### PR DESCRIPTION
Aside from a memory leak fix and some magic number elimination, most of these commits are to fix fragile allocation tests.

The tests as I originally wrote them effectively have the allocation patterns of the parser baked in, in an attempt to make sure all allocation failure code paths get executed despite some allocations being cached.  This broke instantly on undefining `XML_CONTEXT_BYTES`.  The only reliable way to solve this problem is to avoid `XML_ParserReset()` and instead free and recreate the parser.  This needs to be done using the `teardown` and `setup` functions for the relevant test cases to ensure we get a correctly configured parser each time.