### PR TITLE
Fix example programs to compile under XML_UNICODE_WCHAR_T

### DIFF
--- a/expat/examples/elements.c
+++ b/expat/examples/elements.c
@@ -47,8 +47,17 @@
 #define XML_FMT_INT_MOD "l"
 #endif
 
+#ifdef XML_UNICODE_WCHAR_T
+#include <wchar.h>
+#define XML_FMT_STR "ls"
+#define xcputs(s) do { fputws((s), stdout); putchar('\n'); } while (0)
+#else
+#define XML_FMT_STR "s"
+#define xcputs(s) puts(s)
+#endif
+
 static void XMLCALL
-startElement(void *userData, const char *name, const char **atts)
+startElement(void *userData, const XML_Char *name, const XML_Char **atts)
 {
   int i;
   int *depthPtr = (int *)userData;
@@ -56,12 +65,12 @@ startElement(void *userData, const char *name, const char **atts)
 
   for (i = 0; i < *depthPtr; i++)
     putchar('\t');
-  puts(name);
+  xcputs(name);
   *depthPtr += 1;
 }
 
 static void XMLCALL
-endElement(void *userData, const char *name)
+endElement(void *userData, const XML_Char *name)
 {
   int *depthPtr = (int *)userData;
   (void)name;
@@ -86,7 +95,7 @@ main(int argc, char *argv[])
     done = len < sizeof(buf);
     if (XML_Parse(parser, buf, len, done) == XML_STATUS_ERROR) {
       fprintf(stderr,
-              "%s at line %" XML_FMT_INT_MOD "u\n",
+              "%" XML_FMT_STR " at line %" XML_FMT_INT_MOD "u\n",
               XML_ErrorString(XML_GetErrorCode(parser)),
               XML_GetCurrentLineNumber(parser));
       return 1;

--- a/expat/examples/outline.c
+++ b/expat/examples/outline.c
@@ -45,6 +45,12 @@
 #define XML_FMT_INT_MOD "l"
 #endif
 
+#ifdef XML_UNICODE_WCHAR_T
+#define XML_FMT_STR "ls"
+#else
+#define XML_FMT_STR "s"
+#endif
+
 #define BUFFSIZE        8192
 
 char Buff[BUFFSIZE];
@@ -52,7 +58,7 @@ char Buff[BUFFSIZE];
 int Depth;
 
 static void XMLCALL
-start(void *data, const char *el, const char **attr)
+start(void *data, const XML_Char *el, const XML_Char **attr)
 {
   int i;
   (void)data;
@@ -60,10 +66,10 @@ start(void *data, const char *el, const char **attr)
   for (i = 0; i < Depth; i++)
     printf("  ");
 
-  printf("%s", el);
+  printf("%" XML_FMT_STR, el);
 
   for (i = 0; attr[i]; i += 2) {
-    printf(" %s='%s'", attr[i], attr[i + 1]);
+    printf(" %" XML_FMT_STR "='%" XML_FMT_STR "'", attr[i], attr[i + 1]);
   }
 
   printf("\n");
@@ -71,7 +77,7 @@ start(void *data, const char *el, const char **attr)
 }
 
 static void XMLCALL
-end(void *data, const char *el)
+end(void *data, const XML_Char *el)
 {
   (void)data;
   (void)el;
@@ -105,7 +111,8 @@ main(int argc, char *argv[])
     done = feof(stdin);
 
     if (XML_Parse(p, Buff, len, done) == XML_STATUS_ERROR) {
-      fprintf(stderr, "Parse error at line %" XML_FMT_INT_MOD "u:\n%s\n",
+      fprintf(stderr,
+              "Parse error at line %" XML_FMT_INT_MOD "u:\n%" XML_FMT_STR "\n",
               XML_GetCurrentLineNumber(p),
               XML_ErrorString(XML_GetErrorCode(p)));
       exit(-1);


### PR DESCRIPTION
Neither `outline.c` nor `elements.c` were using `XML_Char` type for handler parameters, and therefore won't compile with `XML_UNICODE` set.