### PR TITLE
Fix benchmark to compile under XML_UNICODE_WCHAR_T

### DIFF
--- a/expat/tests/benchmark/benchmark.c
+++ b/expat/tests/benchmark/benchmark.c
@@ -42,6 +42,12 @@
 #define XML_FMT_INT_MOD "l"
 #endif
 
+#ifdef XML_UNICODE_WCHAR_T
+#define XML_FMT_STR "ls"
+#else
+#define XML_FMT_STR "s"
+#endif
+
 static void
 usage(const char *prog, int rc)
 {
@@ -116,7 +122,8 @@ int main (int argc, char *argv[])
       else
         parseBufferSize = bufferSize;
       if (!XML_Parse (parser, XMLBufPtr, parseBufferSize, isFinal)) {
-        fprintf (stderr, "error '%s' at line %" XML_FMT_INT_MOD \
+        fprintf (stderr,
+                 "error '%" XML_FMT_STR "' at line %" XML_FMT_INT_MOD   \
                      "u character %" XML_FMT_INT_MOD "u\n",
                  XML_ErrorString (XML_GetErrorCode (parser)),
                  XML_GetCurrentLineNumber (parser),


### PR DESCRIPTION
Use the right format string for printing `XML_LChar` variables