### PR TITLE
Fix compilation for lack of docbook2x-man (fixes #247)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -12,6 +12,7 @@ Release x.x.x XXX XXXXXX XX XXXX
             #228  Autotools: Modernize configure.ac
             #243  Windows: Fix syntax of .def module definition files
        #245 #246  Autotools: Fix check for -fvisibility=hidden for Clang
+       #247 #248  Autotools: Fix compilation for lack of docbook2x-man
 
         Special thanks to:
             Benjamin Peterson

--- a/expat/doc/Makefile.am
+++ b/expat/doc/Makefile.am
@@ -28,14 +28,17 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 # USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+.PHONY: dist-hook  # not inside conditional to avoid automake warning
+
+if WITH_DOCBOOK
 dist_man_MANS = xmlwf.1
 
 xmlwf.1: xmlwf.xml
-if WITH_DOCBOOK
 	-rm -f $@
 	$(DOCBOOK_TO_MAN) $<
 	test -f $@ || mv XMLWF.1 $@
 else
+dist-hook:
 	@echo 'ERROR: Configure with --with-docbook for "make dist".' 1>&2
 	@false
 endif


### PR DESCRIPTION
To fix #247 

The guard in doc/Makefile.am was supposed to protect against publishing release tarballs lacking a compiled `xmlwf.1` man page without noticing.  Now it does no more than advertised.