### PR TITLE
Fix tests on non-x86 architectures.

### DIFF
--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -5671,7 +5671,7 @@ static int XMLCALL
 prefix_converter(void *UNUSED_P(data), const char *s)
 {
     /* If the first byte is 0xff, raise an error */
-    if (s[0] == -1)
+    if (s[0] == 0xff)
         return -1;
     /* Just add the low bits of the first byte to the second */
     return (s[1] + (s[0] & 0x7f)) & 0x01ff;

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -5671,7 +5671,7 @@ static int XMLCALL
 prefix_converter(void *UNUSED_P(data), const char *s)
 {
     /* If the first byte is 0xff, raise an error */
-    if (s[0] == 0xff)
+    if (s[0] == (char)-1)
         return -1;
     /* Just add the low bits of the first byte to the second */
     return (s[1] + (s[0] & 0x7f)) & 0x01ff;


### PR DESCRIPTION
This s[0] == -1 comparison is failing on non-x86 architectures (the char gets promoted to an int I guess?), hence I get four new test failures with 2.2.3.

> ./run.sh tests/runtests
> Expat version: expat_2.2.3
> Bad name start in unknown encoding not faultedBad name in unknown encoding not faultedInvalid attribute valid not faultedInvalid character not faulted98%: Checks: 326, Failed: 4


