### PR TITLE
fix loss of data warnings with vc15 win64 and /W4

### DIFF
--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -655,7 +655,7 @@ unicode_byte_type(char hi, char lo) {
           return XML_CONVERT_INPUT_INCOMPLETE;                                 \
         }                                                                      \
         plane = (((hi & 0x3) << 2) | ((lo >> 6) & 0x3)) + 1;                   \
-        *(*toP)++ = ((plane >> 2) | UTF8_cval4);                               \
+        *(*toP)++ = (char)((plane >> 2) | UTF8_cval4);                         \
         *(*toP)++ = (((lo >> 2) & 0xF) | ((plane & 0x3) << 4) | 0x80);         \
         from += 2;                                                             \
         lo2 = GET_LO(from);                                                    \


### PR DESCRIPTION
Line 658 in the macro, the expression has an int result because of plane and needs a cast.

`*(*toP)++ = **(char)** ((plane >> 2) | UTF8_cval4);			\

This takes care of the following two warnings.

xmltok.c(699): warning C4244: '=': conversion from 'int' to 'char', possible loss of data
xmltok.c(710): warning C4244: '=': conversion from 'int' to 'char', possible loss of data

There were a few other variable shadowing warnings in 2.2.7, but it looks like those were fixed in subsequent development.   The UNUSED_P fix introduced earlier does not work on VC, and there are many, many warnings (see attached [vc15_x64_log.txt](https://github.com/libexpat/libexpat/files/3507048/vc15_x64_log.txt))     I will address those in a separate PR.

Signed-off-by: David Loffredo <loffredo@steptools.com>