### PR TITLE
Fix fallthrough related warnings

### DIFF
--- a/expat/lib/siphash.h
+++ b/expat/lib/siphash.h
@@ -238,12 +238,19 @@ static uint64_t sip24_final(struct siphash *H) {
 
 	switch (left) {
 	case 7: b |= (uint64_t)H->buf[6] << 48;
+        /* fall through */
 	case 6: b |= (uint64_t)H->buf[5] << 40;
+        /* fall through */
 	case 5: b |= (uint64_t)H->buf[4] << 32;
+        /* fall through */
 	case 4: b |= (uint64_t)H->buf[3] << 24;
+        /* fall through */
 	case 3: b |= (uint64_t)H->buf[2] << 16;
+        /* fall through */
 	case 2: b |= (uint64_t)H->buf[1] << 8;
+        /* fall through */
 	case 1: b |= (uint64_t)H->buf[0] << 0;
+        /* fall through */
 	case 0: break;
 	}
 

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1820,6 +1820,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal)
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       return XML_STATUS_ERROR;
     }
+    /* fall through */
   default:
     parser->m_parsingStatus.parsing = XML_PARSING;
   }
@@ -1969,6 +1970,7 @@ XML_ParseBuffer(XML_Parser parser, int len, int isFinal)
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       return XML_STATUS_ERROR;
     }
+    /* fall through */
   default:
     parser->m_parsingStatus.parsing = XML_PARSING;
   }
@@ -4746,8 +4748,8 @@ doProlog(XML_Parser parser,
           return XML_ERROR_NO_MEMORY;
         parser->m_declEntity->publicId = NULL;
       }
-      /* fall through */
 #endif /* XML_DTD */
+      /* fall through */
     case XML_ROLE_ENTITY_SYSTEM_ID:
       if (dtd->keepProcessing && parser->m_declEntity) {
         parser->m_declEntity->systemId = poolStoreString(&dtd->pool, enc,

--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -74,6 +74,7 @@
       *nextTokPtr = ptr; \
       return XML_TOK_INVALID; \
     } \
+    /* fall through */ \
   case BT_NMSTRT: \
   case BT_HEX: \
   case BT_DIGIT: \
@@ -102,6 +103,7 @@
       *nextTokPtr = ptr; \
       return XML_TOK_INVALID; \
     } \
+    /* fall through */ \
   case BT_NMSTRT: \
   case BT_HEX: \
     ptr += MINBPC(enc); \
@@ -602,7 +604,7 @@ PREFIX(scanAtts)(const ENCODING *enc, const char *ptr, const char *end,
           return XML_TOK_INVALID;
         }
       }
-    /* fall through */
+      /* fall through */
     case BT_EQUALS:
       {
         int open;
@@ -1442,6 +1444,7 @@ PREFIX(isPublicId)(const ENCODING *enc, const char *ptr, const char *end,
     case BT_NMSTRT:
       if (!(BYTE_TO_ASCII(enc, ptr) & ~0x7f))
         break;
+      /* fall through */
     default:
       switch (BYTE_TO_ASCII(enc, ptr)) {
       case 0x24: /* $ */


### PR DESCRIPTION
Some warnings appear in gcc 7+

-Wimplicit-fallthrough
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html