### PR TITLE
Make sure UBSAN errors cause a hard abort.

### DIFF
--- a/expat/qa.sh
+++ b/expat/qa.sh
@@ -66,7 +66,7 @@ populate_environment() {
                 # http://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
                 BASE_COMPILE_FLAGS+=" -fsanitize=undefined"
                 BASE_LINK_FLAGS+=" -fsanitize=undefined"
-                export UBSAN_OPTIONS=print_stacktrace=1
+                export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:abort_on_error=1"
                 ;;
         esac
     fi


### PR DESCRIPTION
The current QA script would probably not catch UBSAN errors, because they don't cause the program to terminate. This patch makes sure UBSAN errors cause an abort via UBSAN_OPTIONS.