### PR TITLE
fix test-driver-wrapper.sh calling non-executable test-driver script

### DIFF
--- a/expat/test-driver-wrapper.sh
+++ b/expat/test-driver-wrapper.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 #                          __  __            _
 #                       ___\ \/ /_ __   __ _| |_
 #                      / _ \\  /| '_ \ / _` | __|
@@ -40,4 +40,4 @@ while [[ ${1} != '--' ]]; do
 done
 shift  # drop "--"
 
-exec "${top_srcdir}"/conftools/test-driver "${test_driver_args[@]}" "${top_builddir}"/run.sh "$@"
+exec "$BASH" "${top_srcdir}"/conftools/test-driver "${test_driver_args[@]}" "${top_builddir}"/run.sh "$@"


### PR DESCRIPTION
With some versions of the GNU Autotools the script "conftools/test-driver"
is created without executable permissions.  The script "test-driver-wrapper.sh"
must run such script through a direct invocation of the shell (bash in this
case).