### PR TITLE
xmlparse.c: Fix extraction of namespace prefix from XML name (#186)

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -6071,7 +6071,7 @@ setElementTypePrefix(XML_Parser parser, ELEMENT_TYPE *elementType)
       else
         poolDiscard(&dtd->pool);
       elementType->prefix = prefix;
-
+      break;
     }
   }
   return 1;


### PR DESCRIPTION
My impression is that function `setElementTypePrefix` extracts the XML namespace prefix from an XML name and puts it into `elementType->prefix` if it was able find a registered prefix for that namespace:

https://github.com/libexpat/libexpat/blob/7f3291057bfc499933eddeb980ba67b9fb87834e/expat/lib/xmlparse.c#L6050-L6078

Now according to this quote …

>  [4] NCName ::= Name - (Char* ':' Char*) /* An XML Name, minus the ":" */

… from [Namespaces in XML 1.0 (Third Edition)](https://www.w3.org/TR/REC-xml-names/#NT-NCName) namespace prefixes cannot contain a colon.

It also seems that colons *should* be used in XML names for namespaces only, but do not render the name malformed if used otherwise they way I read [this](https://www.w3.org/TR/2006/REC-xml-20060816/#dt-name):

> The Namespaces in XML Recommendation [XML Names] assigns a meaning to names containing colon characters. Therefore, authors should not use the colon in XML names except for namespace purposes, but XML processors must accept the colon as a name character.

To conclude from those two, my understanding is that we should treat all text before the first colon (if any) as a namespace prefix and treat the remainder as a name from (or relative to) that namespace, containing further colons or not.

To me, the "right" fix seems to be be to just add a `break` statement to the end if the inner `if`-block to stop after the first time we handled a colon. In my test, this patch does defuse the case of the [file attached](https://github.com/libexpat/libexpat/files/1664546/clusterfuzz-testcase-4543406568112128.txt) to issue #186 while keeping the test suite happy.

Review welcome and appreciated!

----
Related:
- issue #186
- pull request #261