### PR TITLE
Fix warning on AppVeyor Windows build

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -80,7 +80,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_COMPILE_FLAGS}")
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 if(MSVC)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS -wd4996)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS -wd4996 /WX)
 endif(MSVC)
 if(WIN32)
     set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Add a suffix, usually d on Windows")

--- a/expat/examples/elements.c
+++ b/expat/examples/elements.c
@@ -37,6 +37,11 @@
 #include <stdio.h>
 #include <expat.h>
 
+#if defined(_MSC_VER)
+/* https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267 */
+#  pragma warning( disable : 4267)
+#endif
+
 #ifdef XML_LARGE_SIZE
 # if defined(XML_USE_MSC_EXTENSIONS) && _MSC_VER < 1400
 #  define XML_FMT_INT_MOD "I64"

--- a/expat/lib/expat.vcxproj
+++ b/expat/lib/expat.vcxproj
@@ -71,7 +71,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Debug\</AssemblerListingLocation>
       <BrowseInformation>true</BrowseInformation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Debug\expat.pch</PrecompiledHeaderOutputFile>
@@ -113,7 +113,7 @@
       <Optimization>MaxSpeed</Optimization>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Release\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Release\expat.pch</PrecompiledHeaderOutputFile>
       <PrecompiledHeader />

--- a/expat/lib/expat_static.vcxproj
+++ b/expat/lib/expat_static.vcxproj
@@ -71,7 +71,7 @@
       <Optimization>MaxSpeed</Optimization>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>_WINDOWS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDOWS;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Release_static\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Release_static\expat_static.pch</PrecompiledHeaderOutputFile>
       <ObjectFileName>.\..\win32\tmp\Release_static\</ObjectFileName>
@@ -99,7 +99,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Debug_static\</AssemblerListingLocation>
       <BrowseInformation>true</BrowseInformation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Debug_static\expat_static.pch</PrecompiledHeaderOutputFile>

--- a/expat/lib/expatw.vcxproj
+++ b/expat/lib/expatw.vcxproj
@@ -71,7 +71,7 @@
       <Optimization>MaxSpeed</Optimization>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;XML_UNICODE_WCHAR_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;XML_UNICODE_WCHAR_T;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Release-w\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Release-w\expatw.pch</PrecompiledHeaderOutputFile>
       <PrecompiledHeader />
@@ -111,7 +111,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;XML_UNICODE_WCHAR_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;XML_UNICODE_WCHAR_T;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Debug-w\</AssemblerListingLocation>
       <BrowseInformation>true</BrowseInformation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Debug-w\expatw.pch</PrecompiledHeaderOutputFile>

--- a/expat/lib/expatw_static.vcxproj
+++ b/expat/lib/expatw_static.vcxproj
@@ -71,7 +71,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_LIB;XML_UNICODE_WCHAR_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_WINDOWS;_LIB;XML_UNICODE_WCHAR_T;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Debug-w_static\</AssemblerListingLocation>
       <BrowseInformation>true</BrowseInformation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Debug-w_static\expatw_static.pch</PrecompiledHeaderOutputFile>
@@ -101,7 +101,7 @@
       <Optimization>MaxSpeed</Optimization>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
-      <PreprocessorDefinitions>_WINDOWS;NDEBUG;_LIB;XML_UNICODE_WCHAR_T;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDOWS;NDEBUG;_LIB;XML_UNICODE_WCHAR_T;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Release-w_static\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Release-w_static\expatw_static.pch</PrecompiledHeaderOutputFile>
       <ObjectFileName>.\..\win32\tmp\Release-w_static\</ObjectFileName>

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -491,7 +491,6 @@ START_TEST(test_siphash_spec)
     const uint64_t expected = _SIP_ULL(0xa129ca61U, 0x49be45e5U);
     struct siphash state;
     struct sipkey key;
-    (void)sip_tobin;
 
     sip_tokey(&key,
             "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09"

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -58,6 +58,10 @@
 # endif
 #endif
 
+#if defined(_MSC_VER)
+   /* https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267 */
+#  pragma warning( disable : 4267)
+#endif
 
 #include "expat.h"
 #include "chardata.h"
@@ -5050,7 +5054,7 @@ external_entity_devaluer(XML_Parser parser,
         "<!ENTITY % e1 SYSTEM 'bar'>\n"
         "%e1;\n";
     XML_Parser ext_parser;
-    int clear_handler = (intptr_t)XML_GetUserData(parser);
+    intptr_t clear_handler = (intptr_t)XML_GetUserData(parser);
 
     if (systemId == NULL || !xcstrcmp(systemId, XCS("bar")))
         return XML_STATUS_OK;
@@ -7865,8 +7869,8 @@ END_TEST
 #define ALLOC_ALWAYS_SUCCEED (-1)
 #define REALLOC_ALWAYS_SUCCEED (-1)
 
-static int allocation_count = ALLOC_ALWAYS_SUCCEED;
-static int reallocation_count = REALLOC_ALWAYS_SUCCEED;
+static size_t allocation_count = ALLOC_ALWAYS_SUCCEED;
+static size_t reallocation_count = REALLOC_ALWAYS_SUCCEED;
 
 /* Crocked allocator for allocation failure tests */
 static void *duff_allocator(size_t size)

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -1127,7 +1127,7 @@ END_TEST
 #define STRUCT_END_TAG 1
 static void XMLCALL
 start_element_event_handler2(void *userData, const XML_Char *name,
-			     const XML_Char **UNUSED_P(attr))
+                const XML_Char **UNUSED_P(attr))
 {
     StructData *storage = (StructData *) userData;
     StructData_AddItem(storage, name,
@@ -7137,11 +7137,11 @@ START_TEST(test_return_ns_triplet)
         "       xmlns:bar='http://example.org/'>";
     const char *epilog = "</foo:e>";
     const XML_Char *elemstr[] = {
-        XCS("http://example.org/ e foo"),
-        XCS("http://example.org/ a bar")
+        (XML_Char *)XCS("http://example.org/ e foo"),
+        (XML_Char *)XCS("http://example.org/ a bar")
     };
     XML_SetReturnNSTriplet(parser, XML_TRUE);
-    XML_SetUserData(parser, elemstr);
+    XML_SetUserData(parser, (XML_Char **)elemstr);
     XML_SetElementHandler(parser, triplet_start_checker,
                           triplet_end_checker);
     XML_SetNamespaceDeclHandler(parser,
@@ -7392,8 +7392,8 @@ START_TEST(test_ns_prefix_with_empty_uri_4)
     /* Packaged info expected by the end element handler;
        the weird structuring lets us re-use the triplet_end_checker()
        function also used for another test. */
-    const XML_Char *elemstr[] = {
-        XCS("http://example.org/ doc prefix")
+    XML_Char *elemstr[] = {
+        (XML_Char *)XCS("http://example.org/ doc prefix")
     };
     XML_SetReturnNSTriplet(parser, XML_TRUE);
     XML_SetUserData(parser, elemstr);
@@ -7528,10 +7528,10 @@ START_TEST(test_ns_long_element)
         " xmlns:foo='http://example.org/' bar:a='12'\n"
         " xmlns:bar='http://example.org/'>"
         "</foo:thisisalongenoughelementnametotriggerareallocation>";
-    const XML_Char *elemstr[] = {
-        XCS("http://example.org/")
+    XML_Char *elemstr[] = {
+        (XML_Char *)XCS("http://example.org/")
         XCS(" thisisalongenoughelementnametotriggerareallocation foo"),
-        XCS("http://example.org/ a bar")
+        (XML_Char *)XCS("http://example.org/ a bar")
     };
 
     XML_SetReturnNSTriplet(parser, XML_TRUE);
@@ -10784,9 +10784,9 @@ START_TEST(test_nsalloc_long_attr_prefix)
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789AZ"
         "='http://example.org/'>"
         "</foo:e>";
-    const XML_Char *elemstr[] = {
-        XCS("http://example.org/ e foo"),
-        XCS("http://example.org/ a ")
+    XML_Char *elemstr[] = {
+        (XML_Char *)XCS("http://example.org/ e foo"),
+        (XML_Char *)XCS("http://example.org/ a ")
         XCS("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789AZ")
         XCS("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789AZ")
         XCS("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789AZ")
@@ -10862,10 +10862,10 @@ START_TEST(test_nsalloc_long_element)
         " xmlns:foo='http://example.org/' bar:a='12'\n"
         " xmlns:bar='http://example.org/'>"
         "</foo:thisisalongenoughelementnametotriggerareallocation>";
-    const XML_Char *elemstr[] = {
-        XCS("http://example.org/")
+    XML_Char *elemstr[] = {
+        (XML_Char *)XCS("http://example.org/")
         XCS(" thisisalongenoughelementnametotriggerareallocation foo"),
-        XCS("http://example.org/ a bar")
+        (XML_Char *)XCS("http://example.org/ a bar")
     };
     int i;
     const int max_alloc_count = 30;

--- a/expat/tests/structdata.c
+++ b/expat/tests/structdata.c
@@ -60,7 +60,7 @@
 static XML_Char *
 xmlstrdup(const XML_Char *s)
 {
-    int byte_count = (xcstrlen(s) + 1) * sizeof(XML_Char);
+    size_t byte_count = (xcstrlen(s) + 1) * sizeof(XML_Char);
     XML_Char *dup = malloc(byte_count);
 
     assert(dup != NULL);

--- a/expat/xmlwf/readfilemap.c
+++ b/expat/xmlwf/readfilemap.c
@@ -79,7 +79,7 @@ filemap(const tchar *name,
         void (*processor)(const void *, size_t, const tchar *, void *arg),
         void *arg)
 {
-  size_t nbytes;
+  unsigned int nbytes;
   int fd;
   _EXPAT_read_count_t n;
   struct stat sb;

--- a/expat/xmlwf/readfilemap.c
+++ b/expat/xmlwf/readfilemap.c
@@ -43,6 +43,7 @@
 
 /* Function "read": */
 #if defined(_MSC_VER)
+# include <io.h>
   /* https://msdn.microsoft.com/en-us/library/wyssk1bs(v=vs.100).aspx */
 # define _EXPAT_read          _read
 # define _EXPAT_read_count_t  int

--- a/expat/xmlwf/xmlwf.vcxproj
+++ b/expat/xmlwf/xmlwf.vcxproj
@@ -70,7 +70,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level3</WarningLevel>
       <AdditionalIncludeDirectories>..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Release-xmlwf\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Release-xmlwf\xmlwf.pch</PrecompiledHeaderOutputFile>
       <PrecompiledHeader />
@@ -107,7 +107,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\..\win32\tmp\Debug-xmlwf\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\..\win32\tmp\Debug-xmlwf\xmlwf.pch</PrecompiledHeaderOutputFile>
       <ObjectFileName>.\..\win32\tmp\Debug-xmlwf\</ObjectFileName>


### PR DESCRIPTION
- fixed few warning classes
- silenced some warnings related to size_t to int cast on 64bit build
- silenced warnings for unsecure string functions on legacy non-CMake VS projects
- enabled "Treat warnings as errors", to prevent appearing new warnings in future

Builds ok:
https://ci.appveyor.com/project/vanklompf/libexpat
https://travis-ci.org/vanklompf/libexpat