### PR TITLE
Allow configure with DOCBOOK_TO_MAN="xmlto man --skip-validation".

### DIFF
--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -241,7 +241,7 @@ AS_IF([test "x$with_docbook" != xno],
   [if test "x$with_docbook" != xcheck; then 
     AC_MSG_ERROR([Required program 'docbook2x-man' not found.])])])
 
-AM_CONDITIONAL(WITH_DOCBOOK, [test x${DOCBOOK_TO_MAN} != x])
+AM_CONDITIONAL(WITH_DOCBOOK, [test "x${DOCBOOK_TO_MAN}" != x])
 
 AC_CONFIG_FILES([Makefile expat.pc])
 AC_CONFIG_FILES([

--- a/expat/doc/Makefile.am
+++ b/expat/doc/Makefile.am
@@ -32,8 +32,9 @@ dist_man_MANS = xmlwf.1
 
 xmlwf.1: xmlwf.xml
 if WITH_DOCBOOK
+	-rm -f $@
 	$(DOCBOOK_TO_MAN) $<
-	mv XMLWF.1 $@
+	test -f $@ || mv XMLWF.1 $@
 else
 	@echo 'ERROR: Configure with --with-docbook for "make dist".' 1>&2
 	@false


### PR DESCRIPTION
The configure script fails if DOCBOOK_TO_MAN has spaces because of a quoting issue.

This also adjusts the Makefile to allow a DOCBOOK_TO_MAN which produces xmlwf.1 directly.