### PR TITLE
WIP: Compiling xmlwf with -DXML_UNICODE_WCHAR_T in MinGW

### DIFF
--- a/expat/README.md
+++ b/expat/README.md
@@ -102,6 +102,33 @@ support this mode of compilation (yet):
 
 1. Run `make install` (again, excludes xmlwf).
 
+You can also use MinGW to build Expat to provide document information
+in UTF-16 encoding, with an experimental variant of `xmlwf`.  Follow
+these instructions (after having run `make distclean`):
+
+1. Mass-patch `Makefile.am` as above:
+   <br/>
+   `find -name Makefile.am -exec sed
+       -e 's,libexpat\.la,libexpatw.la,'
+       -e 's,libexpat_la,libexpatw_la,'
+       -i {} +`
+
+1. Edit `xmlwf/Makefile.am` to add the following:
+   <br/>
+   `AM_CPPFLAGS = -I$(srcdir)/../lib -mwindows
+   AM_LDFLAGS = -municode`
+
+1. Run `automake` to re-write `Makefile.in` files:<br/>
+   `automake`
+
+1. Configure for a MinGW build:
+   `./configure CPPFLAGS=-DXML_UNICODE_WCHAR_T --host=i686-w64-mingw32`
+
+1. Run `make` as usual.
+
+`make check` and `make run-xmltest` will automatically `wine` to run
+the Windows executables.
+
 Using `DESTDIR` is supported.  It works as follows:
 
 ```console

--- a/expat/tests/udiffer.py
+++ b/expat/tests/udiffer.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python3
+
+import sys
+import difflib
+
+if len(sys.argv) != 3:
+    sys.exit(2)
+
+try:
+    with open(sys.argv[1]) as infile1:
+        first = infile1.readlines()
+except UnicodeDecodeError:
+    with open(sys.argv[1], encoding="utf_16") as infile1:
+        first = infile1.readlines()
+try:
+    with open(sys.argv[2]) as infile2:
+        second = infile2.readlines()
+except UnicodeDecodeError:
+    with open(sys.argv[2], encoding="utf_16") as infile2:
+        second = infile2.readlines()
+
+diffs = list(difflib.unified_diff(first, second,
+                                  fromfile=sys.argv[1], tofile=sys.argv[2]))
+if diffs:
+    sys.stdout.writelines(diffs)
+    sys.exit(1)

--- a/expat/tests/xmltest.sh
+++ b/expat/tests/xmltest.sh
@@ -31,6 +31,8 @@ TS="$MYDIR"
 # OUTPUT must terminate with the directory separator.
 OUTPUT="$TS/out/"
 # OUTPUT=/home/tmp/xml-testsuite-out/
+# Unicode-aware diff utility
+DIFF="$TS/udiffer.py"
 
 
 # RunXmlwfNotWF file reldir
@@ -57,7 +59,7 @@ RunXmlwfWF() {
   read outdata < outfile 
   if test "$outdata" = "" ; then 
       if [ -f "out/$file" ] ; then 
-          diff -u "$OUTPUT$reldir$file" "out/$file" > outfile 
+          $DIFF "$OUTPUT$reldir$file" "out/$file" > outfile 
           if [ -s outfile ] ; then 
               cp outfile "$OUTPUT$reldir$file.diff"
               echo "Output differs: $reldir$file"

--- a/expat/xmlwf/readfilemap.c
+++ b/expat/xmlwf/readfilemap.c
@@ -71,10 +71,11 @@
 #endif
 
 #include "filemap.h"
+#include "xmltchar.h"
 
 int
-filemap(const char *name,
-        void (*processor)(const void *, size_t, const char *, void *arg),
+filemap(const tchar *name,
+        void (*processor)(const void *, size_t, const tchar *, void *arg),
         void *arg)
 {
   size_t nbytes;
@@ -83,18 +84,18 @@ filemap(const char *name,
   struct stat sb;
   void *p;
 
-  fd = open(name, O_RDONLY|O_BINARY);
+  fd = topen(name, O_RDONLY|O_BINARY);
   if (fd < 0) {
-    perror(name);
+    tperror(name);
     return 0;
   }
   if (fstat(fd, &sb) < 0) {
-    perror(name);
+    tperror(name);
     close(fd);
     return 0;
   }
   if (!S_ISREG(sb.st_mode)) {
-    fprintf(stderr, "%s: not a regular file\n", name);
+    ftprintf(stderr, T("%s: not a regular file\n"), name);
     close(fd);
     return 0;
   }
@@ -113,19 +114,19 @@ filemap(const char *name,
   }
   p = malloc(nbytes);
   if (!p) {
-    fprintf(stderr, "%s: out of memory\n", name);
+    ftprintf(stderr, T("%s: out of memory\n"), name);
     close(fd);
     return 0;
   }
   n = _EXPAT_read(fd, p, nbytes);
   if (n < 0) {
-    perror(name);
+    tperror(name);
     free(p);
     close(fd);
     return 0;
   }
   if (n != (_EXPAT_read_count_t)nbytes) {
-    fprintf(stderr, "%s: read unexpected number of bytes\n", name);
+    ftprintf(stderr, T("%s: read unexpected number of bytes\n"), name);
     free(p);
     close(fd);
     return 0;

--- a/expat/xmlwf/readfilemap.c
+++ b/expat/xmlwf/readfilemap.c
@@ -70,8 +70,8 @@
 #endif
 #endif
 
-#include "filemap.h"
 #include "xmltchar.h"
+#include "filemap.h"
 
 int
 filemap(const tchar *name,

--- a/expat/xmlwf/unixfilemap.c
+++ b/expat/xmlwf/unixfilemap.c
@@ -43,11 +43,18 @@
 #define MAP_FILE 0
 #endif
 
+#include "xmltchar.h"
 #include "filemap.h"
 
+#ifdef XML_UNICODE_WCHAR_T
+#define XML_FMT_STR "ls"
+#else
+#define XML_FMT_STR "s"
+#endif
+
 int
-filemap(const char *name,
-        void (*processor)(const void *, size_t, const char *, void *arg),
+filemap(const tchar *name,
+        void (*processor)(const void *, size_t, const tchar *, void *arg),
         void *arg)
 {
   int fd;
@@ -55,19 +62,19 @@ filemap(const char *name,
   struct stat sb;
   void *p;
 
-  fd = open(name, O_RDONLY);
+  fd = topen(name, O_RDONLY);
   if (fd < 0) {
-    perror(name);
+    tperror(name);
     return 0;
   }
   if (fstat(fd, &sb) < 0) {
-    perror(name);
+    tperror(name);
     close(fd);
     return 0;
   }
   if (!S_ISREG(sb.st_mode)) {
     close(fd);
-    fprintf(stderr, "%s: not a regular file\n", name);
+    fprintf(stderr, "%" XML_FMT_STR ": not a regular file\n", name);
     return 0;
   }
   if (sb.st_size > XML_MAX_CHUNK_LEN) {
@@ -86,7 +93,7 @@ filemap(const char *name,
   p = (void *)mmap((void *)0, (size_t)nbytes, PROT_READ,
                    MAP_FILE|MAP_PRIVATE, fd, (off_t)0);
   if (p == (void *)-1) {
-    perror(name);
+    tperror(name);
     close(fd);
     return 0;
   }

--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -202,18 +202,18 @@ processStream(const XML_Char *filename, XML_Parser parser)
       if (filename != NULL)
         close(fd);
       ftprintf(stderr, T("%s: out of memory\n"),
-               filename != NULL ? filename : "xmlwf");
+               filename != NULL ? filename : T("xmlwf"));
       return 0;
     }
     nread = read(fd, buf, READ_SIZE);
     if (nread < 0) {
-      tperror(filename != NULL ? filename : "STDIN");
+      tperror(filename != NULL ? filename : T("STDIN"));
       if (filename != NULL)
         close(fd);
       return 0;
     }
     if (XML_ParseBuffer(parser, nread, nread == 0) == XML_STATUS_ERROR) {
-      reportError(parser, filename != NULL ? filename : "STDIN");
+        reportError(parser, filename != NULL ? filename : T("STDIN"));
       if (filename != NULL)
         close(fd);
       return 0;

--- a/expat/xmlwf/xmltchar.h
+++ b/expat/xmlwf/xmltchar.h
@@ -49,6 +49,7 @@
 #define topen _wopen
 #define tmain wmain
 #define tremove _wremove
+#define tchar wchar_t
 #else /* not XML_UNICODE */
 #define T(x) x
 #define ftprintf fprintf
@@ -65,4 +66,5 @@
 #define topen open
 #define tmain main
 #define tremove remove
+#define tchar char
 #endif /* not XML_UNICODE */

--- a/expat/xmlwf/xmltchar.h
+++ b/expat/xmlwf/xmltchar.h
@@ -30,6 +30,9 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/* Ensures compile-time constants are consistent */
+#include "expat_external.h"
+
 #ifdef XML_UNICODE
 #ifndef XML_UNICODE_WCHAR_T
 #error xmlwf requires a 16-bit Unicode-compatible wchar_t 

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -46,6 +46,10 @@
 #include <crtdbg.h>
 #endif
 
+#ifdef XML_UNICODE
+#include <wchar.h>
+#endif
+
 /* Structures for handler user data */
 typedef struct NotationList {
   struct NotationList *next;
@@ -1018,7 +1022,7 @@ tmain(int argc, XML_Char **argv)
       parser = XML_ParserCreate(encoding);
 
     if (! parser) {
-      tperror("Could not instantiate parser");
+      tperror(T("Could not instantiate parser"));
       exit(1);
     }
 


### PR DESCRIPTION
This is a work-in-progress.  It works on my Linux Mint box except that the distribution has a sufficiently old version of `wine` that it doesn't support `_wperror()` (and it doesn't seem to generate coverage statistics).  It doesn't work on my Gentoo chroot, but that seems likely to be a fault in my wine installation.

See the README.md for instructions on how to build this under MinGW.