### PR TITLE
Remove expat.h from .gitignore

### DIFF
--- a/expat/lib/.gitignore
+++ b/expat/lib/.gitignore
@@ -1,7 +1,6 @@
 Makefile
 .libs
 *.lo
-expat.h
 Debug
 Debug-w
 Release


### PR DESCRIPTION
This line was added to .gitignore long time ago: https://github.com/libexpat/libexpat/commit/4232566#diff-c2e563b3bcc129c372bcd22a14152c01

If I understand correctly, expat.h was auto-generated back then, and it was not present in the repo. However, times changed, and now `expat.h` _is_ present in expat\lib. Thus, it should be removed from .gitignore.

I stumbled upon this when I was adding the sources in our local corporate mirror. I downloaded sources, added to our git repository. Then checked out in a build system, and realized expat.h is missing. That was surprizing.