### PR TITLE
automake fixes

### DIFF
--- a/expat/lib/Makefile.am
+++ b/expat/lib/Makefile.am
@@ -37,8 +37,7 @@ lib_LTLIBRARIES = libexpat.la
 
 libexpat_la_LDFLAGS = \
     -no-undefined \
-    -version-info @LIBCURRENT@:@LIBREVISION@:@LIBAGE@ \
-    -rpath $(libdir)
+    -version-info @LIBCURRENT@:@LIBREVISION@:@LIBAGE@
 
 libexpat_la_SOURCES = \
     loadlibrary.c \

--- a/expat/lib/Makefile.am
+++ b/expat/lib/Makefile.am
@@ -45,16 +45,6 @@ libexpat_la_SOURCES = \
     xmltok.c \
     xmlrole.c
 
-doc_DATA = \
-    ../AUTHORS \
-    ../Changes
-
-install-data-hook:
-	cd "$(DESTDIR)$(docdir)" && $(am__mv) Changes changelog
-
-uninstall-local:
-	$(RM) "$(DESTDIR)$(docdir)/changelog"
-
 EXTRA_DIST = \
     ascii.h \
     asciitab.h \


### PR DESCRIPTION
- Using -rpath libtool option does not make any sense on linking libraries
- Installing AUTHORS and Changes files should not be done over automake as those files are not essential and should be installed or not depends on package managements rules