### PR TITLE
Make xmlwf output look more like conformance test output

### DIFF
--- a/expat/doc/xmlwf.xml
+++ b/expat/doc/xmlwf.xml
@@ -58,6 +58,7 @@
 
 	  <arg><option>-r</option></arg>
 	  <arg><option>-t</option></arg>
+          <arg><option>-N</option></arg>
 
 	  <arg><option>-v</option></arg>
 
@@ -159,8 +160,8 @@ supports both.
   representations of the input files.
   By default, <option>-d</option> outputs a canonical representation
   (described below).
-  You can select different output formats using <option>-c</option>
-  and <option>-m</option>.
+  You can select different output formats using <option>-c</option>,
+  <option>-m</option> and <option>-N</option>.
 	  </para>
 	  <para>
   The output filenames will
@@ -216,6 +217,17 @@ supports both.
   Turns on namespace processing.  (describe namespaces)
   <option>-c</option> disables namespaces.
 	   </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-N</option></term>
+        <listitem>
+          <para>
+  Adds a doctype and notation declarations to canonical XML output.
+  This matches the example output used by the formal XML test cases.
+  Requires <option>-d</option> to specify an output file.
+          </para>
         </listitem>
       </varlistentry>
 

--- a/expat/tests/xmltest.log.expected
+++ b/expat/tests/xmltest.log.expected
@@ -1,35 +1,10 @@
 Output differs: ibm/valid/P02/ibm02v01.xml
-Output differs: ibm/valid/P28/ibm28v02.xml
-Output differs: ibm/valid/P29/ibm29v01.xml
-Output differs: ibm/valid/P29/ibm29v02.xml
-Output differs: ibm/valid/P54/ibm54v01.xml
-Output differs: ibm/valid/P56/ibm56v08.xml
-Output differs: ibm/valid/P57/ibm57v01.xml
-Output differs: ibm/valid/P58/ibm58v01.xml
-Output differs: ibm/valid/P58/ibm58v02.xml
-Output differs: ibm/valid/P70/ibm70v01.xml
-Output differs: ibm/valid/P82/ibm82v01.xml
 ibm49i02.dtd: No such file or directory
-Output differs: ibm/invalid/P58/ibm58i01.xml
-Output differs: ibm/invalid/P58/ibm58i02.xml
-Output differs: xmltest/valid/sa/069.xml
-Output differs: xmltest/valid/sa/076.xml
-Output differs: xmltest/valid/sa/090.xml
-Output differs: xmltest/valid/sa/091.xml
-Output differs: sun/valid/notation01.xml
-Output differs: sun/valid/not-sa01.xml
-Output differs: sun/valid/not-sa02.xml
-Output differs: sun/valid/not-sa03.xml
-Output differs: sun/valid/not-sa04.xml
-Output differs: sun/valid/sa02.xml
-Output differs: sun/valid/sa03.xml
-Output differs: sun/valid/sa04.xml
-Output differs: sun/valid/sa05.xml
 Expected not well-formed: ibm/not-wf/misc/432gewf.xml
 Expected not well-formed: xmltest/not-wf/not-sa/005.xml
 Expected not well-formed: sun/not-wf/uri01.xml
 Expected not well-formed: oasis/p06fail1.xml
 Expected not well-formed: oasis/p08fail1.xml
 Expected not well-formed: oasis/p08fail2.xml
-Passed: 1776
-Failed: 33
+Passed: 1801
+Failed: 8

--- a/expat/tests/xmltest.sh
+++ b/expat/tests/xmltest.sh
@@ -53,7 +53,7 @@ RunXmlwfNotWF() {
 RunXmlwfWF() {
   file="$1"
   reldir="$2"
-  $XMLWF -p -d "$OUTPUT$reldir" "$file" > outfile || return $?
+  $XMLWF -p -N -d "$OUTPUT$reldir" "$file" > outfile || return $?
   read outdata < outfile 
   if test "$outdata" = "" ; then 
       if [ -f "out/$file" ] ; then 

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -304,8 +304,8 @@ freeNotations(XmlwfUserData *data)
 static int
 notationCmp(const void *a, const void *b)
 {
-  const NotationList *n1 = *(NotationList **)a;
-  const NotationList *n2 = *(NotationList **)b;
+  const NotationList * const n1 = *(NotationList **)a;
+  const NotationList * const n2 = *(NotationList **)b;
   const XML_Char *name1 = n1->notationName;
   const XML_Char *name2 = n2->notationName;
 

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -258,19 +258,21 @@ processingInstruction(void *userData, const XML_Char *target,
 }
 
 
-static XML_Char *xmlCharDup(const XML_Char *s)
+static XML_Char *xcsdup(const XML_Char *s)
 {
   XML_Char *result;
-  int len = 0;
+  int count = 0;
+  int numBytes;
 
   /* Get the length of the string, including terminator */
-  while (s[len++] != 0) {
+  while (s[count++] != 0) {
     /* Do nothing */
   }
-  result = malloc(len * sizeof(XML_Char));
+  numBytes = count * sizeof(XML_Char);
+  result = malloc(numBytes);
   if (result == NULL)
     return NULL;
-  memcpy(result, s, len * sizeof(XML_Char));
+  memcpy(result, s, numBytes);
   return result;
 }
 
@@ -282,7 +284,7 @@ startDoctypeDecl(void *userData,
                  int has_internal_subset)
 {
   XmlwfUserData *data = (XmlwfUserData *)userData;
-  data->currentDoctypeName = xmlCharDup(doctypeName);
+  data->currentDoctypeName = xcsdup(doctypeName);
 }
 
 static void
@@ -406,14 +408,14 @@ notationDecl(void *userData,
     fprintf(stderr, "Unable to store NOTATION for output\n");
     return; /* Nothing we can really do about this */
   }
-  entry->notationName = xmlCharDup(notationName);
+  entry->notationName = xcsdup(notationName);
   if (entry->notationName == NULL) {
     fprintf(stderr, "Unable to store NOTATION for output\n");
     free(entry);
     return;
   }
   if (systemId != NULL) {
-    entry->systemId = xmlCharDup(systemId);
+    entry->systemId = xcsdup(systemId);
     if (entry->systemId == NULL) {
       fprintf(stderr, "Unable to store NOTATION for output\n");
       free((void *)entry->notationName);
@@ -425,7 +427,7 @@ notationDecl(void *userData,
     entry->systemId = NULL;
   }
   if (publicId != NULL) {
-    entry->publicId = xmlCharDup(publicId);
+    entry->publicId = xcsdup(publicId);
     if (entry->publicId == NULL) {
       fprintf(stderr, "Unable to store NOTATION for output\n");
       free((void *)entry->systemId); /* Safe if it's NULL */

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -341,8 +341,12 @@ endDoctypeDecl(void *userData)
   /* How many notations do we have? */
   for (p = data->notationListHead; p != NULL; p = p->next)
     notationCount++;
-  if (notationCount == 0)
-    return; /* Nothing to report */
+  if (notationCount == 0) {
+    /* Nothing to report */
+    free((void *)data->currentDoctypeName);
+    data->currentDoctypeName = NULL;
+    return;
+  }
 
   notations = malloc(notationCount * sizeof(NotationList *));
   if (notations == NULL) {

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -377,6 +377,7 @@ endDoctypeDecl(void *userData)
   /* Finally end the DOCTYPE */
   fputts(T("]>\n"), fp);
 
+  free(notations);
   freeNotations();
   free((void *)currentDoctypeName);
   currentDoctypeName = NULL;
@@ -422,6 +423,9 @@ notationDecl(void *UNUSED_P(userData),
       free(entry);
       return;
     }
+  }
+  else {
+    entry->publicId = NULL;
   }
 
   entry->next = notationListHead;
@@ -817,7 +821,7 @@ static void
 usage(const XML_Char *prog, int rc)
 {
   ftprintf(stderr,
-           T("usage: %s [-s] [-n] [-p] [-x] [-e encoding] [-w] [-d output-dir] [-c] [-m] [-r] [-t] [file ...]\n"), prog);
+           T("usage: %s [-s] [-n] [-p] [-x] [-e encoding] [-w] [-d output-dir] [-c] [-m] [-r] [-t] [-N] [file ...]\n"), prog);
   exit(rc);
 }
 
@@ -832,6 +836,7 @@ tmain(int argc, XML_Char **argv)
   int outputType = 0;
   int useNamespaces = 0;
   int requireStandalone = 0;
+  int requiresNotations = 0;
   enum XML_ParamEntityParsing paramEntityParsing = 
     XML_PARAM_ENTITY_PARSING_NEVER;
   int useStdin = 0;
@@ -887,6 +892,10 @@ tmain(int argc, XML_Char **argv)
       break;
     case T('t'):
       outputType = 't';
+      j++;
+      break;
+    case T('N'):
+      requiresNotations = 1;
       j++;
       break;
     case T('d'):
@@ -1026,8 +1035,10 @@ tmain(int argc, XML_Char **argv)
         XML_SetCharacterDataHandler(parser, characterData);
 #ifndef W3C14N
         XML_SetProcessingInstructionHandler(parser, processingInstruction);
-        XML_SetDoctypeDeclHandler(parser, startDoctypeDecl, endDoctypeDecl);
-        XML_SetNotationDeclHandler(parser, notationDecl);
+        if (requiresNotations) {
+          XML_SetDoctypeDeclHandler(parser, startDoctypeDecl, endDoctypeDecl);
+          XML_SetNotationDeclHandler(parser, notationDecl);
+        }
 #endif /* not W3C14N */
         break;
       }

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -354,7 +354,7 @@ endDoctypeDecl(void *userData)
   for (p = data->notationListHead, i = 0;
        i < notationCount;
        p = p->next, i++) {
-      notations[i] = p;
+    notations[i] = p;
   }
   qsort(notations, notationCount, sizeof(NotationList *), notationCmp);
 
@@ -405,21 +405,22 @@ notationDecl(void *userData,
 {
   XmlwfUserData *data = (XmlwfUserData *)userData;
   NotationList *entry = malloc(sizeof(NotationList));
+  const char *errorMessage = "Unable to store NOTATION for output\n";
 
   if (entry == NULL) {
-    fprintf(stderr, "Unable to store NOTATION for output\n");
+    fputs(errorMessage, stderr);
     return; /* Nothing we can really do about this */
   }
   entry->notationName = xcsdup(notationName);
   if (entry->notationName == NULL) {
-    fprintf(stderr, "Unable to store NOTATION for output\n");
+    fputs(errorMessage, stderr);
     free(entry);
     return;
   }
   if (systemId != NULL) {
     entry->systemId = xcsdup(systemId);
     if (entry->systemId == NULL) {
-      fprintf(stderr, "Unable to store NOTATION for output\n");
+      fputs(errorMessage, stderr);
       free((void *)entry->notationName);
       free(entry);
       return;
@@ -431,7 +432,7 @@ notationDecl(void *userData,
   if (publicId != NULL) {
     entry->publicId = xcsdup(publicId);
     if (entry->publicId == NULL) {
-      fprintf(stderr, "Unable to store NOTATION for output\n");
+      fputs(errorMessage, stderr);
       free((void *)entry->systemId); /* Safe if it's NULL */
       free((void *)entry->notationName);
       free(entry);

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -303,28 +303,30 @@ freeNotations(XmlwfUserData *data)
   data->notationListHead = NULL;
 }
 
+static int xcscmp(const XML_Char *xs, const XML_Char *xt)
+{
+  while (*xs != 0 && *xt != 0) {
+    if (*xs < *xt)
+      return -1;
+    if (*xs > *xt)
+      return 1;
+    xs++;
+    xt++;
+  }
+  if (*xs < *xt)
+    return -1;
+  if (*xs > *xt)
+    return 1;
+  return 0;
+}
+
 static int
 notationCmp(const void *a, const void *b)
 {
   const NotationList * const n1 = *(NotationList **)a;
   const NotationList * const n2 = *(NotationList **)b;
-  const XML_Char *name1 = n1->notationName;
-  const XML_Char *name2 = n2->notationName;
 
-  /* Compare notations by comparing their names */
-  while (*name1 != 0 && *name2 != 0) {
-    if (*name1 < *name2)
-      return -1;
-    if (*name1 > *name2)
-      return +1;
-    name1++;
-    name2++;
-  }
-  if (*name1 < *name2)
-    return -1;
-  if (*name1 > *name2)
-    return +1;
-  return 0;
+  return xcscmp(n1->notationName, n2->notationName);
 }
 
 static void XMLCALL

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -17,6 +17,21 @@
 #include <crtdbg.h>
 #endif
 
+/* Structures for handler user data */
+typedef struct NotationList {
+  struct NotationList *next;
+  const XML_Char *notationName;
+  const XML_Char *systemId;
+  const XML_Char *publicId;
+} NotationList;
+
+typedef struct xmlwfUserData {
+    FILE *fp;
+    NotationList *notationListHead;
+    const XML_Char *currentDoctypeName;
+} XmlwfUserData;
+
+
 /* This ensures proper sorting. */
 
 #define NSSEP T('\001')
@@ -24,7 +39,7 @@
 static void XMLCALL
 characterData(void *userData, const XML_Char *s, int len)
 {
-  FILE *fp = (FILE *)userData;
+  FILE *fp = ((XmlwfUserData *)userData)->fp;
   for (; len > 0; --len, ++s) {
     switch (*s) {
     case T('&'):
@@ -119,7 +134,7 @@ startElement(void *userData, const XML_Char *name, const XML_Char **atts)
 {
   int nAtts;
   const XML_Char **p;
-  FILE *fp = (FILE *)userData;
+  FILE *fp = ((XmlwfUserData *)userData)->fp;
   puttc(T('<'), fp);
   fputts(name, fp);
 
@@ -141,7 +156,7 @@ startElement(void *userData, const XML_Char *name, const XML_Char **atts)
 static void XMLCALL
 endElement(void *userData, const XML_Char *name)
 {
-  FILE *fp = (FILE *)userData;
+  FILE *fp = ((XmlwfUserData *)userData)->fp;
   puttc(T('<'), fp);
   puttc(T('/'), fp);
   fputts(name, fp);
@@ -166,7 +181,7 @@ startElementNS(void *userData, const XML_Char *name, const XML_Char **atts)
   int nAtts;
   int nsi;
   const XML_Char **p;
-  FILE *fp = (FILE *)userData;
+  FILE *fp = ((XmlwfUserData *)userData)->fp;
   const XML_Char *sep;
   puttc(T('<'), fp);
 
@@ -212,7 +227,7 @@ startElementNS(void *userData, const XML_Char *name, const XML_Char **atts)
 static void XMLCALL
 endElementNS(void *userData, const XML_Char *name)
 {
-  FILE *fp = (FILE *)userData;
+  FILE *fp = ((XmlwfUserData *)userData)->fp;
   const XML_Char *sep;
   puttc(T('<'), fp);
   puttc(T('/'), fp);
@@ -232,7 +247,7 @@ static void XMLCALL
 processingInstruction(void *userData, const XML_Char *target,
                       const XML_Char *data)
 {
-  FILE *fp = (FILE *)userData;
+  FILE *fp = ((XmlwfUserData *)userData)->fp;
   puttc(T('<'), fp);
   puttc(T('?'), fp);
   fputts(target, fp);
@@ -242,16 +257,6 @@ processingInstruction(void *userData, const XML_Char *target,
   puttc(T('>'), fp);
 }
 
-
-typedef struct NotationList {
-  struct NotationList *next;
-  const XML_Char *notationName;
-  const XML_Char *systemId;
-  const XML_Char *publicId;
-} NotationList;
-
-static NotationList *notationListHead = NULL;
-static const XML_Char *currentDoctypeName = NULL;
 
 static XML_Char *xmlCharDup(const XML_Char *s)
 {
@@ -270,18 +275,21 @@ static XML_Char *xmlCharDup(const XML_Char *s)
 }
 
 static void XMLCALL
-startDoctypeDecl(void *UNUSED_P(userData),
+startDoctypeDecl(void *userData,
                  const XML_Char *doctypeName,
                  const XML_Char *UNUSED_P(sysid),
                  const XML_Char *UNUSED_P(publid),
                  int has_internal_subset)
 {
-  currentDoctypeName = xmlCharDup(doctypeName);
+  XmlwfUserData *data = (XmlwfUserData *)userData;
+  data->currentDoctypeName = xmlCharDup(doctypeName);
 }
 
 static void
-freeNotations(void)
+freeNotations(XmlwfUserData *data)
 {
+  NotationList *notationListHead = data->notationListHead;
+
   while (notationListHead != NULL) {
     NotationList *next = notationListHead->next;
     free((void *)notationListHead->notationName);
@@ -290,6 +298,7 @@ freeNotations(void)
     free(notationListHead);
     notationListHead = next;
   }
+  data->notationListHead = NULL;
 }
 
 static int
@@ -319,14 +328,14 @@ notationCmp(const void *a, const void *b)
 static void XMLCALL
 endDoctypeDecl(void *userData)
 {
-  FILE *fp = (FILE *)userData;
+  XmlwfUserData *data = (XmlwfUserData *)userData;
   NotationList **notations;
   int notationCount = 0;
   NotationList *p;
   int i;
 
   /* How many notations do we have? */
-  for (p = notationListHead; p != NULL; p = p->next)
+  for (p = data->notationListHead; p != NULL; p = p->next)
     notationCount++;
   if (notationCount == 0)
     return; /* Nothing to report */
@@ -334,11 +343,11 @@ endDoctypeDecl(void *userData)
   notations = malloc(notationCount * sizeof(NotationList *));
   if (notations == NULL) {
     fprintf(stderr, "Unable to sort notations");
-    freeNotations();
+    freeNotations(data);
     return;
   }
 
-  for (p = notationListHead, i = 0;
+  for (p = data->notationListHead, i = 0;
        i < notationCount;
        p = p->next, i++) {
       notations[i] = p;
@@ -346,50 +355,51 @@ endDoctypeDecl(void *userData)
   qsort(notations, notationCount, sizeof(NotationList *), notationCmp);
 
   /* Output the DOCTYPE header */
-  fputts(T("<!DOCTYPE "), fp);
-  fputts(currentDoctypeName, fp);
-  fputts(T(" [\n"), fp);
+  fputts(T("<!DOCTYPE "), data->fp);
+  fputts(data->currentDoctypeName, data->fp);
+  fputts(T(" [\n"), data->fp);
 
   /* Now the NOTATIONs */
   for (i = 0; i < notationCount; i++) {
-    fputts(T("<!NOTATION "), fp);
-    fputts(notations[i]->notationName, fp);
+    fputts(T("<!NOTATION "), data->fp);
+    fputts(notations[i]->notationName, data->fp);
     if (notations[i]->publicId != NULL) {
-      fputts(T(" PUBLIC '"), fp);
-      fputts(notations[i]->publicId, fp);
-      puttc(T('\''), fp);
+      fputts(T(" PUBLIC '"), data->fp);
+      fputts(notations[i]->publicId, data->fp);
+      puttc(T('\''), data->fp);
       if (notations[i]->systemId != NULL) {
-        puttc(T(' '), fp);
-        puttc(T('\''), fp);
-        fputts(notations[i]->systemId, fp);
-        puttc(T('\''), fp);
+        puttc(T(' '), data->fp);
+        puttc(T('\''), data->fp);
+        fputts(notations[i]->systemId, data->fp);
+        puttc(T('\''), data->fp);
       }
     }
     else if (notations[i]->systemId != NULL) {
-      fputts(T(" SYSTEM '"), fp);
-      fputts(notations[i]->systemId, fp);
-      puttc(T('\''), fp);
+      fputts(T(" SYSTEM '"), data->fp);
+      fputts(notations[i]->systemId, data->fp);
+      puttc(T('\''), data->fp);
     }
-    puttc(T('>'), fp);
-    puttc(T('\n'), fp);
+    puttc(T('>'), data->fp);
+    puttc(T('\n'), data->fp);
   }
 
   /* Finally end the DOCTYPE */
-  fputts(T("]>\n"), fp);
+  fputts(T("]>\n"), data->fp);
 
   free(notations);
-  freeNotations();
-  free((void *)currentDoctypeName);
-  currentDoctypeName = NULL;
+  freeNotations(data);
+  free((void *)data->currentDoctypeName);
+  data->currentDoctypeName = NULL;
 }
 
 static void XMLCALL
-notationDecl(void *UNUSED_P(userData),
+notationDecl(void *userData,
              const XML_Char *notationName,
              const XML_Char *UNUSED_P(base),
              const XML_Char *systemId,
              const XML_Char *publicId)
 {
+  XmlwfUserData *data = (XmlwfUserData *)userData;
   NotationList *entry = malloc(sizeof(NotationList));
 
   if (entry == NULL) {
@@ -428,8 +438,8 @@ notationDecl(void *UNUSED_P(userData),
     entry->publicId = NULL;
   }
 
-  entry->next = notationListHead;
-  notationListHead = entry;
+  entry->next = data->notationListHead;
+  data->notationListHead = entry;
 }
 
 #endif /* not W3C14N */
@@ -484,7 +494,7 @@ nopProcessingInstruction(void *UNUSED_P(userData), const XML_Char *UNUSED_P(targ
 static void XMLCALL
 markup(void *userData, const XML_Char *s, int len)
 {
-  FILE *fp = (FILE *)XML_GetUserData((XML_Parser) userData);
+  FILE *fp = ((XmlwfUserData *)XML_GetUserData((XML_Parser) userData))->fp;
   for (; len > 0; --len, ++s)
     puttc(*s, fp);
 }
@@ -493,9 +503,10 @@ static void
 metaLocation(XML_Parser parser)
 {
   const XML_Char *uri = XML_GetBase(parser);
+  FILE *fp = ((XmlwfUserData *)XML_GetUserData(parser))->fp;
   if (uri)
-    ftprintf((FILE *)XML_GetUserData(parser), T(" uri=\"%s\""), uri);
-  ftprintf((FILE *)XML_GetUserData(parser),
+    ftprintf(fp, T(" uri=\"%s\""), uri);
+  ftprintf(fp,
            T(" byte=\"%" XML_FMT_INT_MOD "d\" nbytes=\"%d\" \
 			 line=\"%" XML_FMT_INT_MOD "u\" col=\"%" XML_FMT_INT_MOD "u\""),
            XML_GetCurrentByteIndex(parser),
@@ -507,13 +518,15 @@ metaLocation(XML_Parser parser)
 static void
 metaStartDocument(void *userData)
 {
-  fputts(T("<document>\n"), (FILE *)XML_GetUserData((XML_Parser) userData));
+  fputts(T("<document>\n"),
+         ((XmlwfUserData *)XML_GetUserData((XML_Parser) userData))->fp);
 }
 
 static void
 metaEndDocument(void *userData)
 {
-  fputts(T("</document>\n"), (FILE *)XML_GetUserData((XML_Parser) userData));
+  fputts(T("</document>\n"),
+         ((XmlwfUserData *)XML_GetUserData((XML_Parser) userData))->fp);
 }
 
 static void XMLCALL
@@ -521,7 +534,8 @@ metaStartElement(void *userData, const XML_Char *name,
                  const XML_Char **atts)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   const XML_Char **specifiedAttsEnd
     = atts + XML_GetSpecifiedAttributeCount(parser);
   const XML_Char **idAttPtr;
@@ -530,14 +544,14 @@ metaStartElement(void *userData, const XML_Char *name,
     idAttPtr = 0;
   else
     idAttPtr = atts + idAttIndex;
-    
+
   ftprintf(fp, T("<starttag name=\"%s\""), name);
   metaLocation(parser);
   if (*atts) {
     fputts(T(">\n"), fp);
     do {
       ftprintf(fp, T("<attribute name=\"%s\" value=\""), atts[0]);
-      characterData(fp, atts[1], (int)tcslen(atts[1]));
+      characterData(data, atts[1], (int)tcslen(atts[1]));
       if (atts >= specifiedAttsEnd)
         fputts(T("\" defaulted=\"yes\"/>\n"), fp);
       else if (atts == idAttPtr)
@@ -555,7 +569,8 @@ static void XMLCALL
 metaEndElement(void *userData, const XML_Char *name)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   ftprintf(fp, T("<endtag name=\"%s\""), name);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -566,9 +581,10 @@ metaProcessingInstruction(void *userData, const XML_Char *target,
                           const XML_Char *data)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *usrData = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = usrData->fp;
   ftprintf(fp, T("<pi target=\"%s\" data=\""), target);
-  characterData(fp, data, (int)tcslen(data));
+  characterData(usrData, data, (int)tcslen(data));
   puttc(T('"'), fp);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -578,9 +594,10 @@ static void XMLCALL
 metaComment(void *userData, const XML_Char *data)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *usrData = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = usrData->fp;
   fputts(T("<comment data=\""), fp);
-  characterData(fp, data, (int)tcslen(data));
+  characterData(usrData, data, (int)tcslen(data));
   puttc(T('"'), fp);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -590,7 +607,8 @@ static void XMLCALL
 metaStartCdataSection(void *userData)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   fputts(T("<startcdata"), fp);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -600,7 +618,8 @@ static void XMLCALL
 metaEndCdataSection(void *userData)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   fputts(T("<endcdata"), fp);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -610,9 +629,10 @@ static void XMLCALL
 metaCharacterData(void *userData, const XML_Char *s, int len)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   fputts(T("<chars str=\""), fp);
-  characterData(fp, s, len);
+  characterData(data, s, len);
   puttc(T('"'), fp);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -626,7 +646,8 @@ metaStartDoctypeDecl(void *userData,
                      int UNUSED_P(has_internal_subset))
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   ftprintf(fp, T("<startdoctype name=\"%s\""), doctypeName);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -636,7 +657,8 @@ static void XMLCALL
 metaEndDoctypeDecl(void *userData)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   fputts(T("<enddoctype"), fp);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -650,13 +672,14 @@ metaNotationDecl(void *userData,
                  const XML_Char *publicId)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   ftprintf(fp, T("<notation name=\"%s\""), notationName);
   if (publicId)
     ftprintf(fp, T(" public=\"%s\""), publicId);
   if (systemId) {
     fputts(T(" system=\""), fp);
-    characterData(fp, systemId, (int)tcslen(systemId));
+    characterData(data, systemId, (int)tcslen(systemId));
     puttc(T('"'), fp);
   }
   metaLocation(parser);
@@ -676,13 +699,14 @@ metaEntityDecl(void *userData,
                const XML_Char *notationName)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
 
   if (value) {
     ftprintf(fp, T("<entity name=\"%s\""), entityName);
     metaLocation(parser);
     puttc(T('>'), fp);
-    characterData(fp, value, value_length);
+    characterData(data, value, value_length);
     fputts(T("</entity/>\n"), fp);
   }
   else if (notationName) {
@@ -690,7 +714,7 @@ metaEntityDecl(void *userData,
     if (publicId)
       ftprintf(fp, T(" public=\"%s\""), publicId);
     fputts(T(" system=\""), fp);
-    characterData(fp, systemId, (int)tcslen(systemId));
+    characterData(data, systemId, (int)tcslen(systemId));
     puttc(T('"'), fp);
     ftprintf(fp, T(" notation=\"%s\""), notationName);
     metaLocation(parser);
@@ -701,7 +725,7 @@ metaEntityDecl(void *userData,
     if (publicId)
       ftprintf(fp, T(" public=\"%s\""), publicId);
     fputts(T(" system=\""), fp);
-    characterData(fp, systemId, (int)tcslen(systemId));
+    characterData(data, systemId, (int)tcslen(systemId));
     puttc(T('"'), fp);
     metaLocation(parser);
     fputts(T("/>\n"), fp);
@@ -714,13 +738,14 @@ metaStartNamespaceDecl(void *userData,
                        const XML_Char *uri)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   fputts(T("<startns"), fp);
   if (prefix)
     ftprintf(fp, T(" prefix=\"%s\""), prefix);
   if (uri) {
     fputts(T(" ns=\""), fp);
-    characterData(fp, uri, (int)tcslen(uri));
+    characterData(data, uri, (int)tcslen(uri));
     fputts(T("\"/>\n"), fp);
   }
   else
@@ -731,7 +756,8 @@ static void XMLCALL
 metaEndNamespaceDecl(void *userData, const XML_Char *prefix)
 {
   XML_Parser parser = (XML_Parser) userData;
-  FILE *fp = (FILE *)XML_GetUserData(parser);
+  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  FILE *fp = data->fp;
   if (!prefix)
     fputts(T("<endns/>\n"), fp);
   else
@@ -840,6 +866,7 @@ tmain(int argc, XML_Char **argv)
   enum XML_ParamEntityParsing paramEntityParsing = 
     XML_PARAM_ENTITY_PARSING_NEVER;
   int useStdin = 0;
+  XmlwfUserData userData = { NULL, NULL, NULL };
 
 #ifdef _MSC_VER
   _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF|_CRTDBG_LEAK_CHECK_DF);
@@ -943,7 +970,6 @@ tmain(int argc, XML_Char **argv)
     i--;
   }
   for (; i < argc; i++) {
-    FILE *fp = 0;
     XML_Char *outName = 0;
     int result;
     XML_Parser parser;
@@ -992,16 +1018,16 @@ tmain(int argc, XML_Char **argv)
       tcscpy(outName, outputDir);
       tcscat(outName, delim);
       tcscat(outName, file);
-      fp = tfopen(outName, T("wb"));
-      if (!fp) {
+      userData.fp = tfopen(outName, T("wb"));
+      if (!userData.fp) {
         tperror(outName);
         exit(1);
       }
-      setvbuf(fp, NULL, _IOFBF, 16384);
+      setvbuf(userData.fp, NULL, _IOFBF, 16384);
 #ifdef XML_UNICODE
-      puttc(0xFEFF, fp);
+      puttc(0xFEFF, userData.fp);
 #endif
-      XML_SetUserData(parser, fp);
+      XML_SetUserData(parser, &userData);
       switch (outputType) {
       case 'm':
         XML_UseParserAsHandlerArg(parser);
@@ -1049,7 +1075,7 @@ tmain(int argc, XML_Char **argv)
     if (outputDir) {
       if (outputType == 'm')
         metaEndDocument(parser);
-      fclose(fp);
+      fclose(userData.fp);
       if (!result) {
         tremove(outName);
         exit(2);

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -242,6 +242,136 @@ processingInstruction(void *userData, const XML_Char *target,
   puttc(T('>'), fp);
 }
 
+
+typedef struct NotationList {
+  struct NotationList *next;
+  const XML_Char *notationName;
+  const XML_Char *systemId;
+  const XML_Char *publicId;
+} NotationList;
+
+static NotationList *notationListHead = NULL;
+static const XML_Char *currentDoctypeName = NULL;
+
+static XML_Char *xmlCharDup(const XML_Char *s)
+{
+  XML_Char *result;
+  int len = 0;
+
+  /* Get the length of the string, including terminator */
+  while (s[len++] != 0) {
+    /* Do nothing */
+  }
+  result = malloc(len * sizeof(XML_Char));
+  if (result == NULL)
+    return NULL;
+  memcpy(result, s, len * sizeof(XML_Char));
+  return result;
+}
+
+static void XMLCALL
+startDoctypeDecl(void *UNUSED_P(userData),
+                 const XML_Char *doctypeName,
+                 const XML_Char *UNUSED_P(sysid),
+                 const XML_Char *UNUSED_P(publid),
+                 int has_internal_subset)
+{
+  currentDoctypeName = xmlCharDup(doctypeName);
+}
+
+static void XMLCALL
+endDoctypeDecl(void *userData)
+{
+  FILE *fp = (FILE *)userData;
+
+  if (notationListHead != NULL) {
+    /* Output the DOCTYPE header */
+    fputts(T("<!DOCTYPE "), fp);
+    fputts(currentDoctypeName, fp);
+    fputts(T(" [\n"), fp);
+
+    /* Now the NOTATIONs */
+    while (notationListHead != NULL) {
+      NotationList *next = notationListHead->next;
+      fputts(T("<!NOTATION "), fp);
+      fputts(notationListHead->notationName, fp);
+      if (notationListHead->publicId != NULL) {
+        fputts(T(" PUBLIC '"), fp);
+        fputts(notationListHead->publicId, fp);
+        puttc(T('\''), fp);
+        if (notationListHead->systemId != NULL) {
+            puttc(T(' '), fp);
+            puttc(T('\''), fp);
+            fputts(notationListHead->systemId, fp);
+            puttc(T('\''), fp);
+        }
+      }
+      else if (notationListHead->systemId != NULL) {
+        fputts(T(" SYSTEM '"), fp);
+        fputts(notationListHead->systemId, fp);
+        puttc(T('\''), fp);
+      }
+      puttc(T('>'), fp);
+      puttc(T('\n'), fp);
+      free((void *)notationListHead->notationName);
+      free((void *)notationListHead->systemId);
+      free((void *)notationListHead->publicId);
+      free(notationListHead);
+      notationListHead = next;
+    }
+    /* Finally end the DOCTYPE */
+    fputts(T("]>\n"), fp);
+  }
+  free((void *)currentDoctypeName);
+  currentDoctypeName = NULL;
+}
+
+static void XMLCALL
+notationDecl(void *UNUSED_P(userData),
+             const XML_Char *notationName,
+             const XML_Char *UNUSED_P(base),
+             const XML_Char *systemId,
+             const XML_Char *publicId)
+{
+  NotationList *entry = malloc(sizeof(NotationList));
+
+  if (entry == NULL) {
+    fprintf(stderr, "Unable to store NOTATION for output\n");
+    return; /* Nothing we can really do about this */
+  }
+  entry->notationName = xmlCharDup(notationName);
+  if (entry->notationName == NULL) {
+    fprintf(stderr, "Unable to store NOTATION for output\n");
+    free(entry);
+    return;
+  }
+  if (systemId != NULL) {
+    entry->systemId = xmlCharDup(systemId);
+    if (entry->systemId == NULL) {
+      fprintf(stderr, "Unable to store NOTATION for output\n");
+      free((void *)entry->notationName);
+      free(entry);
+      return;
+    }
+  }
+  else {
+    entry->systemId = NULL;
+  }
+  if (publicId != NULL) {
+    entry->publicId = xmlCharDup(publicId);
+    if (entry->publicId == NULL) {
+      fprintf(stderr, "Unable to store NOTATION for output\n");
+      free((void *)entry->systemId); /* Safe if it's NULL */
+      free((void *)entry->notationName);
+      free(entry);
+      return;
+    }
+  }
+
+  entry->next = notationListHead;
+  notationListHead = entry;
+}
+
 #endif /* not W3C14N */
 
 static void XMLCALL
@@ -840,6 +970,8 @@ tmain(int argc, XML_Char **argv)
         XML_SetCharacterDataHandler(parser, characterData);
 #ifndef W3C14N
         XML_SetProcessingInstructionHandler(parser, processingInstruction);
+        XML_SetDoctypeDeclHandler(parser, startDoctypeDecl, endDoctypeDecl);
+        XML_SetNotationDeclHandler(parser, notationDecl);
 #endif /* not W3C14N */
         break;
       }


### PR DESCRIPTION
As mentioned in issue #75, `xmlwf` outputs Canonical XML which is not quite what the conformance tests want.  The test output includes notation declarations (and a doctype to put them in).  This branch adds an `-N` option to `xmlwf` to provide that output and reduce the number of discrepancies in the test output.