### PR TITLE
[W.I.P.] Limit entity expansion to prevent DoS attacks

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -9,10 +9,10 @@ Release x.x.x XXX XXXXXX XX XXXX
                     DTD hash table entries to mitigate DoS attacks like
                     billion laughs and quadratic blowup. Countermeasures
                     are enabled by default and can be tuned with
-                    XML_SetOption().
+                    XML_SetOption.
 
         New features:
-            #220  Add XML_SetOption(), XML_GetOption() and enum XML_Options
+            #220  Add XML_SetOption, XML_GetOption and enum XML_Options
                     to modify DoS mitigations.
             #220  xmlwf: Add argument -H to enable huge entities.
 

--- a/expat/Changes
+++ b/expat/Changes
@@ -3,6 +3,19 @@ NOTE: We are looking for help with a few things:
       If you can help, please get in touch.  Thanks!
 
 Release x.x.x XXX XXXXXX XX XXXX
+        Security fixes:
+            #220  CVE-2013-0340 -- Limit entity expansion nesting, size,
+                    and ratio in relation to processed bytes as well as
+                    DTD hash table entries to mitigate DoS attacks like
+                    billion laughs and quadratic blowup. Countermeasures
+                    are enabled by default and can be tuned with
+                    XML_SetOption().
+
+        New features:
+            #220  Add XML_SetOption(), XML_GetOption() and enum XML_Options
+                    to modify DoS mitigations.
+            #220  xmlwf: Add argument -H to enable huge entities.
+
         Other changes:
        #195 #197  Autotools/CMake: Utilize -fvisibility=hidden to stop
                     exporting non-API symbols
@@ -13,6 +26,7 @@ Release x.x.x XXX XXXXXX XX XXXX
             Benjamin Peterson
             @userwithuid
             Yury Gribov
+            Christian Heimes
 
 Release 2.2.6 Sun August 12 2018
         Bug fixes:

--- a/expat/doc/xmlwf.xml
+++ b/expat/doc/xmlwf.xml
@@ -48,6 +48,7 @@
 	  <arg><option>-n</option></arg>
 	  <arg><option>-p</option></arg>
 	  <arg><option>-x</option></arg>
+	  <arg><option>-H</option></arg>
 
 	  <arg><option>-e <replaceable>encoding</replaceable></option></arg>
 	  <arg><option>-w</option></arg>
@@ -195,6 +196,16 @@ supports both.
 	<literal>UTF-16</literal>, and
 	<literal>ISO-8859-1</literal>.
    Also see the <option>-w</option> option.
+	   </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-H</option></term>
+        <listitem>
+		<para>
+  Enables huge entities option, disabling all mitigations against entity
+  expansion attacks.
 	   </para>
         </listitem>
       </varlistentry>

--- a/expat/doc/xmlwf.xml
+++ b/expat/doc/xmlwf.xml
@@ -204,8 +204,8 @@ supports both.
         <term><option>-H</option></term>
         <listitem>
 		<para>
-  Enables huge entities option, disabling all mitigations against entity
-  expansion attacks.
+  Enables huge XML option, disabling all mitigations against denial
+  of service attacks like billion laughs entity expansion.
 	   </para>
         </listitem>
       </varlistentry>

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -134,7 +134,7 @@ enum XML_Error {
 
 enum XML_Option {
   /* Added in 2.3.0 */
-  XML_OPTION_HUGE_ENTITIES = 1 /* XML_Bool, no limits for entity expansion */
+  XML_OPTION_HUGE_XML = 1 /* XML_Bool, no limits for huge XML (e.g. entity expansion) */
 };
 
 /* Entity expansion protection
@@ -152,8 +152,8 @@ enum XML_Option {
  * https://github.com/GNOME/libxml2/blob/v2.9.8/parser.c#L99
  * https://github.com/GNOME/libxml2/blob/v2.9.8/include/libxml/parserInternals.h#L33
  */
-#ifndef XML_HUGE_ENTITIES_DEFAULT
-#define XML_HUGE_ENTITIES_DEFAULT 0
+#ifndef XML_HUGE_XML_DEFAULT
+#define XML_HUGE_XML_DEFAULT 0
 #endif
 
 #ifndef XML_ENTITY_NESTING_LIMIT
@@ -161,7 +161,8 @@ enum XML_Option {
 #endif
 
 #ifndef XML_ENTITY_EXPANSION_SIZE
-#define XML_ENTITY_EXPANSION_SIZE 10000
+/* 1MB text */
+#define XML_ENTITY_EXPANSION_SIZE 1000000
 #endif
 
 #ifndef XML_ENTITY_EXPANSION_RATIO
@@ -1110,7 +1111,7 @@ enum XML_FeatureEnum {
   XML_FEATURE_LARGE_SIZE,
   XML_FEATURE_ATTR_INFO,
   /* Added in 2.3.0 */
-  XML_FEATURE_HUGE_ENTITIES
+  XML_FEATURE_HUGE_XML
   /* Additional features must be added to the end of this enum. */
 };
 

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -134,7 +134,10 @@ enum XML_Error {
 
 enum XML_Option {
   /* Added in 2.3.0 */
-  XML_OPTION_HUGE_XML = 1 /* XML_Bool, no limits for huge XML (e.g. entity expansion) */
+  XML_OPTION_HUGE_XML = 1, /* XML_Bool, no limits for huge XML (e.g. entity expansion) */
+  XML_OPTION_NESTING_LIMIT, /* int, limit entity nesting depth */
+  XML_OPTION_EXPANSION_RATIO, /* int, ratio between expansions and processed text */
+  XML_OPTION_MAX_EXPANSION_SIZE /* XML_Size, limit max entity size for single and nested entities */
 };
 
 /* Entity expansion protection

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -129,7 +129,8 @@ enum XML_Error {
   XML_ERROR_ENTITY_VIOLATION_SIZE,
   XML_ERROR_ENTITY_VIOLATION_NESTED_SIZE,
   XML_ERROR_ENTITY_VIOLATION_RATIO,
-  XML_ERROR_ENTITY_VIOLATION_DEPTH
+  XML_ERROR_ENTITY_VIOLATION_DEPTH,
+  XML_ERROR_HASH_TABLE_VIOLATION
 };
 
 enum XML_Option {
@@ -137,7 +138,8 @@ enum XML_Option {
   XML_OPTION_HUGE_XML = 1, /* XML_Bool, no limits for huge XML (e.g. entity expansion) */
   XML_OPTION_NESTING_LIMIT, /* int, limit entity nesting depth */
   XML_OPTION_EXPANSION_RATIO, /* int, ratio between expansions and processed text */
-  XML_OPTION_MAX_EXPANSION_SIZE /* XML_Size, limit max entity size for single and nested entities */
+  XML_OPTION_MAX_EXPANSION_SIZE, /* XML_Size, limit max entity size for single and nested entities */
+  XML_OPTION_MAX_HASH_TABLE_ENTRIES /* XML_Size, max entries in DTD hash tables */
 };
 
 /* Entity expansion protection
@@ -150,6 +152,8 @@ enum XML_Option {
  * XML_ENTITY_EXPANSION_RATIO constrains the ratio between position in XML
  *  document and total amount of all expanded entities once more than
  *  XML_ENTITY_EXPANSION_SIZE bytes have been expanded.
+ * XML_MAX_HASH_TABLE_ENTRIES limits total amount of entries across all
+ *   DTD hash tables.
  *
  * The limits are modelled after libxml2's limits
  * https://github.com/GNOME/libxml2/blob/v2.9.8/parser.c#L99
@@ -171,6 +175,12 @@ enum XML_Option {
 #ifndef XML_ENTITY_EXPANSION_RATIO
 #define XML_ENTITY_EXPANSION_RATIO 10
 #endif
+
+#ifndef XML_MAX_HASH_TABLE_ENTRIES
+/* 1M entries across all hash tables */
+#define XML_MAX_HASH_TABLE_ENTRIES 1000000
+#endif
+
 
 enum XML_Content_Type {
   XML_CTYPE_EMPTY = 1,

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -126,32 +126,44 @@ enum XML_Error {
   /* Added in 2.2.1. */
   XML_ERROR_INVALID_ARGUMENT,
   /* Added in 2.3.0 */
-  XML_ERROR_ENTITY_VIOLATION_SIZE,
-  XML_ERROR_ENTITY_VIOLATION_NESTED_SIZE,
-  XML_ERROR_ENTITY_VIOLATION_RATIO,
-  XML_ERROR_ENTITY_VIOLATION_DEPTH,
-  XML_ERROR_HASH_TABLE_VIOLATION
+  XML_ERROR_ENTITY_SIZE_VIOLATION,
+  XML_ERROR_ENTITY_NESTED_SIZE_VIOLATION,
+  XML_ERROR_ENTITY_EXPANSION_RATIO_VIOLATION,
+  XML_ERROR_ENTITY_NESTING_VIOLATION,
+  XML_ERROR_HASH_TABLE_SIZE_VIOLATION
 };
+
+/*
+ * HUGE_XML: enable huge XML processing and disable all parsing limits
+ * ENTITIES_MAX_NESTED_REFS: restrict nested entity expansions of an entity
+ *   reference.
+ * ENTITIES_MAX_RATIO: restrict ratio between expanded entities and processed
+ *  XML bytes.
+ * ENTITIES_MAX_RATIO_THRESHOLD: start treshold for ratio
+ * ENTITIES_MAX_SIZE: limit max entity size in bytes for single and nested entities
+ * HASH_TABLE_DTD_MAX_ENTRY_COUNT: max entries in DTD hash tables
+ */
 
 enum XML_Option {
   /* Added in 2.3.0 */
-  XML_OPTION_HUGE_XML = 1, /* XML_Bool, no limits for huge XML (e.g. entity expansion) */
-  XML_OPTION_NESTING_LIMIT, /* int, limit entity nesting depth */
-  XML_OPTION_EXPANSION_RATIO, /* int, ratio between expansions and processed text */
-  XML_OPTION_MAX_EXPANSION_SIZE, /* XML_Size, limit max entity size for single and nested entities */
-  XML_OPTION_MAX_HASH_TABLE_ENTRIES /* XML_Size, max entries in DTD hash tables */
+  XML_OPTION_HUGE_XML, /* XML_Bool */
+  XML_OPTION_ENTITIES_MAX_NESTED_REFS, /* unsigned int */
+  XML_OPTION_ENTITIES_MAX_RATIO, /* unsigned int */
+  XML_OPTION_ENTITIES_MAX_RATIO_THRESHOLD, /* unsigned int */
+  XML_OPTION_ENTITIES_MAX_SIZE, /* size_t,  */
+  XML_OPTION_HASH_TABLE_DTD_MAX_ENTRY_COUNT /* size_t */
 };
 
 /* Entity expansion protection
  *
  * Mitigation against billion laugh and quadratic blowup attacks.
  *
- * XML_ENTITY_NESTING_LIMIT confines nesting of entities within entities.
+ * XML_ENTITY_NESTED_REFERENCE_LIMIT confines nesting of entities within entities.
  * XML_ENTITY_EXPANSION_SIZE restricts the maximum length of entities,
  *   both text of a single entity and resulting text of nested entities.
  * XML_ENTITY_EXPANSION_RATIO constrains the ratio between position in XML
  *  document and total amount of all expanded entities once more than
- *  XML_ENTITY_EXPANSION_SIZE bytes have been expanded.
+ *  XML_ENTITY_EXPANSION_RATIO_THRESHOLD bytes have been expanded.
  * XML_MAX_HASH_TABLE_ENTRIES limits total amount of entries across all
  *   DTD hash tables.
  *
@@ -163,8 +175,8 @@ enum XML_Option {
 #define XML_HUGE_XML_DEFAULT 0
 #endif
 
-#ifndef XML_ENTITY_NESTING_LIMIT
-#define XML_ENTITY_NESTING_LIMIT 40
+#ifndef XML_ENTITY_NESTED_REFERENCE_LIMIT
+#define XML_ENTITY_NESTED_REFERENCE_LIMIT 40
 #endif
 
 #ifndef XML_ENTITY_EXPANSION_SIZE
@@ -174,6 +186,11 @@ enum XML_Option {
 
 #ifndef XML_ENTITY_EXPANSION_RATIO
 #define XML_ENTITY_EXPANSION_RATIO 10
+#endif
+
+#ifndef XML_ENTITY_EXPANSION_RATIO_THRESHOLD
+/* 1MB text */
+#define XML_ENTITY_EXPANSION_RATIO_THRESHOLD 1000000
 #endif
 
 #ifndef XML_MAX_HASH_TABLE_ENTRIES

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -127,6 +127,7 @@ enum XML_Error {
   XML_ERROR_INVALID_ARGUMENT,
   /* Added in 2.3.0 */
   XML_ERROR_ENTITY_VIOLATION_SIZE,
+  XML_ERROR_ENTITY_VIOLATION_NESTED_SIZE,
   XML_ERROR_ENTITY_VIOLATION_RATIO,
   XML_ERROR_ENTITY_VIOLATION_DEPTH
 };
@@ -141,29 +142,31 @@ enum XML_Option {
  * Mitigation against billion laugh and quadratic blowup attacks.
  *
  * XML_ENTITY_NESTING_LIMIT confines nesting of entities within entities.
- * XML_ENTITY_EXPANSION_SIZE restricts the maximum length of entities.
+ * XML_ENTITY_EXPANSION_SIZE restricts the maximum length of entities,
+ *   both text of a single entity and resulting text of nested entities.
  * XML_ENTITY_EXPANSION_RATIO constrains the ratio between position in XML
- * document and total amount of all expanded entities.
+ *  document and total amount of all expanded entities once more than
+ *  XML_ENTITY_EXPANSION_SIZE bytes have been expanded.
  *
  * The limits are modelled after libxml2's limits
  * https://github.com/GNOME/libxml2/blob/v2.9.8/parser.c#L99
+ * https://github.com/GNOME/libxml2/blob/v2.9.8/include/libxml/parserInternals.h#L33
  */
 #ifndef XML_HUGE_ENTITIES_DEFAULT
 #define XML_HUGE_ENTITIES_DEFAULT 0
 #endif
 
 #ifndef XML_ENTITY_NESTING_LIMIT
-#define XML_ENTITY_NESTING_LIMIT 3
+#define XML_ENTITY_NESTING_LIMIT 40
 #endif
 
 #ifndef XML_ENTITY_EXPANSION_SIZE
-#define XML_ENTITY_EXPANSION_SIZE 1023
+#define XML_ENTITY_EXPANSION_SIZE 10000
 #endif
 
 #ifndef XML_ENTITY_EXPANSION_RATIO
 #define XML_ENTITY_EXPANSION_RATIO 10
 #endif
-
 
 enum XML_Content_Type {
   XML_CTYPE_EMPTY = 1,

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -131,10 +131,9 @@ enum XML_Error {
   XML_ERROR_ENTITY_VIOLATION_DEPTH
 };
 
-enum XML_Options {
+enum XML_Option {
   /* Added in 2.3.0 */
-  XML_OPTION_NONE = 0,
-  XML_OPTION_HUGE_ENTITIES = 1<<0 /* No limits for entity expansion */
+  XML_OPTION_HUGE_ENTITIES = 1 /* XML_Bool, no limits for entity expansion */
 };
 
 /* Entity expansion protection
@@ -991,11 +990,11 @@ XML_SetHashSalt(XML_Parser parser,
  *
  * Added in 2.3.0
  */
-XMLPARSEAPI(int)
-XML_SetOptions(XML_Parser parser, int options);
+XMLPARSEAPI(enum XML_Status)
+XML_SetOption(XML_Parser parser, enum XML_Option option, void *value);
 
-XMLPARSEAPI(int)
-XML_GetOptions(XML_Parser parser);
+XMLPARSEAPI(enum XML_Status)
+XML_GetOption(XML_Parser parser, enum XML_Option option, void *rvalue);
 
 /* If XML_Parse or XML_ParseBuffer have returned XML_STATUS_ERROR, then
    XML_GetErrorCode returns information about the error.
@@ -1107,6 +1106,7 @@ enum XML_FeatureEnum {
   XML_FEATURE_NS,
   XML_FEATURE_LARGE_SIZE,
   XML_FEATURE_ATTR_INFO,
+  /* Added in 2.3.0 */
   XML_FEATURE_HUGE_ENTITIES
   /* Additional features must be added to the end of this enum. */
 };

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -124,8 +124,47 @@ enum XML_Error {
   XML_ERROR_RESERVED_PREFIX_XMLNS,
   XML_ERROR_RESERVED_NAMESPACE_URI,
   /* Added in 2.2.1. */
-  XML_ERROR_INVALID_ARGUMENT
+  XML_ERROR_INVALID_ARGUMENT,
+  /* Added in 2.3.0 */
+  XML_ERROR_ENTITY_VIOLATION_SIZE,
+  XML_ERROR_ENTITY_VIOLATION_RATIO,
+  XML_ERROR_ENTITY_VIOLATION_DEPTH
 };
+
+enum XML_Options {
+  /* Added in 2.3.0 */
+  XML_OPTION_NONE = 0,
+  XML_OPTION_HUGE_ENTITIES = 1<<0 /* No limits for entity expansion */
+};
+
+/* Entity expansion protection
+ *
+ * Mitigation against billion laugh and quadratic blowup attacks.
+ *
+ * XML_ENTITY_NESTING_LIMIT confines nesting of entities within entities.
+ * XML_ENTITY_EXPANSION_SIZE restricts the maximum length of entities.
+ * XML_ENTITY_EXPANSION_RATIO constrains the ratio between position in XML
+ * document and total amount of all expanded entities.
+ *
+ * The limits are modelled after libxml2's limits
+ * https://github.com/GNOME/libxml2/blob/v2.9.8/parser.c#L99
+ */
+#ifndef XML_HUGE_ENTITIES_DEFAULT
+#define XML_HUGE_ENTITIES_DEFAULT 0
+#endif
+
+#ifndef XML_ENTITY_NESTING_LIMIT
+#define XML_ENTITY_NESTING_LIMIT 3
+#endif
+
+#ifndef XML_ENTITY_EXPANSION_SIZE
+#define XML_ENTITY_EXPANSION_SIZE 1023
+#endif
+
+#ifndef XML_ENTITY_EXPANSION_RATIO
+#define XML_ENTITY_EXPANSION_RATIO 10
+#endif
+
 
 enum XML_Content_Type {
   XML_CTYPE_EMPTY = 1,
@@ -948,6 +987,16 @@ XMLPARSEAPI(int)
 XML_SetHashSalt(XML_Parser parser,
                 unsigned long hash_salt);
 
+/* Set / get XML parser options, see enum XML_Options
+ *
+ * Added in 2.3.0
+ */
+XMLPARSEAPI(int)
+XML_SetOptions(XML_Parser parser, int options);
+
+XMLPARSEAPI(int)
+XML_GetOptions(XML_Parser parser);
+
 /* If XML_Parse or XML_ParseBuffer have returned XML_STATUS_ERROR, then
    XML_GetErrorCode returns information about the error.
 */
@@ -1057,7 +1106,8 @@ enum XML_FeatureEnum {
   XML_FEATURE_SIZEOF_XML_LCHAR,
   XML_FEATURE_NS,
   XML_FEATURE_LARGE_SIZE,
-  XML_FEATURE_ATTR_INFO
+  XML_FEATURE_ATTR_INFO,
+  XML_FEATURE_HUGE_ENTITIES
   /* Additional features must be added to the end of this enum. */
 };
 

--- a/expat/lib/libexpat.def
+++ b/expat/lib/libexpat.def
@@ -76,3 +76,6 @@ EXPORTS
   XML_SetHashSalt @67@
 ; added with version 2.2.5
   _INTERNAL_trim_to_complete_utf8_characters @68@
+; added with version 2.3.0
+  XML_GetOption @69@
+  XML_SetOption @70@

--- a/expat/lib/libexpatw.def
+++ b/expat/lib/libexpatw.def
@@ -77,5 +77,5 @@ EXPORTS
 ; added with version 2.2.5
   _INTERNAL_trim_to_complete_utf8_characters @68@
 ; added with version 2.3.0
-  XML_GetOptions @69@
-  XML_SetOptions @70@
+  XML_GetOption @69@
+  XML_SetOption @70@

--- a/expat/lib/libexpatw.def
+++ b/expat/lib/libexpatw.def
@@ -76,3 +76,6 @@ EXPORTS
   XML_SetHashSalt @67@
 ; added with version 2.2.5
   _INTERNAL_trim_to_complete_utf8_characters @68@
+; added with version 2.3.0
+  XML_GetOptions @69@
+  XML_SetOptions @70@

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -371,6 +371,13 @@ typedef struct open_internal_entity {
   XML_Bool betweenDecl; /* WFC: PE Between Declarations */
 } OPEN_INTERNAL_ENTITY;
 
+typedef struct {
+  ENTITY *first_entity;
+  int entityNestingLevel;
+  XML_Size nestedEntityExpansionSize;
+  XML_Size totalEntityExpansionSize;
+} LIMIT;
+
 typedef enum XML_Error PTRCALL Processor(XML_Parser parser,
                                          const char *start,
                                          const char *end,
@@ -463,6 +470,12 @@ setContext(XML_Parser parser, const XML_Char *context);
 
 static void FASTCALL normalizePublicId(XML_Char *s);
 
+static LIMIT * limitCreate(const XML_Memory_Handling_Suite *ms);
+/* do not call if m_parentParser != NULL */
+static void limitDestroy(LIMIT *limit, const XML_Memory_Handling_Suite *ms);
+static enum XML_Error limitPreContent(XML_Parser parser, ENTITY *entity);
+static enum XML_Error limitPostContent(XML_Parser parser, ENTITY *entity);
+
 static DTD * dtdCreate(const XML_Memory_Handling_Suite *ms);
 /* do not call if m_parentParser != NULL */
 static void dtdReset(DTD *p, const XML_Memory_Handling_Suite *ms);
@@ -518,7 +531,8 @@ static XML_Parser
 parserCreate(const XML_Char *encodingName,
              const XML_Memory_Handling_Suite *memsuite,
              const XML_Char *nameSep,
-             DTD *dtd);
+             DTD *dtd,
+             LIMIT *limit);
 
 static void
 parserInit(XML_Parser parser, const XML_Char *encodingName);
@@ -595,9 +609,6 @@ struct XML_ParserStruct {
   OPEN_INTERNAL_ENTITY *m_freeInternalEntities;
   XML_Bool m_defaultExpandInternalEntities;
   XML_Bool m_hugeEntities;
-  int m_entityNestingLevel;
-  int m_entityRecursionLevel;
-  XML_Size m_entityExpansionLen;
   int m_tagLevel;
   ENTITY *m_declEntity;
   const XML_Char *m_doctypeName;
@@ -640,6 +651,7 @@ struct XML_ParserStruct {
   enum XML_ParamEntityParsing m_paramEntityParsing;
 #endif
   unsigned long m_hash_secret_salt;
+  LIMIT *m_limit;
 };
 
 #define MALLOC(parser, s)      (parser->m_mem.malloc_fcn((s)))
@@ -908,14 +920,15 @@ XML_ParserCreate_MM(const XML_Char *encodingName,
                     const XML_Memory_Handling_Suite *memsuite,
                     const XML_Char *nameSep)
 {
-  return parserCreate(encodingName, memsuite, nameSep, NULL);
+  return parserCreate(encodingName, memsuite, nameSep, NULL, NULL);
 }
 
 static XML_Parser
 parserCreate(const XML_Char *encodingName,
              const XML_Memory_Handling_Suite *memsuite,
              const XML_Char *nameSep,
-             DTD *dtd)
+             DTD *dtd,
+             LIMIT *limit)
 {
   XML_Parser parser;
 
@@ -972,6 +985,21 @@ parserCreate(const XML_Char *encodingName,
   }
   parser->m_dataBufEnd = parser->m_dataBuf + INIT_DATA_BUF_SIZE;
 
+  if (limit) {
+    parser->m_limit = limit;
+  } else {
+      parser->m_limit = limitCreate(&parser->m_mem);
+      if (parser->m_limit == NULL) {
+          FREE(parser, parser->m_dataBuf);
+          FREE(parser, parser->m_atts);
+#ifdef XML_ATTR_INFO
+          FREE(parser, parser->m_attInfo);
+#endif
+          FREE(parser, parser);
+          return NULL;
+      }
+  }
+
   if (dtd)
     parser->m_dtd = dtd;
   else {
@@ -982,6 +1010,8 @@ parserCreate(const XML_Char *encodingName,
 #ifdef XML_ATTR_INFO
       FREE(parser, parser->m_attInfo);
 #endif
+      if (!limit)
+        limitDestroy(parser->m_limit, &parser->m_mem);
       FREE(parser, parser);
       return NULL;
     }
@@ -1084,8 +1114,6 @@ parserInit(XML_Parser parser, const XML_Char *encodingName)
   parser->m_positionPtr = NULL;
   parser->m_openInternalEntities = NULL;
   parser->m_defaultExpandInternalEntities = XML_TRUE;
-  parser->m_entityNestingLevel = 0;
-  parser->m_entityExpansionLen = 0;
   parser->m_hugeEntities = XML_HUGE_ENTITIES_DEFAULT ? XML_TRUE : XML_FALSE;
   parser->m_tagLevel = 0;
   parser->m_tagStack = NULL;
@@ -1193,6 +1221,7 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser,
   XML_Parser parser = oldParser;
   DTD *newDtd = NULL;
   DTD *oldDtd;
+  LIMIT *oldLimit;
   XML_StartElementHandler oldStartElementHandler;
   XML_EndElementHandler oldEndElementHandler;
   XML_CharacterDataHandler oldCharacterDataHandler;
@@ -1214,8 +1243,6 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser,
   XML_EntityDeclHandler oldEntityDeclHandler;
   XML_XmlDeclHandler oldXmlDeclHandler;
   ELEMENT_TYPE * oldDeclElementType;
-  int oldEntityNestingLevel;
-  XML_Size oldEntityExpansionLen;
   XML_Bool oldHugeEntities;
 
   void *oldUserData;
@@ -1240,6 +1267,7 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser,
 
   /* Stash the original parser contents on the stack */
   oldDtd = parser->m_dtd;
+  oldLimit = parser->m_limit;
   oldStartElementHandler = parser->m_startElementHandler;
   oldEndElementHandler = parser->m_endElementHandler;
   oldCharacterDataHandler = parser->m_characterDataHandler;
@@ -1278,8 +1306,6 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser,
   */
   oldhash_secret_salt = parser->m_hash_secret_salt;
 
-  oldEntityNestingLevel = parser->m_entityNestingLevel;
-  oldEntityExpansionLen = parser->m_entityExpansionLen;
   oldHugeEntities = parser->m_hugeEntities;
 
 #ifdef XML_DTD
@@ -1295,10 +1321,10 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser,
   if (parser->m_ns) {
     XML_Char tmp[2];
     *tmp = parser->m_namespaceSeparator;
-    parser = parserCreate(encodingName, &parser->m_mem, tmp, newDtd);
+    parser = parserCreate(encodingName, &parser->m_mem, tmp, newDtd, oldLimit);
   }
   else {
-    parser = parserCreate(encodingName, &parser->m_mem, NULL, newDtd);
+    parser = parserCreate(encodingName, &parser->m_mem, NULL, newDtd, oldLimit);
   }
 
   if (!parser)
@@ -1335,8 +1361,6 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser,
   parser->m_defaultExpandInternalEntities = oldDefaultExpandInternalEntities;
   parser->m_ns_triplets = oldns_triplets;
   parser->m_hash_secret_salt = oldhash_secret_salt;
-  parser->m_entityNestingLevel = oldEntityNestingLevel;
-  parser->m_entityExpansionLen = oldEntityExpansionLen;
   parser->m_hugeEntities = oldHugeEntities;
   parser->m_parentParser = oldParser;
 #ifdef XML_DTD
@@ -1428,11 +1452,15 @@ XML_ParserFree(XML_Parser parser)
   /* external parameter entity parsers share the DTD structure
      parser->m_dtd with the root parser, so we must not destroy it
   */
-  if (!parser->m_isParamEntity && parser->m_dtd)
+  if (!parser->m_isParamEntity && parser->m_dtd) {
 #else
-  if (parser->m_dtd)
+  if (parser->m_dtd) {
 #endif /* XML_DTD */
     dtdDestroy(parser->m_dtd, (XML_Bool)!parser->m_parentParser, &parser->m_mem);
+  }
+  /* LIMIT structure parser-m_limit is shared with all external parsers */
+  if (!parser->m_parentParser)
+      limitDestroy(parser->m_limit, &parser->m_mem);
   FREE(parser, (void *)parser->m_atts);
 #ifdef XML_ATTR_INFO
   FREE(parser, (void *)parser->m_attInfo);
@@ -2463,11 +2491,13 @@ XML_ErrorString(enum XML_Error code)
     return XML_L("invalid argument");
   /* Added in 2.3.0 */
   case XML_ERROR_ENTITY_VIOLATION_SIZE:
-    return XML_L("entity is too large");
+    return XML_L("entity text is too large");
+  case XML_ERROR_ENTITY_VIOLATION_NESTED_SIZE:
+    return XML_L("nested entity text is too large");
   case XML_ERROR_ENTITY_VIOLATION_RATIO:
     return XML_L("entity expansion limit reached");
   case XML_ERROR_ENTITY_VIOLATION_DEPTH:
-    return XML_L("entity recursion limit reached");
+    return XML_L("entity nesting limit reached");
   }
   return NULL;
 }
@@ -2807,6 +2837,7 @@ doContent(XML_Parser parser,
       {
         const XML_Char *name;
         ENTITY *entity;
+        enum XML_Error result;
         XML_Char ch = (XML_Char) XmlPredefinedEntityName(enc,
                                               s + enc->minBytesPerChar,
                                               next - enc->minBytesPerChar);
@@ -2845,8 +2876,10 @@ doContent(XML_Parser parser,
           return XML_ERROR_RECURSIVE_ENTITY_REF;
         if (entity->notation)
           return XML_ERROR_BINARY_ENTITY_REF;
+        result = limitPreContent(parser, entity);
+        if (result != XML_ERROR_NONE)
+            return result;
         if (entity->textPtr) {
-          enum XML_Error result;
           if (!parser->m_defaultExpandInternalEntities) {
             if (parser->m_skippedEntityHandler)
               parser->m_skippedEntityHandler(parser->m_handlerArg, entity->name, 0);
@@ -2857,21 +2890,31 @@ doContent(XML_Parser parser,
           result = processInternalEntity(parser, entity, XML_FALSE);
           if (result != XML_ERROR_NONE)
             return result;
+          result = limitPostContent(parser, entity);
+          if (result != XML_ERROR_NONE)
+            return result;
         }
         else if (parser->m_externalEntityRefHandler) {
           const XML_Char *context;
           entity->open = XML_TRUE;
           context = getContext(parser);
           entity->open = XML_FALSE;
-          if (!context)
+          if (!context) {
+            limitPostContent(parser, entity);
             return XML_ERROR_NO_MEMORY;
+          }
           if (!parser->m_externalEntityRefHandler(parser->m_externalEntityRefHandlerArg,
                                         context,
                                         entity->base,
                                         entity->systemId,
-                                        entity->publicId))
+                                        entity->publicId)) {
+            limitPostContent(parser, entity);
             return XML_ERROR_EXTERNAL_ENTITY_HANDLING;
+          }
           poolDiscard(&parser->m_tempPool);
+          result = limitPostContent(parser, entity);
+          if (result != XML_ERROR_NONE)
+            return result;
         }
         else if (parser->m_defaultHandler)
           reportDefault(parser, enc, s, next);
@@ -5443,13 +5486,6 @@ processInternalEntity(XML_Parser parser, ENTITY *entity,
   enum XML_Error result;
   OPEN_INTERNAL_ENTITY *openEntity;
 
-  if (!parser->m_hugeEntities) {
-      parser->m_entityNestingLevel++;
-      if (parser->m_entityNestingLevel > XML_ENTITY_NESTING_LIMIT) {
-        return XML_ERROR_ENTITY_VIOLATION_DEPTH;
-      }
-   }
-
   if (parser->m_freeInternalEntities) {
     openEntity = parser->m_freeInternalEntities;
     parser->m_freeInternalEntities = openEntity->next;
@@ -5459,6 +5495,10 @@ processInternalEntity(XML_Parser parser, ENTITY *entity,
     if (!openEntity)
       return XML_ERROR_NO_MEMORY;
   }
+  if (parser->m_limit->first_entity == NULL) {
+    parser->m_limit->first_entity = entity;
+  }
+
   entity->open = XML_TRUE;
   entity->processed = 0;
   openEntity->next = parser->m_openInternalEntities;
@@ -5495,28 +5535,6 @@ processInternalEntity(XML_Parser parser, ENTITY *entity,
       /* put openEntity back in list of free instances */
       openEntity->next = parser->m_freeInternalEntities;
       parser->m_freeInternalEntities = openEntity;
-    }
-  }
-
-  if (!parser->m_hugeEntities) {
-    XML_Index index = XML_GetCurrentByteIndex(parser);
-    parser->m_entityNestingLevel--;
-    if (entity->textLen > XML_ENTITY_EXPANSION_SIZE) {
-      /* Current entity is too large */
-      return XML_ERROR_ENTITY_VIOLATION_SIZE;
-    }
-    /* Entity expension length isn't equal to output length. For nested
-     * entities, it records length of each expansion level and not sum of
-     * expanded text. */
-    parser->m_entityExpansionLen += entity->textLen;
-    if (index > 0) {
-      /* overflow safe comparison */
-      XML_Size limit = (parser->m_entityExpansionLen +
-        (XML_ENTITY_EXPANSION_RATIO - 1)) / XML_ENTITY_EXPANSION_RATIO;
-      if (limit > (XML_Size)index) {
-        /* Ratio between processed bytes and all expanded entities is off */
-        return XML_ERROR_ENTITY_VIOLATION_RATIO;
-      }
     }
   }
 
@@ -6411,6 +6429,76 @@ normalizePublicId(XML_Char *publicId)
   if (p != publicId && p[-1] == 0x20)
     --p;
   *p = XML_T('\0');
+}
+
+static LIMIT *
+limitCreate(const XML_Memory_Handling_Suite *ms)
+{
+    LIMIT *limit = (LIMIT *)ms->malloc_fcn(sizeof(LIMIT));
+    if (!limit)
+      return NULL;
+    limit->first_entity = NULL;
+    limit->entityNestingLevel = 0;
+    limit->nestedEntityExpansionSize = 0;
+    limit->totalEntityExpansionSize = 0;
+    return limit;
+}
+
+static void
+limitDestroy(LIMIT *limit,const XML_Memory_Handling_Suite *ms)
+{
+    ms->free_fcn(limit);
+}
+
+static enum XML_Error
+limitPreContent(XML_Parser parser, ENTITY *entity)
+{
+  if (parser->m_limit->first_entity == NULL) {
+    parser->m_limit->first_entity = entity;
+  } else {
+    parser->m_limit->entityNestingLevel++;
+  }
+  parser->m_limit->nestedEntityExpansionSize += entity->textLen;
+  parser->m_limit->totalEntityExpansionSize += entity->textLen;
+  fprintf(stderr, "%s, %s %i %li\n", entity->name, parser->m_limit->first_entity->name, parser->m_limit->entityNestingLevel, parser->m_limit->nestedEntityExpansionSize);
+
+  if (!parser->m_hugeEntities) {
+    XML_Index index = XML_GetCurrentByteIndex(parser);
+
+    if (parser->m_limit->entityNestingLevel > XML_ENTITY_NESTING_LIMIT)
+      return XML_ERROR_ENTITY_VIOLATION_DEPTH;
+
+    if (entity->textLen > XML_ENTITY_EXPANSION_SIZE)
+      /* current entity text is too large */
+      return XML_ERROR_ENTITY_VIOLATION_SIZE;
+
+    if (parser->m_limit->nestedEntityExpansionSize > XML_ENTITY_EXPANSION_SIZE)
+      /* sum of text is too large */
+      return XML_ERROR_ENTITY_VIOLATION_NESTED_SIZE;
+
+    if (index > 0) {
+      /* overflow safe comparison */
+      XML_Size limit = (parser->m_limit->totalEntityExpansionSize +
+        (XML_ENTITY_EXPANSION_RATIO - 1)) / XML_ENTITY_EXPANSION_RATIO;
+      if (limit > (XML_Size)index)
+        /* Ratio between processed bytes and all expanded entities is off */
+        return XML_ERROR_ENTITY_VIOLATION_RATIO;
+    }
+  }
+
+  return XML_ERROR_NONE;
+}
+
+static enum XML_Error
+limitPostContent(XML_Parser parser, ENTITY *entity)
+{
+  if (parser->m_limit->first_entity == entity) {
+    parser->m_limit->first_entity = NULL;
+    parser->m_limit->entityNestingLevel = 0;
+    parser->m_limit->nestedEntityExpansionSize = 0;
+  }
+
+  return XML_ERROR_NONE;
 }
 
 static DTD *

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -7123,30 +7123,30 @@ START_TEST(test_set_get_options)
         fail("XML_SetOption with unsupported option should have failed.");
 
     /* check default */
-    if (XML_GetOption(parser, XML_OPTION_HUGE_ENTITIES, &he) != XML_STATUS_OK)
+    if (XML_GetOption(parser, XML_OPTION_HUGE_XML, &he) != XML_STATUS_OK)
         fail("XML_GetOption failed");
     if (he != XML_FALSE)
-        fail("Expected XML_OPTION_HUGE_ENTITIES=XML_FALSE as default");
+        fail("Expected XML_OPTION_HUGE_XML=XML_FALSE as default");
 
     /* set and get */
     he = XML_TRUE;
-    if (XML_SetOption(parser, XML_OPTION_HUGE_ENTITIES, &he) != XML_STATUS_OK) {
+    if (XML_SetOption(parser, XML_OPTION_HUGE_XML, &he) != XML_STATUS_OK) {
         fail("XML_SetOptions() failed");
     }
-    if (XML_GetOption(parser, XML_OPTION_HUGE_ENTITIES, &he) != XML_STATUS_OK)
+    if (XML_GetOption(parser, XML_OPTION_HUGE_XML, &he) != XML_STATUS_OK)
         fail("XML_GetOption failed");
     if (he != XML_TRUE)
-        fail("Expected XML_OPTION_HUGE_ENTITIES=XML_TRUE");
+        fail("Expected XML_OPTION_HUGE_XML=XML_TRUE");
 
     /* XML_SetOptions() fails while parsing */
     if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text),
                                 XML_FALSE) == XML_STATUS_ERROR)
         xml_failure(parser);
     he = XML_FALSE;
-    if (XML_SetOption(parser, XML_OPTION_HUGE_ENTITIES, &he) != XML_STATUS_ERROR) {
+    if (XML_SetOption(parser, XML_OPTION_HUGE_XML, &he) != XML_STATUS_ERROR) {
         fail("XML_SetOptions() should fail during parsing");
     }
-   if (XML_GetOption(parser, XML_OPTION_HUGE_ENTITIES, &he) != XML_STATUS_OK)
+   if (XML_GetOption(parser, XML_OPTION_HUGE_XML, &he) != XML_STATUS_OK)
         fail("XML_GetOption failed");
     if (he != XML_TRUE)
         fail("Failed XML_SetOption() should not have modified parser options.");
@@ -8198,7 +8198,7 @@ END_TEST
 static void
 alloc_setup(void)
 {
-    XML_Bool huge_entities = XML_TRUE;
+    XML_Bool huge_xml = XML_TRUE;
     XML_Memory_Handling_Suite memsuite = {
         duff_allocator,
         duff_reallocator,
@@ -8211,9 +8211,8 @@ alloc_setup(void)
     parser = XML_ParserCreate_MM(NULL, &memsuite, NULL);
     if (parser == NULL)
         fail("Parser not created");
-    /* Enable huge entities for realloc tests */
-
-    if (XML_SetOption(parser, XML_OPTION_HUGE_ENTITIES, &huge_entities) != XML_STATUS_OK)
+    /* Enable huge XML for realloc tests */
+    if (XML_SetOption(parser, XML_OPTION_HUGE_XML, &huge_xml) != XML_STATUS_OK)
         fail("XML_SetOptions() failed");
 }
 
@@ -12023,11 +12022,13 @@ START_TEST(test_nsalloc_prefixed_element)
 }
 END_TEST
 
-/* Tests for huge entity limits */
+/* Tests for huge XML limits */
 static void
-huge_entities_setup(void)
+huge_xml_setup(void)
 {
-    XML_Bool huge_entities = XML_FALSE;
+    XML_Bool huge_xml = XML_FALSE;
+    int nestingLimit = 3;
+    XML_Size expansionSize = 1023;
     XML_Memory_Handling_Suite memsuite = {
         duff_allocator,
         duff_reallocator,
@@ -12040,18 +12041,22 @@ huge_entities_setup(void)
     parser = XML_ParserCreate_MM(NULL, &memsuite, NULL);
     if (parser == NULL)
         fail("Parser not created");
-    /* Enable huge entities for realloc tests */
-    if (XML_SetOption(parser, XML_OPTION_HUGE_ENTITIES, &huge_entities) != XML_STATUS_OK)
-        fail("XML_SetOptions() failed");
+    /* Disable huge XML and reduce limits for huge XML limit tests */
+    if (XML_SetOption(parser, XML_OPTION_HUGE_XML, &huge_xml) != XML_STATUS_OK)
+        fail("XML_SetOptions(XML_OPTION_HUGE_XML) failed");
+    if (XML_SetOption(parser, XML_OPTION_NESTING_LIMIT, &nestingLimit) != XML_STATUS_OK)
+        fail("XML_SetOptions(XML_OPTION_NESTING_LIMIT) failed");
+    if (XML_SetOption(parser, XML_OPTION_MAX_EXPANSION_SIZE, &expansionSize) != XML_STATUS_OK)
+        fail("XML_SetOptions(XML_OPTION_MAX_EXPANSION_SIZE) failed");
 }
 
 static void
-huge_entities_teardown(void)
+huge_xml_teardown(void)
 {
     basic_teardown();
 }
 
-START_TEST(test_huge_entities_recursion_limit)
+START_TEST(test_huge_xml_entity_nesting_limit)
 {
     const char *text =
         "<!DOCTYPE he [\n"
@@ -12067,7 +12072,7 @@ START_TEST(test_huge_entities_recursion_limit)
 }
 END_TEST
 
-START_TEST(test_huge_entities_recursion_ok)
+START_TEST(test_huge_xml_entity_nesting_ok)
 {
     const char *text =
         "<!DOCTYPE he [\n"
@@ -12084,7 +12089,7 @@ START_TEST(test_huge_entities_recursion_ok)
 END_TEST
 
 
-START_TEST(test_huge_entities_not_too_large)
+START_TEST(test_huge_xml_entity_not_too_large)
 {
     const char *text =
         "<!DOCTYPE he [\n"
@@ -12118,7 +12123,7 @@ START_TEST(test_huge_entities_not_too_large)
 }
 END_TEST
 
-START_TEST(test_huge_entities_too_large)
+START_TEST(test_huge_xml_entity_too_large)
 {
     const char *text =
         "<!DOCTYPE he [\n"
@@ -12150,7 +12155,7 @@ START_TEST(test_huge_entities_too_large)
 }
 END_TEST
 
-START_TEST(test_huge_entities_expansion_limit)
+START_TEST(test_huge_xml_entity_expansion_limit)
 {
     const char *text =
         "<!DOCTYPE he ["
@@ -12180,7 +12185,7 @@ make_suite(void)
     TCase *tc_misc = tcase_create("miscellaneous tests");
     TCase *tc_alloc = tcase_create("allocation tests");
     TCase *tc_nsalloc = tcase_create("namespace allocation tests");
-    TCase *tc_huge_entities = tcase_create("huge entities");
+    TCase *tc_huge_xml = tcase_create("huge XML tests");
 
     suite_add_tcase(s, tc_basic);
     tcase_add_checked_fixture(tc_basic, basic_setup, basic_teardown);
@@ -12533,14 +12538,14 @@ make_suite(void)
     tcase_add_test(tc_nsalloc, test_nsalloc_long_systemid_in_ext);
     tcase_add_test(tc_nsalloc, test_nsalloc_prefixed_element);
 
-    suite_add_tcase(s, tc_huge_entities);
-    tcase_add_checked_fixture(tc_huge_entities, huge_entities_setup,
-                              huge_entities_teardown);
-    tcase_add_test(tc_huge_entities, test_huge_entities_recursion_limit);
-    tcase_add_test(tc_huge_entities, test_huge_entities_recursion_ok);
-    tcase_add_test(tc_huge_entities, test_huge_entities_too_large);
-    tcase_add_test(tc_huge_entities, test_huge_entities_not_too_large);
-    tcase_add_test(tc_huge_entities, test_huge_entities_expansion_limit);
+    suite_add_tcase(s, tc_huge_xml);
+    tcase_add_checked_fixture(tc_huge_xml, huge_xml_setup,
+                              huge_xml_teardown);
+    tcase_add_test(tc_huge_xml, test_huge_xml_entity_nesting_limit);
+    tcase_add_test(tc_huge_xml, test_huge_xml_entity_nesting_ok);
+    tcase_add_test(tc_huge_xml, test_huge_xml_entity_too_large);
+    tcase_add_test(tc_huge_xml, test_huge_xml_entity_not_too_large);
+    tcase_add_test(tc_huge_xml, test_huge_xml_entity_expansion_limit);
 
     return s;
 }

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -12175,6 +12175,55 @@ START_TEST(test_huge_xml_entity_expansion_limit)
 }
 END_TEST
 
+START_TEST(test_huge_xml_hash_table_limit)
+{
+    XML_Size tableEntries = 4; /* smaller than 4 entities + 1 element */
+    const char *text =
+        "<!DOCTYPE he [\n"
+        "  <!ELEMENT he (#PCDATA)*>\n"
+        "  <!ENTITY e1 '&e2;'>\n"
+        "  <!ENTITY e2 '&e3;'>\n"
+        "  <!ENTITY e3 '&e4;'>\n"
+        "  <!ENTITY e4 'entity'>\n"
+        "]>\n"
+        "<he>&e1;</he>\n";
+
+    if (XML_SetOption(parser, XML_OPTION_MAX_HASH_TABLE_ENTRIES, &tableEntries) != XML_STATUS_OK)
+        fail("XML_SetOptions(XML_OPTION_MAX_HASH_TABLE_ENTRIES) failed");
+
+    expect_failure(text, XML_ERROR_HASH_TABLE_VIOLATION,
+                   "XML_ERROR_HASH_TABLE_VIOLATION not raised");
+}
+END_TEST
+
+START_TEST(test_huge_xml_enabled)
+{
+    XML_Size smallSize = 1;
+    int smallInt = 1;
+    XML_Bool hugeXML = XML_TRUE;
+    const char *text =
+        "<!DOCTYPE he [\n"
+        "  <!ELEMENT he (#PCDATA)*>\n"
+        "  <!ENTITY e1 '&e2;'>\n"
+        "  <!ENTITY e2 '&e3;'>\n"
+        "  <!ENTITY e3 '&e4;'>\n"
+        "  <!ENTITY e4 'entity'>\n"
+        "]>\n"
+        "<he>&e1;</he>\n";
+
+    if (XML_SetOption(parser, XML_OPTION_MAX_HASH_TABLE_ENTRIES, &smallSize) != XML_STATUS_OK)
+        fail("XML_SetOptions(XML_OPTION_MAX_HASH_TABLE_ENTRIES) failed");
+    if (XML_SetOption(parser, XML_OPTION_NESTING_LIMIT, &smallInt) != XML_STATUS_OK)
+        fail("XML_SetOptions(XML_OPTION_NESTING_LIMIT) failed");
+    if (XML_SetOption(parser, XML_OPTION_HUGE_XML, &hugeXML) != XML_STATUS_OK)
+        fail("XML_SetOptions(XML_OPTION_HUGE_XML) failed");
+
+    if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text), XML_TRUE) != XML_STATUS_OK) {
+        fail("expected XML_STATUS_OK with hugeXML");
+    }
+}
+END_TEST
+
 
 static Suite *
 make_suite(void)
@@ -12546,6 +12595,8 @@ make_suite(void)
     tcase_add_test(tc_huge_xml, test_huge_xml_entity_too_large);
     tcase_add_test(tc_huge_xml, test_huge_xml_entity_not_too_large);
     tcase_add_test(tc_huge_xml, test_huge_xml_entity_expansion_limit);
+    tcase_add_test(tc_huge_xml, test_huge_xml_hash_table_limit);
+    tcase_add_test(tc_huge_xml, test_huge_xml_enabled);
 
     return s;
 }

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -913,7 +913,7 @@ tmain(int argc, XML_Char **argv)
   int useNamespaces = 0;
   int requireStandalone = 0;
   int requiresNotations = 0;
-  int hugeEntities = 0;
+  XML_Bool hugeEntities = XML_FALSE;
   enum XML_ParamEntityParsing paramEntityParsing = 
     XML_PARAM_ENTITY_PARSING_NEVER;
   int useStdin = 0;
@@ -977,7 +977,7 @@ tmain(int argc, XML_Char **argv)
       j++;
       break;
     case T('H'):
-      hugeEntities = 1;
+      hugeEntities = XML_TRUE;
       j++;
       break;
     case T('d'):
@@ -1040,8 +1040,7 @@ tmain(int argc, XML_Char **argv)
 
     if (requireStandalone)
       XML_SetNotStandaloneHandler(parser, notStandalone);
-    if (hugeEntities)
-      XML_SetOptions(parser, XML_OPTION_HUGE_ENTITIES);
+    XML_SetOption(parser, XML_OPTION_HUGE_ENTITIES, &hugeEntities);
     XML_SetParamEntityParsing(parser, paramEntityParsing);
     if (outputType == 't') {
       /* This is for doing timings; this gives a more realistic estimate of

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -892,7 +892,7 @@ static void
 usage(const XML_Char *prog, int rc)
 {
   ftprintf(stderr,
-           T("usage: %s [-s] [-n] [-p] [-x] [-e encoding] [-w] [-d output-dir] [-c] [-m] [-r] [-t] [-N] [file ...]\n"), prog);
+           T("usage: %s [-s] [-n] [-p] [-x] [-e encoding] [-w] [-d output-dir] [-c] [-m] [-r] [-t] [-N] [-H] [file ...]\n"), prog);
   exit(rc);
 }
 
@@ -913,6 +913,7 @@ tmain(int argc, XML_Char **argv)
   int useNamespaces = 0;
   int requireStandalone = 0;
   int requiresNotations = 0;
+  int hugeEntities = 0;
   enum XML_ParamEntityParsing paramEntityParsing = 
     XML_PARAM_ENTITY_PARSING_NEVER;
   int useStdin = 0;
@@ -975,6 +976,10 @@ tmain(int argc, XML_Char **argv)
       requiresNotations = 1;
       j++;
       break;
+    case T('H'):
+      hugeEntities = 1;
+      j++;
+      break;
     case T('d'):
       if (argv[i][j + 1] == T('\0')) {
         if (++i == argc)
@@ -1035,6 +1040,8 @@ tmain(int argc, XML_Char **argv)
 
     if (requireStandalone)
       XML_SetNotStandaloneHandler(parser, notStandalone);
+    if (hugeEntities)
+      XML_SetOptions(parser, XML_OPTION_HUGE_ENTITIES);
     XML_SetParamEntityParsing(parser, paramEntityParsing);
     if (outputType == 't') {
       /* This is for doing timings; this gives a more realistic estimate of

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -913,7 +913,7 @@ tmain(int argc, XML_Char **argv)
   int useNamespaces = 0;
   int requireStandalone = 0;
   int requiresNotations = 0;
-  XML_Bool hugeEntities = XML_FALSE;
+  XML_Bool hugeXML = XML_FALSE;
   enum XML_ParamEntityParsing paramEntityParsing = 
     XML_PARAM_ENTITY_PARSING_NEVER;
   int useStdin = 0;
@@ -977,7 +977,7 @@ tmain(int argc, XML_Char **argv)
       j++;
       break;
     case T('H'):
-      hugeEntities = XML_TRUE;
+      hugeXML = XML_TRUE;
       j++;
       break;
     case T('d'):
@@ -1040,7 +1040,7 @@ tmain(int argc, XML_Char **argv)
 
     if (requireStandalone)
       XML_SetNotStandaloneHandler(parser, notStandalone);
-    XML_SetOption(parser, XML_OPTION_HUGE_ENTITIES, &hugeEntities);
+    XML_SetOption(parser, XML_OPTION_HUGE_XML, &hugeXML);
     XML_SetParamEntityParsing(parser, paramEntityParsing);
     if (outputType == 't') {
       /* This is for doing timings; this gives a more realistic estimate of


### PR DESCRIPTION
libexpat is vulnerable to billion laughs and quadratic blowup DoS attacks.
processInternalEntity() function now limits entity expansion and
nesting in three ways:

* Entity nesting is limited to three levels of recursion.
* Total length of an entity is limited to 1023 bytes.
* The ratio of entity expansion to processed bytes cannot exceed 1:10.

The mitigation is enabled by default and can be disabled with
XML_SetOptions(parser, XML_OPTION_HUGE_ENTITES).

The xmlwf command has a new option -H to enable huge entities.

The new entity expansion limits cause one test to fail. The XML test
file tests/xmlconf/xmltest/valid/ext-sa/012.xml has five levels of
entity expansion.

Fixes: https://github.com/libexpat/libexpat/issues/34
Fixes: https://github.com/libexpat/libexpat/issues/46
Signed-off-by: Christian Heimes <christian@python.org>

- [x] write tests
- [x] update changelog
- [ ] update documentation