### PR TITLE
Fix syntax of Windows module definition files

### DIFF
--- a/expat/lib/libexpat.def
+++ b/expat/lib/libexpat.def
@@ -73,6 +73,6 @@ EXPORTS
   XML_GetParsingStatus @65
 ; added with version 2.1.1
 ; XML_GetAttributeInfo @66
-  XML_SetHashSalt @67@
+  XML_SetHashSalt @67
 ; added with version 2.2.5
-  _INTERNAL_trim_to_complete_utf8_characters @68@
+  _INTERNAL_trim_to_complete_utf8_characters @68

--- a/expat/lib/libexpatw.def
+++ b/expat/lib/libexpatw.def
@@ -73,6 +73,6 @@ EXPORTS
   XML_GetParsingStatus @65
 ; added with version 2.1.1
 ; XML_GetAttributeInfo @66
-  XML_SetHashSalt @67@
+  XML_SetHashSalt @67
 ; added with version 2.2.5
-  _INTERNAL_trim_to_complete_utf8_characters @68@
+  _INTERNAL_trim_to_complete_utf8_characters @68


### PR DESCRIPTION
Otherwise this fails with:
  Cannot export @: symbol not defined