### PR TITLE
TravisCI: add out-of-source CMake build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -48,6 +48,13 @@ elif [[ ${MODE} = cmake ]]; then
     make all test
     make DESTDIR="${PWD}"/ROOT install
     ( cd ROOT/ && find | sort )
+elif [[ ${MODE} = cmake-oos ]]; then
+    mkdir build
+    cd build
+    cmake ..
+    make all test
+    make DESTDIR="${PWD}"/ROOT install
+    ( cd ROOT/ && find | sort )
 else
     ./qa.sh "${MODE}"
 fi

--- a/.travis.sh
+++ b/.travis.sh
@@ -47,14 +47,14 @@ elif [[ ${MODE} = cmake ]]; then
     cmake .
     make all test
     make DESTDIR="${PWD}"/ROOT install
-    ( cd ROOT/ && find | sort )
+    find ROOT -printf "%P\n" | sort
 elif [[ ${MODE} = cmake-oos ]]; then
     mkdir build
     cd build
     cmake ..
     make all test
     make DESTDIR="${PWD}"/ROOT install
-    ( cd ROOT/ && find | sort )
+    find ROOT -printf "%P\n" | sort
 else
     ./qa.sh "${MODE}"
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
     - MODE=address
     - MODE=cmake
+    - MODE=cmake-oos
     - MODE=distcheck
     - MODE=lib-coverage
 


### PR DESCRIPTION
That is the preferred way of building CMake software, so make sure this also works.