### PR TITLE
Do not cast arguments of memcpy(3).

### DIFF
--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -412,7 +412,7 @@ utf8_toUtf8(const ENCODING *UNUSED_P(enc),
   }
 
   const ptrdiff_t bytesToCopy = fromLim - *fromP;
-  memcpy((void *)*toP, (const void *)*fromP, (size_t)bytesToCopy);
+  memcpy(*toP, *fromP, bytesToCopy);
   *fromP += bytesToCopy;
   *toP += bytesToCopy;
 


### PR DESCRIPTION
With an explicit cast, the C compiler does not check whether the
function's arguments are compatible and will just convert anything.
So removing the cast makes the code safer as the compiler will
complain in more cases.  The implicit cast does the correct thing.