### PR TITLE
CMake: Use GNUInstallDirs for pkgconfig too

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -187,8 +187,8 @@ expat_install(TARGETS expat RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "\${prefix}")
-set(libdir "\${exec_prefix}/lib")
-set(includedir "\${prefix}/include")
+set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 configure_file(expat.pc.in ${CMAKE_CURRENT_BINARY_DIR}/expat.pc @ONLY)
 
 expat_install(FILES lib/expat.h lib/expat_external.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Fixes i.e. multilib setups on linux

Follow-up to 5681911965ef