### PR TITLE
Assume memmove(3) exists.

### DIFF
--- a/expat/ConfigureChecks.cmake
+++ b/expat/ConfigureChecks.cmake
@@ -18,8 +18,6 @@ check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 
 check_symbol_exists("getpagesize" "unistd.h" HAVE_GETPAGESIZE)
-check_symbol_exists("bcopy" "strings.h" HAVE_BCOPY)
-check_symbol_exists("memmove" "string.h" HAVE_MEMMOVE)
 check_symbol_exists("mmap" "sys/mman.h" HAVE_MMAP)
 check_symbol_exists("getrandom" "sys/random.h" HAVE_GETRANDOM)
 

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -99,8 +99,6 @@ AC_C_BIGENDIAN_CROSS
 
 AC_C_CONST
 AC_TYPE_SIZE_T
-AC_CHECK_FUNCS(memmove bcopy)
-
 
 AC_ARG_WITH([xmlwf], [
 AS_HELP_STRING([--without-xmlwf], [do not build xmlwf])], [], [with_xmlwf=yes])

--- a/expat/expat_config.h.cmake
+++ b/expat/expat_config.h.cmake
@@ -9,9 +9,6 @@
 /* Define to 1 if you have the `arc4random_buf' function. */
 #cmakedefine HAVE_ARC4RANDOM_BUF
 
-/* Define to 1 if you have the `bcopy' function. */
-#cmakedefine HAVE_BCOPY
-
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #cmakedefine HAVE_DLFCN_H
 
@@ -29,9 +26,6 @@
 
 /* Define to 1 if you have the `bsd' library (-lbsd). */
 #cmakedefine HAVE_LIBBSD
-
-/* Define to 1 if you have the `memmove' function. */
-#cmakedefine HAVE_MEMMOVE
 
 /* Define to 1 if you have the <memory.h> header file. */
 #cmakedefine HAVE_MEMORY_H

--- a/expat/lib/winconfig.h
+++ b/expat/lib/winconfig.h
@@ -53,10 +53,6 @@
 /* we will assume all Windows platforms are little endian */
 #define BYTEORDER 1234
 
-/* Windows has memmove() available. */
-#define HAVE_MEMMOVE
-
-
 #endif /* !defined(HAVE_EXPAT_CONFIG_H) */
 
 

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -164,15 +164,6 @@ typedef char ICHAR;
 /* Do safe (NULL-aware) pointer arithmetic */
 #define EXPAT_SAFE_PTR_DIFF(p, q) (((p) && (q)) ? ((p) - (q)) : 0)
 
-/* Handle the case where memmove() doesn't exist. */
-#ifndef HAVE_MEMMOVE
-#ifdef HAVE_BCOPY
-#define memmove(d,s,l) bcopy((s),(d),(l))
-#else
-#error memmove does not exist on this platform, nor is a substitute available
-#endif /* HAVE_BCOPY */
-#endif /* HAVE_MEMMOVE */
-
 #include "internal.h"
 #include "xmltok.h"
 #include "xmlrole.h"


### PR DESCRIPTION
memmove is specified since POSIX.1-2001 and C89, and bcopy is deprecated.