### PR TITLE
Don't suppress default handler for public/system doctype IDs

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -4478,7 +4478,10 @@ doProlog(XML_Parser parser,
         normalizePublicId(tem);
         declEntity->publicId = tem;
         poolFinish(&dtd->pool);
-        if (entityDeclHandler)
+        /* Don't suppress the default handler if we fell through from
+         * the XML_ROLE_DOCTYPE_PUBLIC_ID case.
+         */
+        if (entityDeclHandler && role == XML_ROLE_ENTITY_PUBLIC_ID)
           handleDefault = XML_FALSE;
       }
       break;
@@ -4782,7 +4785,10 @@ doProlog(XML_Parser parser,
           return XML_ERROR_NO_MEMORY;
         declEntity->base = curBase;
         poolFinish(&dtd->pool);
-        if (entityDeclHandler)
+        /* Don't suppress the default handler if we fell through from
+         * the XML_ROLE_DOCTYPE_SYSTEM_ID case.
+         */
+        if (entityDeclHandler && role == XML_ROLE_ENTITY_SYSTEM_ID)
           handleDefault = XML_FALSE;
       }
       break;

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -6805,6 +6805,64 @@ START_TEST(test_bad_notation)
 }
 END_TEST
 
+/* Test for issue #11, wrongly suppressed default handler */
+typedef struct default_check {
+    const XML_Char *expected;
+    int len;
+    XML_Bool seen;
+} DefaultCheck;
+
+static void XMLCALL
+checking_default_handler(void *userData,
+                         const XML_Char *s,
+                         int len)
+{
+    DefaultCheck *data = (DefaultCheck *)userData;
+    int i;
+
+    for (i = 0; data[i].expected != NULL; i++) {
+        if (data[i].len == len &&
+            !memcmp(data[i].expected, s, len * sizeof(XML_Char))) {
+            data[i].seen = XML_TRUE;
+            break;
+        }
+    }
+}
+
+START_TEST(test_default_doctype_handler)
+{
+    const char *text =
+        "<!DOCTYPE doc PUBLIC 'pubname' 'test.dtd' [\n"
+        "  <!ENTITY foo 'bar'>\n"
+        "]>\n"
+        "<doc>&foo;</doc>";
+    DefaultCheck test_data[] = {
+        {
+            "'pubname'",
+            9,
+            XML_FALSE
+        },
+        {
+            "'test.dtd'",
+            10,
+            XML_FALSE
+        },
+        { NULL, 0, XML_FALSE }
+    };
+    int i;
+
+    XML_SetUserData(parser, &test_data);
+    XML_SetDefaultHandler(parser, checking_default_handler);
+    XML_SetEntityDeclHandler(parser, dummy_entity_decl_handler);
+    if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
+                                XML_TRUE) == XML_STATUS_ERROR)
+        xml_failure(parser);
+    for (i = 0; test_data[i].expected != NULL; i++)
+        if (!test_data[i].seen)
+            fail("Default handler not run for public !DOCTYPE");
+}
+END_TEST
+
 /*
  * Namespaces tests.
  */
@@ -11860,6 +11918,7 @@ make_suite(void)
     tcase_add_test(tc_basic, test_bad_entity_3);
     tcase_add_test(tc_basic, test_bad_entity_4);
     tcase_add_test(tc_basic, test_bad_notation);
+    tcase_add_test(tc_basic, test_default_doctype_handler);
 
     suite_add_tcase(s, tc_namespace);
     tcase_add_checked_fixture(tc_namespace,

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -6808,7 +6808,7 @@ END_TEST
 /* Test for issue #11, wrongly suppressed default handler */
 typedef struct default_check {
     const XML_Char *expected;
-    int len;
+    const int expectedLen;
     XML_Bool seen;
 } DefaultCheck;
 
@@ -6821,7 +6821,7 @@ checking_default_handler(void *userData,
     int i;
 
     for (i = 0; data[i].expected != NULL; i++) {
-        if (data[i].len == len &&
+        if (data[i].expectedLen == len &&
             !memcmp(data[i].expected, s, len * sizeof(XML_Char))) {
             data[i].seen = XML_TRUE;
             break;


### PR DESCRIPTION
(Issue #11)  The default handler wasn't being called when it should for a SYSTEM or PUBLIC doctype if an entity declaration handler was registered.