### PR TITLE
Expand buffer size to avoid GCC 7.x warning.

### DIFF
--- a/expat/tests/chardata.c
+++ b/expat/tests/chardata.c
@@ -78,7 +78,7 @@ CharData_AppendXMLChars(CharData *storage, const XML_Char *s, int len)
 int
 CharData_CheckString(CharData *storage, const char *expected)
 {
-    char buffer[1280];
+    char buffer[4096];
     int len;
     int count;
 


### PR DESCRIPTION
tests/chardata.c currently compiles with a warning with GCC 7.x:

```
tests/chardata.c: In function ‘CharData_CheckString’:
tests/chardata.c:91:29: warning: ‘%s’ directive writing up to 2047 bytes into a region of size between 1209 and 1228 [-Wformat-overflow=]
             sprintf(buffer, "wrong number of data characters:"
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tests/chardata.c:92:45: note: format string is defined here
                     " got %d, expected %d:\n%s", count, len, storage->data);
                                             ^~
```

This is fixed by expanding the size of the buffer - alternatively, using snprintf would work.