### PR TITLE
Fix compilation for -Werror with -Wunused-function/-Wall

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -738,7 +738,7 @@ writeRandomBytes_dev_urandom(void * target, size_t count) {
 #endif  /* ! defined(HAVE_ARC4RANDOM_BUF) && ! defined(HAVE_ARC4RANDOM) */
 
 
-#if defined(HAVE_ARC4RANDOM)
+#if defined(HAVE_ARC4RANDOM) && ! defined(HAVE_ARC4RANDOM_BUF)
 
 static void
 writeRandomBytes_arc4random(void * target, size_t count) {
@@ -756,7 +756,7 @@ writeRandomBytes_arc4random(void * target, size_t count) {
   }
 }
 
-#endif  /* defined(HAVE_ARC4RANDOM) */
+#endif  /* defined(HAVE_ARC4RANDOM) && ! defined(HAVE_ARC4RANDOM_BUF) */
 
 
 #ifdef _WIN32


### PR DESCRIPTION
The writeRandomBytes_arc4random is not used if the arc4random_buf
is available. This caused compiler to throw warnings.
Finally this breaks a build when warnings are treated as errors.