### PR TITLE
install-data-hook blows up on incremental builds

### DIFF
--- a/expat/lib/Makefile.am
+++ b/expat/lib/Makefile.am
@@ -50,7 +50,9 @@ doc_DATA = \
     ../Changes
 
 install-data-hook:
-	cd "$(DESTDIR)$(docdir)" && $(am__mv) Changes changelog
+	if test -e "$(DESTDIR)$(docdir)/Changes"; then \
+		cd "$(DESTDIR)$(docdir)" && $(am__mv) Changes changelog; \
+	fi
 
 uninstall-local:
 	$(RM) "$(DESTDIR)$(docdir)/changelog"


### PR DESCRIPTION
The hooks run even if the targets are up to date, and as such incremental builds may fail because the "Changes" file has already been moved into place.