### PR TITLE
Add XML_UNICODE_WCHAR_T builds to appveyor build matrix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,9 +56,21 @@ environment:
       PLATFORM: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 
+    # Visual Studio 2010 Win32 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 10 2010
+      PLATFORM: Win32
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+
     # Visual Studio 2010 x64
     - GENERATOR: Visual Studio 10 2010 Win64
       PLATFORM: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+
+    # Visual Studio 2010 x64 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 10 2010 Win64
+      PLATFORM: x64
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 
     # Visual Studio 2012 Win32
@@ -66,9 +78,21 @@ environment:
       PLATFORM: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 
+    # Visual Studio 2012 Win32 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 11 2012
+      PLATFORM: Win32
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+
     # Visual Studio 2012 x64
     - GENERATOR: Visual Studio 11 2012 Win64
       PLATFORM: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+
+    # Visual Studio 2012 x64 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 11 2012 Win64
+      PLATFORM: x64
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 
     # Visual Studio 2013 Win32
@@ -76,9 +100,21 @@ environment:
       PLATFORM: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 
+    # Visual Studio 2013 Win32 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 12 2013
+      PLATFORM: Win32
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+
     # Visual Studio 2013 x64
     - GENERATOR: Visual Studio 12 2013 Win64
       PLATFORM: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+
+    # Visual Studio 2013 x64 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 12 2013 Win64
+      PLATFORM: x64
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 
     # Visual Studio 2015 Win32
@@ -86,9 +122,21 @@ environment:
       PLATFORM: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
+    # Visual Studio 2015 Win32 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 14 2015
+      PLATFORM: Win32
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
     # Visual Studio 2015 x64
     - GENERATOR: Visual Studio 14 2015 Win64
       PLATFORM: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+
+    # Visual Studio 2015 x64 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 14 2015 Win64
+      PLATFORM: x64
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     # Visual Studio 2017 Win32
@@ -96,9 +144,21 @@ environment:
       PLATFORM: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
+    # Visual Studio 2017 Win32 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 15 2017
+      PLATFORM: Win32
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
     # Visual Studio 2017 x64
     - GENERATOR: Visual Studio 15 2017 Win64
       PLATFORM: x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    # Visual Studio 2017 x64 XML_UNICODE_WCHAR_T
+    - GENERATOR: Visual Studio 15 2017 Win64
+      PLATFORM: x64
+      CFLAGS: -DXML_UNICODE -DXML_UNICODE_WCHAR_T
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 before_build:


### PR DESCRIPTION
See issue [#147](https://github.com/libexpat/libexpat/issues/147)