### PR TITLE
Port to Plan 9

### DIFF
--- a/expat/lib/mkfile
+++ b/expat/lib/mkfile
@@ -1,0 +1,36 @@
+</sys/src/ape/config
+
+CFLAGS=-c -FTV\
+	-D_POSIX_SOURCE\
+	-D_SUSV2_SOURCE\
+	-D_PLAN9_SOURCE\
+	-DHAVE_ARC4RANDOM_BUF\
+
+OFILES=\
+	loadlibrary.$O\
+	xmlparse.$O\
+	xmlparse_plan9.$O\
+	xmltok.$O\
+	xmlrole.$O\
+
+HFILES=\
+	ascii.h\
+	asciitab.h\
+	expat.h\
+	expat_external.h\
+	iasciitab.h\
+	internal.h\
+	latin1tab.h\
+	nametab.h\
+	siphash.h\
+	utf8tab.h\
+	winconfig.h\
+	xmlrole.h\
+	xmltok.h\
+	xmltok_impl.h\
+
+LIB=libexpat.a
+
+</sys/src/cmd/mklib
+
+xmltok.$O: xmltok.c xmltok_impl.c xmltok_ns.c

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -841,6 +841,7 @@ generate_hash_secret_salt(XML_Parser parser)
 
   /* "Failproof" high quality providers: */
 #if defined(HAVE_ARC4RANDOM_BUF)
+  extern void arc4random_buf(void *buf, size_t nbytes);
   arc4random_buf(&entropy, sizeof(entropy));
   return ENTROPY_DEBUG("arc4random_buf", entropy);
 #elif defined(HAVE_ARC4RANDOM)

--- a/expat/lib/xmlparse_plan9.c
+++ b/expat/lib/xmlparse_plan9.c
@@ -1,0 +1,23 @@
+#include <u.h>
+#include <lib9.h>
+#include <inttypes.h>
+#include <sys/types.h>
+typedef uint32_t u32int;
+typedef uint64_t u64int;
+#include <libsec.h>
+
+extern vlong _NSEC(void);
+
+char *argv0; // this is needed because is referenced from lib9.
+
+vlong
+nsec(void)
+{
+	return _NSEC();
+}
+
+void
+arc4random_buf(void *buf, size_t nbytes)
+{
+	genrandom(buf, nbytes);
+}

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -38,6 +38,11 @@
 # define bool   int
 # define false  0
 # define true   1
+#elif defined(_POSIX_SOURCE)
+  /* for Plan 9 APE pcc */
+# define bool   int
+# define false  0
+# define true   1
 #else
 # include <stdbool.h>
 #endif

--- a/expat/tests/mkfile
+++ b/expat/tests/mkfile
@@ -1,0 +1,25 @@
+</sys/src/ape/config
+
+CFLAGS=-c -FV\
+	-I../lib\
+	-D_POSIX_SOURCE\
+	-D_SUSV2_SOURCE\
+	-D_PLAN9_SOURCE\
+	-D__func__="<unknown>"\
+
+OFILES=\
+	chardata.$O\
+	structdata.$O\
+	memcheck.$O\
+	minicheck.$O\
+	runtests.$O\
+
+LIB=../lib/libexpat.a
+
+HFILES=\
+	chardata.h\
+	structdata.h\
+	memcheck.h\
+	minicheck.h\
+
+</sys/src/cmd/mkone

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -66,6 +66,11 @@
 #  define bool   int
 #  define false  0
 #  define true   1
+# elif defined(_POSIX_SOURCE)
+   /* for Plan 9 APE pcc */
+#  define bool   int
+#  define false  0
+#  define true   1
 # else
 #  include <stdbool.h>
 # endif


### PR DESCRIPTION
I ported libexpat to Plan 9 operating system.

This PR did:

- To build libexpat library
- To build runtests command

To build in Plan 9, just run few steps.

```console
% cd lib
% mk
% mk install
```

Currently, 90% of tests are passed.
Could you merge this?