### PR TITLE
Fix link step on MinGW for CMake

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -153,9 +153,9 @@ set(expat_SRCS
 
 if(BUILD_shared)
     set(_SHARED SHARED)
-    if(WIN32)
+    if(MSVC)
         set(expat_SRCS ${expat_SRCS} lib/libexpat.def)
-    endif(WIN32)
+    endif(MSVC)
 else(BUILD_shared)
     set(_SHARED STATIC)
     if(WIN32)


### PR DESCRIPTION
.def files are handled differently on MinGW than MSVC for the WIN32 target:

```
[ 14%] Linking C shared library libexpat.dll
/usr/lib/gcc/x86_64-w64-mingw32/9.1.0/../../../../x86_64-w64-mingw32/bin/ld: ../lib/libexpat.def:4: syntax error
/usr/lib/gcc/x86_64-w64-mingw32/9.1.0/../../../../x86_64-w64-mingw32/bin/ld:../lib/libexpat.def: file format not recognized; treating as linker script
/usr/lib/gcc/x86_64-w64-mingw32/9.1.0/../../../../x86_64-w64-mingw32/bin/ld:../lib/libexpat.def:1: syntax error
collect2: error: ld returned 1 exit status
```