### PR TITLE
Handle unused parameters with (void) statement rather than gcc-specific att

### DIFF
--- a/expat/lib/internal.h
+++ b/expat/lib/internal.h
@@ -102,11 +102,7 @@
 #endif
 
 #ifndef UNUSED_P
-#  if defined(__GNUC__) && (__GNUC__ >= 4)
-#    define UNUSED_P(p) UNUSED_##p __attribute__((__unused__))
-#  else
-#    define UNUSED_P(p) UNUSED_##p
-#  endif
+#  define UNUSED_P(p) (void)p
 #endif
 
 #ifdef __cplusplus

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -5257,8 +5257,11 @@ internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
 }
 
 static enum XML_Error PTRCALL
-errorProcessor(XML_Parser parser, const char *UNUSED_P(s),
-               const char *UNUSED_P(end), const char **UNUSED_P(nextPtr)) {
+errorProcessor(XML_Parser parser, const char *s, const char *end,
+               const char **nextPtr) {
+  UNUSED_P(s);
+  UNUSED_P(end);
+  UNUSED_P(nextPtr);
   return parser->m_errorCode;
 }
 

--- a/expat/lib/xmlrole.c
+++ b/expat/lib/xmlrole.c
@@ -195,8 +195,11 @@ prolog1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-prolog2(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-        const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+prolog2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+        const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_NONE;
@@ -212,8 +215,11 @@ prolog2(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-doctype0(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+doctype0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_DOCTYPE_NONE;
@@ -252,8 +258,11 @@ doctype1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-doctype2(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+doctype2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_DOCTYPE_NONE;
@@ -265,8 +274,11 @@ doctype2(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-doctype3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+doctype3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_DOCTYPE_NONE;
@@ -278,8 +290,11 @@ doctype3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-doctype4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+doctype4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_DOCTYPE_NONE;
@@ -294,8 +309,11 @@ doctype4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-doctype5(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+doctype5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_DOCTYPE_NONE;
@@ -389,8 +407,11 @@ externalSubset1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 #endif /* XML_DTD */
 
 static int PTRCALL
-entity0(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-        const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+entity0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+        const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ENTITY_NONE;
@@ -405,8 +426,11 @@ entity0(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-entity1(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-        const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+entity1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+        const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ENTITY_NONE;
@@ -442,8 +466,11 @@ entity2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-entity3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-        const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+entity3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+        const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ENTITY_NONE;
@@ -455,8 +482,11 @@ entity3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-entity4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-        const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+entity4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+        const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ENTITY_NONE;
@@ -487,8 +517,11 @@ entity5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-entity6(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-        const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+entity6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+        const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ENTITY_NONE;
@@ -525,8 +558,11 @@ entity7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-entity8(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-        const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+entity8(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+        const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ENTITY_NONE;
@@ -538,8 +574,11 @@ entity8(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-entity9(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-        const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+entity9(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+        const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ENTITY_NONE;
@@ -551,8 +590,11 @@ entity9(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-entity10(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+entity10(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ENTITY_NONE;
@@ -564,8 +606,11 @@ entity10(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-notation0(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-          const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+notation0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+          const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_NOTATION_NONE;
@@ -597,8 +642,11 @@ notation1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-notation2(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-          const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+notation2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+          const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_NOTATION_NONE;
@@ -610,8 +658,11 @@ notation2(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-notation3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-          const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+notation3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+          const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_NOTATION_NONE;
@@ -624,8 +675,11 @@ notation3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-notation4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-          const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+notation4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+          const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_NOTATION_NONE;
@@ -641,8 +695,11 @@ notation4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-attlist0(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+attlist0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ATTLIST_NONE;
@@ -655,8 +712,11 @@ attlist0(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-attlist1(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+attlist1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ATTLIST_NONE;
@@ -702,8 +762,11 @@ attlist2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-attlist3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+attlist3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ATTLIST_NONE;
@@ -717,8 +780,11 @@ attlist3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-attlist4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+attlist4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ATTLIST_NONE;
@@ -733,8 +799,11 @@ attlist4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-attlist5(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+attlist5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ATTLIST_NONE;
@@ -746,8 +815,11 @@ attlist5(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-attlist6(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+attlist6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ATTLIST_NONE;
@@ -759,8 +831,11 @@ attlist6(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-attlist7(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+attlist7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ATTLIST_NONE;
@@ -806,8 +881,11 @@ attlist8(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-attlist9(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+attlist9(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ATTLIST_NONE;
@@ -819,8 +897,11 @@ attlist9(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-element0(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+element0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ELEMENT_NONE;
@@ -893,8 +974,11 @@ element2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-element3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+element3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ELEMENT_NONE;
@@ -914,8 +998,11 @@ element3(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-element4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+element4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ELEMENT_NONE;
@@ -928,8 +1015,11 @@ element4(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-element5(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+element5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ELEMENT_NONE;
@@ -945,8 +1035,11 @@ element5(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-element6(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+element6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ELEMENT_NONE;
@@ -971,8 +1064,11 @@ element6(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-element7(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-         const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+element7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+         const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_ELEMENT_NONE;
@@ -1037,8 +1133,11 @@ condSect0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-condSect1(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-          const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+condSect1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+          const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_NONE;
@@ -1051,8 +1150,11 @@ condSect1(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 }
 
 static int PTRCALL
-condSect2(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-          const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+condSect2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+          const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return XML_ROLE_NONE;
@@ -1066,8 +1168,11 @@ condSect2(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
 #endif /* XML_DTD */
 
 static int PTRCALL
-declClose(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
-          const char *UNUSED_P(end), const ENCODING *UNUSED_P(enc)) {
+declClose(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+          const ENCODING *enc) {
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   switch (tok) {
   case XML_TOK_PROLOG_S:
     return state->role_none;
@@ -1099,9 +1204,13 @@ declClose(PROLOG_STATE *state, int tok, const char *UNUSED_P(ptr),
  * LCOV_EXCL_START
  */
 static int PTRCALL
-error(PROLOG_STATE *UNUSED_P(state), int UNUSED_P(tok),
-      const char *UNUSED_P(ptr), const char *UNUSED_P(end),
-      const ENCODING *UNUSED_P(enc)) {
+error(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
+      const ENCODING *enc) {
+  UNUSED_P(state);
+  UNUSED_P(tok);
+  UNUSED_P(ptr);
+  UNUSED_P(end);
+  UNUSED_P(enc);
   return XML_ROLE_NONE;
 }
 /* LCOV_EXCL_STOP */

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -131,46 +131,55 @@
                  || ((*p) == 0xF4 ? (p)[1] > 0x8F : ((p)[1] & 0xC0) == 0xC0)))
 
 static int PTRFASTCALL
-isNever(const ENCODING *UNUSED_P(enc), const char *UNUSED_P(p)) {
+isNever(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
+  UNUSED_P(p);
   return 0;
 }
 
 static int PTRFASTCALL
-utf8_isName2(const ENCODING *UNUSED_P(enc), const char *p) {
+utf8_isName2(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
   return UTF8_GET_NAMING2(namePages, (const unsigned char *)p);
 }
 
 static int PTRFASTCALL
-utf8_isName3(const ENCODING *UNUSED_P(enc), const char *p) {
+utf8_isName3(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
   return UTF8_GET_NAMING3(namePages, (const unsigned char *)p);
 }
 
 #define utf8_isName4 isNever
 
 static int PTRFASTCALL
-utf8_isNmstrt2(const ENCODING *UNUSED_P(enc), const char *p) {
+utf8_isNmstrt2(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
   return UTF8_GET_NAMING2(nmstrtPages, (const unsigned char *)p);
 }
 
 static int PTRFASTCALL
-utf8_isNmstrt3(const ENCODING *UNUSED_P(enc), const char *p) {
+utf8_isNmstrt3(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
   return UTF8_GET_NAMING3(nmstrtPages, (const unsigned char *)p);
 }
 
 #define utf8_isNmstrt4 isNever
 
 static int PTRFASTCALL
-utf8_isInvalid2(const ENCODING *UNUSED_P(enc), const char *p) {
+utf8_isInvalid2(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
   return UTF8_INVALID2((const unsigned char *)p);
 }
 
 static int PTRFASTCALL
-utf8_isInvalid3(const ENCODING *UNUSED_P(enc), const char *p) {
+utf8_isInvalid3(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
   return UTF8_INVALID3((const unsigned char *)p);
 }
 
 static int PTRFASTCALL
-utf8_isInvalid4(const ENCODING *UNUSED_P(enc), const char *p) {
+utf8_isInvalid4(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
   return UTF8_INVALID4((const unsigned char *)p);
 }
 
@@ -346,14 +355,15 @@ _INTERNAL_trim_to_complete_utf8_characters(const char *from,
 }
 
 static enum XML_Convert_Result PTRCALL
-utf8_toUtf8(const ENCODING *UNUSED_P(enc), const char **fromP,
-            const char *fromLim, char **toP, const char *toLim) {
+utf8_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
+            char **toP, const char *toLim) {
   bool input_incomplete = false;
   bool output_exhausted = false;
 
   /* Avoid copying partial characters (due to limited space). */
   const ptrdiff_t bytesAvailable = fromLim - *fromP;
   const ptrdiff_t bytesStorable = toLim - *toP;
+  UNUSED_P(enc);
   if (bytesAvailable > bytesStorable) {
     fromLim = *fromP + bytesStorable;
     output_exhausted = true;
@@ -482,8 +492,9 @@ static const struct normal_encoding internal_utf8_encoding
        STANDARD_VTABLE(sb_) NORMAL_VTABLE(utf8_)};
 
 static enum XML_Convert_Result PTRCALL
-latin1_toUtf8(const ENCODING *UNUSED_P(enc), const char **fromP,
-              const char *fromLim, char **toP, const char *toLim) {
+latin1_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
+              char **toP, const char *toLim) {
+  UNUSED_P(enc);
   for (;;) {
     unsigned char c;
     if (*fromP == fromLim)
@@ -504,9 +515,9 @@ latin1_toUtf8(const ENCODING *UNUSED_P(enc), const char **fromP,
 }
 
 static enum XML_Convert_Result PTRCALL
-latin1_toUtf16(const ENCODING *UNUSED_P(enc), const char **fromP,
-               const char *fromLim, unsigned short **toP,
-               const unsigned short *toLim) {
+latin1_toUtf16(const ENCODING *enc, const char **fromP, const char *fromLim,
+               unsigned short **toP, const unsigned short *toLim) {
+  UNUSED_P(enc);
   while (*fromP < fromLim && *toP < toLim)
     *(*toP)++ = (unsigned char)*(*fromP)++;
 
@@ -539,8 +550,9 @@ static const struct normal_encoding latin1_encoding
        STANDARD_VTABLE(sb_) NULL_VTABLE};
 
 static enum XML_Convert_Result PTRCALL
-ascii_toUtf8(const ENCODING *UNUSED_P(enc), const char **fromP,
-             const char *fromLim, char **toP, const char *toLim) {
+ascii_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
+             char **toP, const char *toLim) {
+  UNUSED_P(enc);
   while (*fromP < fromLim && *toP < toLim)
     *(*toP)++ = *(*fromP)++;
 
@@ -598,9 +610,10 @@ unicode_byte_type(char hi, char lo) {
 
 #define DEFINE_UTF16_TO_UTF8(E)                                                \
   static enum XML_Convert_Result PTRCALL E##toUtf8(                            \
-      const ENCODING *UNUSED_P(enc), const char **fromP, const char *fromLim,  \
+      const ENCODING *enc, const char **fromP, const char *fromLim,            \
       char **toP, const char *toLim) {                                         \
     const char *from = *fromP;                                                 \
+    UNUSED_P(enc);                                                             \
     fromLim = from + (((fromLim - from) >> 1) << 1); /* shrink to even */      \
     for (; from < fromLim; from += 2) {                                        \
       int plane;                                                               \
@@ -674,9 +687,10 @@ unicode_byte_type(char hi, char lo) {
 
 #define DEFINE_UTF16_TO_UTF16(E)                                               \
   static enum XML_Convert_Result PTRCALL E##toUtf16(                           \
-      const ENCODING *UNUSED_P(enc), const char **fromP, const char *fromLim,  \
+      const ENCODING *enc, const char **fromP, const char *fromLim,            \
       unsigned short **toP, const unsigned short *toLim) {                     \
     enum XML_Convert_Result res = XML_CONVERT_COMPLETED;                       \
+    UNUSED_P(enc);                                                             \
     fromLim = *fromP + (((fromLim - *fromP) >> 1) << 1); /* shrink to even */  \
     /* Avoid copying first half only of surrogate */                           \
     if (fromLim - *fromP > ((toLim - *toP) << 1)                               \
@@ -999,8 +1013,9 @@ streqci(const char *s1, const char *s2) {
 }
 
 static void PTRCALL
-initUpdatePosition(const ENCODING *UNUSED_P(enc), const char *ptr,
-                   const char *end, POSITION *pos) {
+initUpdatePosition(const ENCODING *enc, const char *ptr, const char *end,
+                   POSITION *pos) {
+  UNUSED_P(enc);
   normal_updatePosition(&utf8_encoding.enc, ptr, end, pos);
 }
 

--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -218,9 +218,10 @@ PREFIX(scanDecl)(const ENCODING *enc, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-PREFIX(checkPiTarget)(const ENCODING *UNUSED_P(enc), const char *ptr,
-                      const char *end, int *tokPtr) {
+PREFIX(checkPiTarget)(const ENCODING *enc, const char *ptr, const char *end,
+                      int *tokPtr) {
   int upper = 0;
+  UNUSED_P(enc);
   *tokPtr = XML_TOK_PI;
   if (end - ptr != MINBPC(enc) * 3)
     return 1;
@@ -322,11 +323,12 @@ PREFIX(scanPi)(const ENCODING *enc, const char *ptr, const char *end,
 }
 
 static int PTRCALL
-PREFIX(scanCdataSection)(const ENCODING *UNUSED_P(enc), const char *ptr,
-                         const char *end, const char **nextTokPtr) {
+PREFIX(scanCdataSection)(const ENCODING *enc, const char *ptr, const char *end,
+                         const char **nextTokPtr) {
   static const char CDATA_LSQB[]
       = {ASCII_C, ASCII_D, ASCII_A, ASCII_T, ASCII_A, ASCII_LSQB};
   int i;
+  UNUSED_P(enc);
   /* CDATA[ */
   REQUIRE_CHARS(enc, ptr, end, 6);
   for (i = 0; i < 6; i++, ptr += MINBPC(enc)) {
@@ -1583,9 +1585,10 @@ PREFIX(getAtts)(const ENCODING *enc, const char *ptr, int attsMax,
 }
 
 static int PTRFASTCALL
-PREFIX(charRefNumber)(const ENCODING *UNUSED_P(enc), const char *ptr) {
+PREFIX(charRefNumber)(const ENCODING *enc, const char *ptr) {
   int result = 0;
   /* skip &# */
+  UNUSED_P(enc);
   ptr += 2 * MINBPC(enc);
   if (CHAR_MATCHES(enc, ptr, ASCII_x)) {
     for (ptr += MINBPC(enc); ! CHAR_MATCHES(enc, ptr, ASCII_SEMI);
@@ -1640,8 +1643,9 @@ PREFIX(charRefNumber)(const ENCODING *UNUSED_P(enc), const char *ptr) {
 }
 
 static int PTRCALL
-PREFIX(predefinedEntityName)(const ENCODING *UNUSED_P(enc), const char *ptr,
+PREFIX(predefinedEntityName)(const ENCODING *enc, const char *ptr,
                              const char *end) {
+  UNUSED_P(enc);
   switch ((end - ptr) / MINBPC(enc)) {
   case 2:
     if (CHAR_MATCHES(enc, ptr + MINBPC(enc), ASCII_t)) {
@@ -1693,8 +1697,9 @@ PREFIX(predefinedEntityName)(const ENCODING *UNUSED_P(enc), const char *ptr,
 }
 
 static int PTRCALL
-PREFIX(nameMatchesAscii)(const ENCODING *UNUSED_P(enc), const char *ptr1,
+PREFIX(nameMatchesAscii)(const ENCODING *enc, const char *ptr1,
                          const char *end1, const char *ptr2) {
+  UNUSED_P(enc);
   for (; *ptr2; ptr1 += MINBPC(enc), ptr2++) {
     if (end1 - ptr1 < MINBPC(enc)) {
       /* This line cannot be executed.  The incoming data has already

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -197,12 +197,14 @@ srunner_run_all(SRunner *runner, int verbosity) {
 }
 
 void
-_fail_unless(int UNUSED_P(condition), const char *UNUSED_P(file),
-             int UNUSED_P(line), const char *msg) {
+_fail_unless(int condition, const char *file, int line, const char *msg) {
   /* Always print the error message so it isn't lost.  In this case,
      we have a failure, so there's no reason to be quiet about what
      it is.
   */
+  UNUSED_P(condition);
+  UNUSED_P(file);
+  UNUSED_P(line);
   if (msg != NULL) {
     const int has_newline = (msg[strlen(msg) - 1] == '\n');
     fprintf(stderr, "ERROR: %s%s", msg, has_newline ? "" : "\n");

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -202,47 +202,67 @@ static unsigned long dummy_handler_flags = 0;
 #define DUMMY_DEFAULT_HANDLER_FLAG (1UL << 17)
 
 static void XMLCALL
-dummy_xdecl_handler(void *UNUSED_P(userData), const XML_Char *UNUSED_P(version),
-                    const XML_Char *UNUSED_P(encoding),
-                    int UNUSED_P(standalone)) {
+dummy_xdecl_handler(void *userData, const XML_Char *version,
+                    const XML_Char *encoding, int standalone) {
+  UNUSED_P(userData);
+  UNUSED_P(version);
+  UNUSED_P(encoding);
+  UNUSED_P(standalone);
 }
 
 static void XMLCALL
-dummy_start_doctype_handler(void *UNUSED_P(userData),
-                            const XML_Char *UNUSED_P(doctypeName),
-                            const XML_Char *UNUSED_P(sysid),
-                            const XML_Char *UNUSED_P(pubid),
-                            int UNUSED_P(has_internal_subset)) {
+dummy_start_doctype_handler(void *userData, const XML_Char *doctypeName,
+                            const XML_Char *sysid, const XML_Char *pubid,
+                            int has_internal_subset) {
+  UNUSED_P(userData);
+  UNUSED_P(doctypeName);
+  UNUSED_P(sysid);
+  UNUSED_P(pubid);
+  UNUSED_P(has_internal_subset);
   dummy_handler_flags |= DUMMY_START_DOCTYPE_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_end_doctype_handler(void *UNUSED_P(userData)) {
+dummy_end_doctype_handler(void *userData) {
+  UNUSED_P(userData);
   dummy_handler_flags |= DUMMY_END_DOCTYPE_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_entity_decl_handler(
-    void *UNUSED_P(userData), const XML_Char *UNUSED_P(entityName),
-    int UNUSED_P(is_parameter_entity), const XML_Char *UNUSED_P(value),
-    int UNUSED_P(value_length), const XML_Char *UNUSED_P(base),
-    const XML_Char *UNUSED_P(systemId), const XML_Char *UNUSED_P(publicId),
-    const XML_Char *UNUSED_P(notationName)) {
+dummy_entity_decl_handler(void *userData, const XML_Char *entityName,
+                          int is_parameter_entity, const XML_Char *value,
+                          int value_length, const XML_Char *base,
+                          const XML_Char *systemId, const XML_Char *publicId,
+                          const XML_Char *notationName) {
+  UNUSED_P(userData);
+  UNUSED_P(entityName);
+  UNUSED_P(is_parameter_entity);
+  UNUSED_P(value);
+  UNUSED_P(value_length);
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
+  UNUSED_P(notationName);
   dummy_handler_flags |= DUMMY_ENTITY_DECL_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_notation_decl_handler(void *UNUSED_P(userData),
-                            const XML_Char *UNUSED_P(notationName),
-                            const XML_Char *UNUSED_P(base),
-                            const XML_Char *UNUSED_P(systemId),
-                            const XML_Char *UNUSED_P(publicId)) {
+dummy_notation_decl_handler(void *userData, const XML_Char *notationName,
+                            const XML_Char *base, const XML_Char *systemId,
+                            const XML_Char *publicId) {
+  UNUSED_P(userData);
+  UNUSED_P(notationName);
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   dummy_handler_flags |= DUMMY_NOTATION_DECL_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_element_decl_handler(void *UNUSED_P(userData),
-                           const XML_Char *UNUSED_P(name), XML_Content *model) {
+dummy_element_decl_handler(void *userData, const XML_Char *name,
+                           XML_Content *model) {
+  UNUSED_P(userData);
+  UNUSED_P(name);
   /* The content model must be freed by the handler.  Unfortunately
    * we cannot pass the parser as the userData because this is used
    * with other handlers that require other userData.
@@ -252,62 +272,80 @@ dummy_element_decl_handler(void *UNUSED_P(userData),
 }
 
 static void XMLCALL
-dummy_attlist_decl_handler(void *UNUSED_P(userData),
-                           const XML_Char *UNUSED_P(elname),
-                           const XML_Char *UNUSED_P(attname),
-                           const XML_Char *UNUSED_P(att_type),
-                           const XML_Char *UNUSED_P(dflt),
-                           int UNUSED_P(isrequired)) {
+dummy_attlist_decl_handler(void *userData, const XML_Char *elname,
+                           const XML_Char *attname, const XML_Char *att_type,
+                           const XML_Char *dflt, int isrequired) {
+  UNUSED_P(userData);
+  UNUSED_P(elname);
+  UNUSED_P(attname);
+  UNUSED_P(att_type);
+  UNUSED_P(dflt);
+  UNUSED_P(isrequired);
   dummy_handler_flags |= DUMMY_ATTLIST_DECL_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_comment_handler(void *UNUSED_P(userData),
-                      const XML_Char *UNUSED_P(data)) {
+dummy_comment_handler(void *userData, const XML_Char *data) {
+  UNUSED_P(userData);
+  UNUSED_P(data);
   dummy_handler_flags |= DUMMY_COMMENT_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_pi_handler(void *UNUSED_P(userData), const XML_Char *UNUSED_P(target),
-                 const XML_Char *UNUSED_P(data)) {
+dummy_pi_handler(void *userData, const XML_Char *target, const XML_Char *data) {
+  UNUSED_P(userData);
+  UNUSED_P(target);
+  UNUSED_P(data);
   dummy_handler_flags |= DUMMY_PI_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_start_element(void *UNUSED_P(userData), const XML_Char *UNUSED_P(name),
-                    const XML_Char **UNUSED_P(atts)) {
+dummy_start_element(void *userData, const XML_Char *name,
+                    const XML_Char **atts) {
+  UNUSED_P(userData);
+  UNUSED_P(name);
+  UNUSED_P(atts);
   dummy_handler_flags |= DUMMY_START_ELEMENT_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_end_element(void *UNUSED_P(userData), const XML_Char *UNUSED_P(name)) {
+dummy_end_element(void *userData, const XML_Char *name) {
+  UNUSED_P(userData);
+  UNUSED_P(name);
 }
 
 static void XMLCALL
-dummy_start_cdata_handler(void *UNUSED_P(userData)) {
+dummy_start_cdata_handler(void *userData) {
+  UNUSED_P(userData);
   dummy_handler_flags |= DUMMY_START_CDATA_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_end_cdata_handler(void *UNUSED_P(userData)) {
+dummy_end_cdata_handler(void *userData) {
+  UNUSED_P(userData);
   dummy_handler_flags |= DUMMY_END_CDATA_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_cdata_handler(void *UNUSED_P(userData), const XML_Char *UNUSED_P(s),
-                    int UNUSED_P(len)) {
+dummy_cdata_handler(void *userData, const XML_Char *s, int len) {
+  UNUSED_P(userData);
+  UNUSED_P(s);
+  UNUSED_P(len);
 }
 
 static void XMLCALL
-dummy_start_namespace_decl_handler(void *UNUSED_P(userData),
-                                   const XML_Char *UNUSED_P(prefix),
-                                   const XML_Char *UNUSED_P(uri)) {
+dummy_start_namespace_decl_handler(void *userData, const XML_Char *prefix,
+                                   const XML_Char *uri) {
+  UNUSED_P(userData);
+  UNUSED_P(prefix);
+  UNUSED_P(uri);
   dummy_handler_flags |= DUMMY_START_NS_DECL_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_end_namespace_decl_handler(void *UNUSED_P(userData),
-                                 const XML_Char *UNUSED_P(prefix)) {
+dummy_end_namespace_decl_handler(void *userData, const XML_Char *prefix) {
+  UNUSED_P(userData);
+  UNUSED_P(prefix);
   dummy_handler_flags |= DUMMY_END_NS_DECL_HANDLER_FLAG;
 }
 
@@ -315,38 +353,51 @@ dummy_end_namespace_decl_handler(void *UNUSED_P(userData),
  * ensure that dealing with the handler is covered by tests.
  */
 static void XMLCALL
-dummy_unparsed_entity_decl_handler(void *UNUSED_P(userData),
-                                   const XML_Char *UNUSED_P(entityName),
-                                   const XML_Char *UNUSED_P(base),
-                                   const XML_Char *UNUSED_P(systemId),
-                                   const XML_Char *UNUSED_P(publicId),
-                                   const XML_Char *UNUSED_P(notationName)) {
+dummy_unparsed_entity_decl_handler(void *userData, const XML_Char *entityName,
+                                   const XML_Char *base,
+                                   const XML_Char *systemId,
+                                   const XML_Char *publicId,
+                                   const XML_Char *notationName) {
+  UNUSED_P(userData);
+  UNUSED_P(entityName);
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
+  UNUSED_P(notationName);
   dummy_handler_flags |= DUMMY_UNPARSED_ENTITY_DECL_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_default_handler(void *UNUSED_P(userData), const XML_Char *UNUSED_P(s),
-                      int UNUSED_P(len)) {
+dummy_default_handler(void *userData, const XML_Char *s, int len) {
+  UNUSED_P(userData);
+  UNUSED_P(s);
+  UNUSED_P(len);
 }
 
 static void XMLCALL
-dummy_start_doctype_decl_handler(void *UNUSED_P(userData),
-                                 const XML_Char *UNUSED_P(doctypeName),
-                                 const XML_Char *UNUSED_P(sysid),
-                                 const XML_Char *UNUSED_P(pubid),
-                                 int UNUSED_P(has_internal_subset)) {
+dummy_start_doctype_decl_handler(void *userData, const XML_Char *doctypeName,
+                                 const XML_Char *sysid, const XML_Char *pubid,
+                                 int has_internal_subset) {
+  UNUSED_P(userData);
+  UNUSED_P(doctypeName);
+  UNUSED_P(sysid);
+  UNUSED_P(pubid);
+  UNUSED_P(has_internal_subset);
   dummy_handler_flags |= DUMMY_START_DOCTYPE_DECL_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_end_doctype_decl_handler(void *UNUSED_P(userData)) {
+dummy_end_doctype_decl_handler(void *userData) {
+  UNUSED_P(userData);
   dummy_handler_flags |= DUMMY_END_DOCTYPE_DECL_HANDLER_FLAG;
 }
 
 static void XMLCALL
-dummy_skip_handler(void *UNUSED_P(userData),
-                   const XML_Char *UNUSED_P(entityName),
-                   int UNUSED_P(is_parameter_entity)) {
+dummy_skip_handler(void *userData, const XML_Char *entityName,
+                   int is_parameter_entity) {
+  UNUSED_P(userData);
+  UNUSED_P(entityName);
+  UNUSED_P(is_parameter_entity);
   dummy_handler_flags |= DUMMY_SKIP_HANDLER_FLAG;
 }
 
@@ -358,12 +409,13 @@ typedef struct ExtOption {
 
 static int XMLCALL
 external_entity_optioner(XML_Parser parser, const XML_Char *context,
-                         const XML_Char *UNUSED_P(base),
-                         const XML_Char *systemId,
-                         const XML_Char *UNUSED_P(publicId)) {
+                         const XML_Char *base, const XML_Char *systemId,
+                         const XML_Char *publicId) {
   ExtOption *options = (ExtOption *)XML_GetUserData(parser);
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(publicId);
   while (options->parse_text != NULL) {
     if (! xcstrcmp(systemId, options->system_id)) {
       enum XML_Status rc;
@@ -392,12 +444,16 @@ static const XML_Char *entity_value_to_match = NULL;
 static int entity_match_flag = ENTITY_MATCH_NOT_FOUND;
 
 static void XMLCALL
-param_entity_match_handler(void *UNUSED_P(userData), const XML_Char *entityName,
+param_entity_match_handler(void *userData, const XML_Char *entityName,
                            int is_parameter_entity, const XML_Char *value,
-                           int value_length, const XML_Char *UNUSED_P(base),
-                           const XML_Char *UNUSED_P(systemId),
-                           const XML_Char *UNUSED_P(publicId),
-                           const XML_Char *UNUSED_P(notationName)) {
+                           int value_length, const XML_Char *base,
+                           const XML_Char *systemId, const XML_Char *publicId,
+                           const XML_Char *notationName) {
+  UNUSED_P(userData);
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
+  UNUSED_P(notationName);
   if (! is_parameter_entity || entity_name_to_match == NULL
       || entity_value_to_match == NULL) {
     return;
@@ -518,10 +574,10 @@ accumulate_characters(void *userData, const XML_Char *s, int len) {
 }
 
 static void XMLCALL
-accumulate_attribute(void *userData, const XML_Char *UNUSED_P(name),
+accumulate_attribute(void *userData, const XML_Char *name,
                      const XML_Char **atts) {
   CharData *storage = (CharData *)userData;
-
+  UNUSED_P(name);
   /* Check there are attributes to deal with */
   if (atts == NULL)
     return;
@@ -1031,8 +1087,9 @@ END_TEST
 #define STRUCT_END_TAG 1
 static void XMLCALL
 start_element_event_handler2(void *userData, const XML_Char *name,
-                             const XML_Char **UNUSED_P(attr)) {
+                             const XML_Char **attr) {
   StructData *storage = (StructData *)userData;
+  UNUSED_P(attr);
   StructData_AddItem(storage, name, XML_GetCurrentColumnNumber(g_parser),
                      XML_GetCurrentLineNumber(g_parser), STRUCT_START_TAG);
 }
@@ -1199,7 +1256,8 @@ END_TEST
 
 static void XMLCALL
 start_element_event_handler(void *userData, const XML_Char *name,
-                            const XML_Char **UNUSED_P(atts)) {
+                            const XML_Char **atts) {
+  UNUSED_P(atts);
   CharData_AppendXMLChars((CharData *)userData, name, -1);
 }
 
@@ -1289,10 +1347,11 @@ testhelper_is_whitespace_normalized(void) {
 }
 
 static void XMLCALL
-check_attr_contains_normalized_whitespace(void *UNUSED_P(userData),
-                                          const XML_Char *UNUSED_P(name),
+check_attr_contains_normalized_whitespace(void *userData, const XML_Char *name,
                                           const XML_Char **atts) {
   int i;
+  UNUSED_P(userData);
+  UNUSED_P(name);
   for (i = 0; atts[i] != NULL; i += 2) {
     const XML_Char *attrname = atts[i];
     const XML_Char *value = atts[i + 1];
@@ -1369,8 +1428,9 @@ END_TEST
 
 /* Regression test for SF bug #584832. */
 static int XMLCALL
-UnknownEncodingHandler(void *UNUSED_P(data), const XML_Char *encoding,
+UnknownEncodingHandler(void *data, const XML_Char *encoding,
                        XML_Encoding *info) {
+  UNUSED_P(data);
   if (xcstrcmp(encoding, XCS("unsupported-encoding")) == 0) {
     int i;
     for (i = 0; i < 256; ++i)
@@ -1397,13 +1457,15 @@ END_TEST
 
 /* Test unrecognised encoding handler */
 static void
-dummy_release(void *UNUSED_P(data)) {
+dummy_release(void *data) {
+  UNUSED_P(data);
 }
 
 static int XMLCALL
-UnrecognisedEncodingHandler(void *UNUSED_P(data),
-                            const XML_Char *UNUSED_P(encoding),
+UnrecognisedEncodingHandler(void *data, const XML_Char *encoding,
                             XML_Encoding *info) {
+  UNUSED_P(data);
+  UNUSED_P(encoding);
   info->data = NULL;
   info->convert = NULL;
   info->release = dummy_release;
@@ -1425,12 +1487,14 @@ END_TEST
 /* Regression test for SF bug #620106. */
 static int XMLCALL
 external_entity_loader(XML_Parser parser, const XML_Char *context,
-                       const XML_Char *UNUSED_P(base),
-                       const XML_Char *UNUSED_P(systemId),
-                       const XML_Char *UNUSED_P(publicId)) {
+                       const XML_Char *base, const XML_Char *systemId,
+                       const XML_Char *publicId) {
   ExtTest *test_data = (ExtTest *)XML_GetUserData(parser);
   XML_Parser extparser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   extparser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (extparser == NULL)
     fail("Could not create external entity parser.");
@@ -1512,12 +1576,14 @@ typedef struct ext_faults {
 
 static int XMLCALL
 external_entity_faulter(XML_Parser parser, const XML_Char *context,
-                        const XML_Char *UNUSED_P(base),
-                        const XML_Char *UNUSED_P(systemId),
-                        const XML_Char *UNUSED_P(publicId)) {
+                        const XML_Char *base, const XML_Char *systemId,
+                        const XML_Char *publicId) {
   XML_Parser ext_parser;
   ExtFaults *fault = (ExtFaults *)XML_GetUserData(parser);
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -1659,7 +1725,8 @@ END_TEST
 
 /* Test that an error is reported if our NotStandalone handler fails */
 static int XMLCALL
-reject_not_standalone_handler(void *UNUSED_P(userData)) {
+reject_not_standalone_handler(void *userData) {
+  UNUSED_P(userData);
   return XML_STATUS_ERROR;
 }
 
@@ -1686,7 +1753,8 @@ END_TEST
 
 /* Test that no error is reported if our NotStandalone handler succeeds */
 static int XMLCALL
-accept_not_standalone_handler(void *UNUSED_P(userData)) {
+accept_not_standalone_handler(void *userData) {
+  UNUSED_P(userData);
   return XML_STATUS_OK;
 }
 
@@ -1912,9 +1980,11 @@ static const char *long_character_data_text
 static XML_Bool resumable = XML_FALSE;
 
 static void
-clearing_aborting_character_handler(void *UNUSED_P(userData),
-                                    const XML_Char *UNUSED_P(s),
-                                    int UNUSED_P(len)) {
+clearing_aborting_character_handler(void *userData, const XML_Char *s,
+                                    int len) {
+  UNUSED_P(userData);
+  UNUSED_P(s);
+  UNUSED_P(len);
   XML_StopParser(g_parser, resumable);
   XML_SetCharacterDataHandler(g_parser, NULL);
 }
@@ -1970,8 +2040,10 @@ END_TEST
 static XML_Bool abortable = XML_FALSE;
 
 static void
-parser_stop_character_handler(void *UNUSED_P(userData),
-                              const XML_Char *UNUSED_P(s), int UNUSED_P(len)) {
+parser_stop_character_handler(void *userData, const XML_Char *s, int len) {
+  UNUSED_P(userData);
+  UNUSED_P(s);
+  UNUSED_P(len);
   XML_StopParser(g_parser, resumable);
   XML_SetCharacterDataHandler(g_parser, NULL);
   if (! resumable) {
@@ -2465,27 +2537,31 @@ START_TEST(test_memory_allocation) {
 END_TEST
 
 static void XMLCALL
-record_default_handler(void *userData, const XML_Char *UNUSED_P(s),
-                       int UNUSED_P(len)) {
+record_default_handler(void *userData, const XML_Char *s, int len) {
+  UNUSED_P(s);
+  UNUSED_P(len);
   CharData_AppendXMLChars((CharData *)userData, XCS("D"), 1);
 }
 
 static void XMLCALL
-record_cdata_handler(void *userData, const XML_Char *UNUSED_P(s),
-                     int UNUSED_P(len)) {
+record_cdata_handler(void *userData, const XML_Char *s, int len) {
+  UNUSED_P(s);
+  UNUSED_P(len);
   CharData_AppendXMLChars((CharData *)userData, XCS("C"), 1);
   XML_DefaultCurrent(g_parser);
 }
 
 static void XMLCALL
-record_cdata_nodefault_handler(void *userData, const XML_Char *UNUSED_P(s),
-                               int UNUSED_P(len)) {
+record_cdata_nodefault_handler(void *userData, const XML_Char *s, int len) {
+  UNUSED_P(s);
+  UNUSED_P(len);
   CharData_AppendXMLChars((CharData *)userData, XCS("c"), 1);
 }
 
 static void XMLCALL
-record_skip_handler(void *userData, const XML_Char *UNUSED_P(entityName),
+record_skip_handler(void *userData, const XML_Char *entityName,
                     int is_parameter_entity) {
+  UNUSED_P(entityName);
   CharData_AppendXMLChars((CharData *)userData,
                           is_parameter_entity ? XCS("E") : XCS("e"), 1);
 }
@@ -2695,11 +2771,14 @@ END_TEST
 
 /* Test XML_UseForeignDTD with no external subset present */
 static int XMLCALL
-external_entity_null_loader(XML_Parser UNUSED_P(parser),
-                            const XML_Char *UNUSED_P(context),
-                            const XML_Char *UNUSED_P(base),
-                            const XML_Char *UNUSED_P(systemId),
-                            const XML_Char *UNUSED_P(publicId)) {
+external_entity_null_loader(XML_Parser parser, const XML_Char *context,
+                            const XML_Char *base, const XML_Char *systemId,
+                            const XML_Char *publicId) {
+  UNUSED_P(parser);
+  UNUSED_P(context);
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   return XML_STATUS_OK;
 }
 
@@ -2922,13 +3001,15 @@ END_TEST
 /* Test resetting a subordinate parser does exactly nothing */
 static int XMLCALL
 external_entity_resetter(XML_Parser parser, const XML_Char *context,
-                         const XML_Char *UNUSED_P(base),
-                         const XML_Char *UNUSED_P(systemId),
-                         const XML_Char *UNUSED_P(publicId)) {
+                         const XML_Char *base, const XML_Char *systemId,
+                         const XML_Char *publicId) {
   const char *text = "<!ELEMENT doc (#PCDATA)*>";
   XML_Parser ext_parser;
   XML_ParsingStatus status;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -2979,10 +3060,11 @@ END_TEST
 /* Test suspending a subordinate parser */
 
 static void XMLCALL
-entity_suspending_decl_handler(void *userData, const XML_Char *UNUSED_P(name),
+entity_suspending_decl_handler(void *userData, const XML_Char *name,
                                XML_Content *model) {
   XML_Parser ext_parser = (XML_Parser)userData;
 
+  UNUSED_P(name);
   if (XML_StopParser(ext_parser, XML_TRUE) != XML_STATUS_ERROR)
     fail("Attempting to suspend a subordinate parser not faulted");
   if (XML_GetErrorCode(ext_parser) != XML_ERROR_SUSPEND_PE)
@@ -2993,12 +3075,14 @@ entity_suspending_decl_handler(void *userData, const XML_Char *UNUSED_P(name),
 
 static int XMLCALL
 external_entity_suspender(XML_Parser parser, const XML_Char *context,
-                          const XML_Char *UNUSED_P(base),
-                          const XML_Char *UNUSED_P(systemId),
-                          const XML_Char *UNUSED_P(publicId)) {
+                          const XML_Char *base, const XML_Char *systemId,
+                          const XML_Char *publicId) {
   const char *text = "<!ELEMENT doc (#PCDATA)*>";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -3029,26 +3113,29 @@ END_TEST
 /* Test suspending a subordinate parser from an XML declaration */
 /* Increases code coverage of the tests */
 static void XMLCALL
-entity_suspending_xdecl_handler(void *userData,
-                                const XML_Char *UNUSED_P(version),
-                                const XML_Char *UNUSED_P(encoding),
-                                int UNUSED_P(standalone)) {
+entity_suspending_xdecl_handler(void *userData, const XML_Char *version,
+                                const XML_Char *encoding, int standalone) {
   XML_Parser ext_parser = (XML_Parser)userData;
 
+  UNUSED_P(version);
+  UNUSED_P(encoding);
+  UNUSED_P(standalone);
   XML_StopParser(ext_parser, resumable);
   XML_SetXmlDeclHandler(ext_parser, NULL);
 }
 
 static int XMLCALL
 external_entity_suspend_xmldecl(XML_Parser parser, const XML_Char *context,
-                                const XML_Char *UNUSED_P(base),
-                                const XML_Char *UNUSED_P(systemId),
-                                const XML_Char *UNUSED_P(publicId)) {
+                                const XML_Char *base, const XML_Char *systemId,
+                                const XML_Char *publicId) {
   const char *text = "<?xml version='1.0' encoding='us-ascii'?>";
   XML_Parser ext_parser;
   XML_ParsingStatus status;
   enum XML_Status rc;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -3109,14 +3196,17 @@ END_TEST
 /* Test external entity fault handling with suspension */
 static int XMLCALL
 external_entity_suspending_faulter(XML_Parser parser, const XML_Char *context,
-                                   const XML_Char *UNUSED_P(base),
-                                   const XML_Char *UNUSED_P(systemId),
-                                   const XML_Char *UNUSED_P(publicId)) {
+                                   const XML_Char *base,
+                                   const XML_Char *systemId,
+                                   const XML_Char *publicId) {
   XML_Parser ext_parser;
   ExtFaults *fault = (ExtFaults *)XML_GetUserData(parser);
   void *buffer;
   int parse_len = (int)strlen(fault->parse_text);
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -3236,12 +3326,14 @@ END_TEST
 /* Test trailing CR in an external entity parse */
 static int XMLCALL
 external_entity_cr_catcher(XML_Parser parser, const XML_Char *context,
-                           const XML_Char *UNUSED_P(base),
-                           const XML_Char *UNUSED_P(systemId),
-                           const XML_Char *UNUSED_P(publicId)) {
+                           const XML_Char *base, const XML_Char *systemId,
+                           const XML_Char *publicId) {
   const char *text = "\r";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -3255,12 +3347,14 @@ external_entity_cr_catcher(XML_Parser parser, const XML_Char *context,
 
 static int XMLCALL
 external_entity_bad_cr_catcher(XML_Parser parser, const XML_Char *context,
-                               const XML_Char *UNUSED_P(base),
-                               const XML_Char *UNUSED_P(systemId),
-                               const XML_Char *UNUSED_P(publicId)) {
+                               const XML_Char *base, const XML_Char *systemId,
+                               const XML_Char *publicId) {
   const char *text = "<tag>\r";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -3358,12 +3452,14 @@ END_TEST
 /* Test trailing right square bracket in an external entity parse */
 static int XMLCALL
 external_entity_rsqb_catcher(XML_Parser parser, const XML_Char *context,
-                             const XML_Char *UNUSED_P(base),
-                             const XML_Char *UNUSED_P(systemId),
-                             const XML_Char *UNUSED_P(publicId)) {
+                             const XML_Char *base, const XML_Char *systemId,
+                             const XML_Char *publicId) {
   const char *text = "<tag>]";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -3399,14 +3495,16 @@ END_TEST
 /* Test CDATA handling in an external entity */
 static int XMLCALL
 external_entity_good_cdata_ascii(XML_Parser parser, const XML_Char *context,
-                                 const XML_Char *UNUSED_P(base),
-                                 const XML_Char *UNUSED_P(systemId),
-                                 const XML_Char *UNUSED_P(publicId)) {
+                                 const XML_Char *base, const XML_Char *systemId,
+                                 const XML_Char *publicId) {
   const char *text = "<a><![CDATA[<greeting>Hello, world!</greeting>]]></a>";
   const XML_Char *expected = XCS("<greeting>Hello, world!</greeting>");
   CharData storage;
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   CharData_Init(&storage);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
@@ -3448,8 +3546,10 @@ static int skip_count = 0;
 static int xdecl_count = 0;
 
 static void XMLCALL
-xml_decl_handler(void *userData, const XML_Char *UNUSED_P(version),
-                 const XML_Char *UNUSED_P(encoding), int standalone) {
+xml_decl_handler(void *userData, const XML_Char *version,
+                 const XML_Char *encoding, int standalone) {
+  UNUSED_P(version);
+  UNUSED_P(encoding);
   if (userData != handler_data)
     fail("User data (xml decl) not correctly set");
   if (standalone != -1)
@@ -3458,15 +3558,18 @@ xml_decl_handler(void *userData, const XML_Char *UNUSED_P(version),
 }
 
 static void XMLCALL
-param_check_skip_handler(void *userData, const XML_Char *UNUSED_P(entityName),
-                         int UNUSED_P(is_parameter_entity)) {
+param_check_skip_handler(void *userData, const XML_Char *entityName,
+                         int is_parameter_entity) {
+  UNUSED_P(entityName);
+  UNUSED_P(is_parameter_entity);
   if (userData != handler_data)
     fail("User data (skip) not correctly set");
   skip_count++;
 }
 
 static void XMLCALL
-data_check_comment_handler(void *userData, const XML_Char *UNUSED_P(data)) {
+data_check_comment_handler(void *userData, const XML_Char *data) {
+  UNUSED_P(data);
   /* Check that the userData passed through is what we expect */
   if (userData != handler_data)
     fail("User data (parser) not correctly set");
@@ -3478,13 +3581,15 @@ data_check_comment_handler(void *userData, const XML_Char *UNUSED_P(data)) {
 
 static int XMLCALL
 external_entity_param_checker(XML_Parser parser, const XML_Char *context,
-                              const XML_Char *UNUSED_P(base),
-                              const XML_Char *UNUSED_P(systemId),
-                              const XML_Char *UNUSED_P(publicId)) {
+                              const XML_Char *base, const XML_Char *systemId,
+                              const XML_Char *publicId) {
   const char *text = "<!-- Subordinate parser -->\n"
                      "<!ELEMENT doc (#PCDATA)*>";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -3549,12 +3654,15 @@ END_TEST
  */
 static int XMLCALL
 external_entity_ref_param_checker(XML_Parser parameter, const XML_Char *context,
-                                  const XML_Char *UNUSED_P(base),
-                                  const XML_Char *UNUSED_P(systemId),
-                                  const XML_Char *UNUSED_P(publicId)) {
+                                  const XML_Char *base,
+                                  const XML_Char *systemId,
+                                  const XML_Char *publicId) {
   const char *text = "<!ELEMENT doc (#PCDATA)*>";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   if ((void *)parameter != handler_data)
     fail("External entity ref handler parameter not correct");
 
@@ -3782,12 +3890,13 @@ typedef struct ByteTestData {
 } ByteTestData;
 
 static void
-byte_character_handler(void *userData, const XML_Char *UNUSED_P(s), int len) {
+byte_character_handler(void *userData, const XML_Char *s, int len) {
 #ifdef XML_CONTEXT_BYTES
   int offset, size;
   const char *buffer;
   ByteTestData *data = (ByteTestData *)userData;
 
+  UNUSED_P(s);
   buffer = XML_GetInputContext(g_parser, &offset, &size);
   if (buffer == NULL)
     fail("Failed to get context buffer");
@@ -3802,8 +3911,9 @@ byte_character_handler(void *userData, const XML_Char *UNUSED_P(s), int len) {
   if (XML_GetCurrentByteCount(g_parser) != len)
     fail("Character byte count incorrect");
 #else
-  (void)userData;
-  (void)len;
+  UNUSED_P(s);
+  UNUSED_P(userData);
+  UNUSED_P(len);
 #endif
 }
 
@@ -3867,8 +3977,8 @@ END_TEST
  */
 static int XMLCALL
 external_entity_param(XML_Parser parser, const XML_Char *context,
-                      const XML_Char *UNUSED_P(base), const XML_Char *systemId,
-                      const XML_Char *UNUSED_P(publicId)) {
+                      const XML_Char *base, const XML_Char *systemId,
+                      const XML_Char *publicId) {
   const char *text1 = "<!ELEMENT doc EMPTY>\n"
                       "<!ENTITY % e1 SYSTEM '004-2.ent'>\n"
                       "<!ENTITY % e2 '%e1;'>\n"
@@ -3877,6 +3987,8 @@ external_entity_param(XML_Parser parser, const XML_Char *context,
                       "<el/>\n";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(publicId);
   if (systemId == NULL)
     return XML_STATUS_OK;
 
@@ -3933,12 +4045,14 @@ END_TEST
 /* Test conditional inclusion (IGNORE) */
 static int XMLCALL
 external_entity_load_ignore(XML_Parser parser, const XML_Char *context,
-                            const XML_Char *UNUSED_P(base),
-                            const XML_Char *UNUSED_P(systemId),
-                            const XML_Char *UNUSED_P(publicId)) {
+                            const XML_Char *base, const XML_Char *systemId,
+                            const XML_Char *publicId) {
   const char *text = "<![IGNORE[<!ELEMENT e (#PCDATA)*>]]>";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -3976,9 +4090,9 @@ END_TEST
 
 static int XMLCALL
 external_entity_load_ignore_utf16(XML_Parser parser, const XML_Char *context,
-                                  const XML_Char *UNUSED_P(base),
-                                  const XML_Char *UNUSED_P(systemId),
-                                  const XML_Char *UNUSED_P(publicId)) {
+                                  const XML_Char *base,
+                                  const XML_Char *systemId,
+                                  const XML_Char *publicId) {
   const char text[] =
       /* <![IGNORE[<!ELEMENT e (#PCDATA)*>]]> */
       "<\0!\0[\0I\0G\0N\0O\0R\0E\0[\0"
@@ -3986,6 +4100,9 @@ external_entity_load_ignore_utf16(XML_Parser parser, const XML_Char *context,
       "(\0#\0P\0C\0D\0A\0T\0A\0)\0*\0>\0]\0]\0>\0";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -4026,9 +4143,9 @@ END_TEST
 
 static int XMLCALL
 external_entity_load_ignore_utf16_be(XML_Parser parser, const XML_Char *context,
-                                     const XML_Char *UNUSED_P(base),
-                                     const XML_Char *UNUSED_P(systemId),
-                                     const XML_Char *UNUSED_P(publicId)) {
+                                     const XML_Char *base,
+                                     const XML_Char *systemId,
+                                     const XML_Char *publicId) {
   const char text[] =
       /* <![IGNORE[<!ELEMENT e (#PCDATA)*>]]> */
       "\0<\0!\0[\0I\0G\0N\0O\0R\0E\0["
@@ -4036,6 +4153,9 @@ external_entity_load_ignore_utf16_be(XML_Parser parser, const XML_Char *context,
       "\0(\0#\0P\0C\0D\0A\0T\0A\0)\0*\0>\0]\0]\0>";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -4104,14 +4224,16 @@ END_TEST
 /* Test recursive parsing */
 static int XMLCALL
 external_entity_valuer(XML_Parser parser, const XML_Char *context,
-                       const XML_Char *UNUSED_P(base), const XML_Char *systemId,
-                       const XML_Char *UNUSED_P(publicId)) {
+                       const XML_Char *base, const XML_Char *systemId,
+                       const XML_Char *publicId) {
   const char *text1 = "<!ELEMENT doc EMPTY>\n"
                       "<!ENTITY % e1 SYSTEM '004-2.ent'>\n"
                       "<!ENTITY % e2 '%e1;'>\n"
                       "%e1;\n";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(publicId);
   if (systemId == NULL)
     return XML_STATUS_OK;
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
@@ -4192,15 +4314,16 @@ END_TEST
 /* Test the recursive parse interacts with a not standalone handler */
 static int XMLCALL
 external_entity_not_standalone(XML_Parser parser, const XML_Char *context,
-                               const XML_Char *UNUSED_P(base),
-                               const XML_Char *systemId,
-                               const XML_Char *UNUSED_P(publicId)) {
+                               const XML_Char *base, const XML_Char *systemId,
+                               const XML_Char *publicId) {
   const char *text1 = "<!ELEMENT doc EMPTY>\n"
                       "<!ENTITY % e1 SYSTEM 'bar'>\n"
                       "%e1;\n";
   const char *text2 = "<!ATTLIST doc a1 CDATA 'value'>";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(publicId);
   if (systemId == NULL)
     return XML_STATUS_OK;
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
@@ -4239,9 +4362,8 @@ END_TEST
 
 static int XMLCALL
 external_entity_value_aborter(XML_Parser parser, const XML_Char *context,
-                              const XML_Char *UNUSED_P(base),
-                              const XML_Char *systemId,
-                              const XML_Char *UNUSED_P(publicId)) {
+                              const XML_Char *base, const XML_Char *systemId,
+                              const XML_Char *publicId) {
   const char *text1 = "<!ELEMENT doc EMPTY>\n"
                       "<!ENTITY % e1 SYSTEM '004-2.ent'>\n"
                       "<!ENTITY % e2 '%e1;'>\n"
@@ -4249,6 +4371,8 @@ external_entity_value_aborter(XML_Parser parser, const XML_Char *context,
   const char *text2 = "<?xml version='1.0' encoding='utf-8'?>";
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(publicId);
   if (systemId == NULL)
     return XML_STATUS_OK;
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
@@ -4371,7 +4495,8 @@ END_TEST
 
 static void XMLCALL
 record_element_start_handler(void *userData, const XML_Char *name,
-                             const XML_Char **UNUSED_P(atts)) {
+                             const XML_Char **atts) {
+  UNUSED_P(atts);
   CharData_AppendXMLChars((CharData *)userData, name, (int)xcstrlen(name));
 }
 
@@ -4427,7 +4552,7 @@ END_TEST
 
 static int XMLCALL
 external_entity_public(XML_Parser parser, const XML_Char *context,
-                       const XML_Char *UNUSED_P(base), const XML_Char *systemId,
+                       const XML_Char *base, const XML_Char *systemId,
                        const XML_Char *publicId) {
   const char *text1 = (const char *)XML_GetUserData(parser);
   const char *text2 = "<!ATTLIST doc a CDATA 'value'>";
@@ -4435,6 +4560,7 @@ external_entity_public(XML_Parser parser, const XML_Char *context,
   XML_Parser ext_parser;
   int parse_res;
 
+  UNUSED_P(base);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     return XML_STATUS_ERROR;
@@ -4514,15 +4640,16 @@ END_TEST
 /* Test undefined parameter entity in external entity handler */
 static int XMLCALL
 external_entity_devaluer(XML_Parser parser, const XML_Char *context,
-                         const XML_Char *UNUSED_P(base),
-                         const XML_Char *systemId,
-                         const XML_Char *UNUSED_P(publicId)) {
+                         const XML_Char *base, const XML_Char *systemId,
+                         const XML_Char *publicId) {
   const char *text = "<!ELEMENT doc EMPTY>\n"
                      "<!ENTITY % e1 SYSTEM 'bar'>\n"
                      "%e1;\n";
   XML_Parser ext_parser;
   intptr_t clear_handler = (intptr_t)XML_GetUserData(parser);
 
+  UNUSED_P(base);
+  UNUSED_P(publicId);
   if (systemId == NULL || ! xcstrcmp(systemId, XCS("bar")))
     return XML_STATUS_OK;
   if (xcstrcmp(systemId, XCS("foo")))
@@ -4565,10 +4692,12 @@ START_TEST(test_undefined_ext_entity_in_external_dtd) {
 END_TEST
 
 static void XMLCALL
-aborting_xdecl_handler(void *UNUSED_P(userData),
-                       const XML_Char *UNUSED_P(version),
-                       const XML_Char *UNUSED_P(encoding),
-                       int UNUSED_P(standalone)) {
+aborting_xdecl_handler(void *userData, const XML_Char *version,
+                       const XML_Char *encoding, int standalone) {
+  UNUSED_P(userData);
+  UNUSED_P(version);
+  UNUSED_P(encoding);
+  UNUSED_P(standalone);
   XML_StopParser(g_parser, resumable);
   XML_SetXmlDeclHandler(g_parser, NULL);
 }
@@ -4647,7 +4776,8 @@ START_TEST(test_suspend_epilog) {
 END_TEST
 
 static void XMLCALL
-suspending_end_handler(void *userData, const XML_Char *UNUSED_P(s)) {
+suspending_end_handler(void *userData, const XML_Char *s) {
+  UNUSED_P(s);
   XML_StopParser((XML_Parser)userData, 1);
 }
 
@@ -4723,8 +4853,10 @@ END_TEST
 
 /* Test resuming a parse suspended in entity substitution */
 static void XMLCALL
-start_element_suspender(void *UNUSED_P(userData), const XML_Char *name,
-                        const XML_Char **UNUSED_P(atts)) {
+start_element_suspender(void *userData, const XML_Char *name,
+                        const XML_Char **atts) {
+  UNUSED_P(userData);
+  UNUSED_P(atts);
   if (! xcstrcmp(name, XCS("suspend")))
     XML_StopParser(g_parser, XML_TRUE);
   if (! xcstrcmp(name, XCS("abort")))
@@ -4778,8 +4910,10 @@ END_TEST
 
 /* Test suspending and resuming in a parameter entity substitution */
 static void XMLCALL
-element_decl_suspender(void *UNUSED_P(userData), const XML_Char *UNUSED_P(name),
+element_decl_suspender(void *userData, const XML_Char *name,
                        XML_Content *model) {
+  UNUSED_P(userData);
+  UNUSED_P(name);
   XML_StopParser(g_parser, XML_TRUE);
   XML_FreeContentModel(g_parser, model);
 }
@@ -4897,12 +5031,14 @@ typedef struct ext_hdlr_data {
 
 static int XMLCALL
 external_entity_oneshot_loader(XML_Parser parser, const XML_Char *context,
-                               const XML_Char *UNUSED_P(base),
-                               const XML_Char *UNUSED_P(systemId),
-                               const XML_Char *UNUSED_P(publicId)) {
+                               const XML_Char *base, const XML_Char *systemId,
+                               const XML_Char *publicId) {
   ExtHdlrData *test_data = (ExtHdlrData *)XML_GetUserData(parser);
   XML_Parser ext_parser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser.");
@@ -5232,13 +5368,16 @@ END_TEST
  * conversion but no conversion function is faulted
  */
 static int XMLCALL
-failing_converter(void *UNUSED_P(data), const char *UNUSED_P(s)) {
+failing_converter(void *data, const char *s) {
+  UNUSED_P(data);
+  UNUSED_P(s);
   /* Always claim to have failed */
   return -1;
 }
 
 static int XMLCALL
-prefix_converter(void *UNUSED_P(data), const char *s) {
+prefix_converter(void *data, const char *s) {
+  UNUSED_P(data);
   /* If the first byte is 0xff, raise an error */
   if (s[0] == (char)-1)
     return -1;
@@ -5495,12 +5634,14 @@ typedef struct ExtTest2 {
 
 static int XMLCALL
 external_entity_loader2(XML_Parser parser, const XML_Char *context,
-                        const XML_Char *UNUSED_P(base),
-                        const XML_Char *UNUSED_P(systemId),
-                        const XML_Char *UNUSED_P(publicId)) {
+                        const XML_Char *base, const XML_Char *systemId,
+                        const XML_Char *publicId) {
   ExtTest2 *test_data = (ExtTest2 *)XML_GetUserData(parser);
   XML_Parser extparser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   extparser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (extparser == NULL)
     fail("Coulr not create external entity parser");
@@ -5736,12 +5877,14 @@ typedef struct ExtFaults2 {
 
 static int XMLCALL
 external_entity_faulter2(XML_Parser parser, const XML_Char *context,
-                         const XML_Char *UNUSED_P(base),
-                         const XML_Char *UNUSED_P(systemId),
-                         const XML_Char *UNUSED_P(publicId)) {
+                         const XML_Char *base, const XML_Char *systemId,
+                         const XML_Char *publicId) {
   ExtFaults2 *test_data = (ExtFaults2 *)XML_GetUserData(parser);
   XML_Parser extparser;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   extparser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (extparser == NULL)
     fail("Could not create external entity parser");
@@ -5904,13 +6047,17 @@ END_TEST
 
 static void XMLCALL
 accumulate_entity_decl(void *userData, const XML_Char *entityName,
-                       int UNUSED_P(is_parameter_entity), const XML_Char *value,
-                       int value_length, const XML_Char *UNUSED_P(base),
-                       const XML_Char *UNUSED_P(systemId),
-                       const XML_Char *UNUSED_P(publicId),
-                       const XML_Char *UNUSED_P(notationName)) {
+                       int is_parameter_entity, const XML_Char *value,
+                       int value_length, const XML_Char *base,
+                       const XML_Char *systemId, const XML_Char *publicId,
+                       const XML_Char *notationName) {
   CharData *storage = (CharData *)userData;
 
+  UNUSED_P(is_parameter_entity);
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
+  UNUSED_P(notationName);
   CharData_AppendXMLChars(storage, entityName, -1);
   CharData_AppendXMLChars(storage, XCS("="), 1);
   CharData_AppendXMLChars(storage, value, value_length);
@@ -6469,16 +6616,21 @@ END_TEST
 
 /* Regression test for SF bug #620343. */
 static void XMLCALL
-start_element_fail(void *UNUSED_P(userData), const XML_Char *UNUSED_P(name),
-                   const XML_Char **UNUSED_P(atts)) {
+start_element_fail(void *userData, const XML_Char *name,
+                   const XML_Char **atts) {
+  UNUSED_P(userData);
+  UNUSED_P(name);
+  UNUSED_P(atts);
+
   /* We should never get here. */
   fail("should never reach start_element_fail()");
 }
 
 static void XMLCALL
-start_ns_clearing_start_element(void *userData,
-                                const XML_Char *UNUSED_P(prefix),
-                                const XML_Char *UNUSED_P(uri)) {
+start_ns_clearing_start_element(void *userData, const XML_Char *prefix,
+                                const XML_Char *uri) {
+  UNUSED_P(prefix);
+  UNUSED_P(uri);
   XML_SetStartElementHandler((XML_Parser)userData, NULL);
 }
 
@@ -6502,13 +6654,15 @@ END_TEST
 /* Regression test for SF bug #616863. */
 static int XMLCALL
 external_entity_handler(XML_Parser parser, const XML_Char *context,
-                        const XML_Char *UNUSED_P(base),
-                        const XML_Char *UNUSED_P(systemId),
-                        const XML_Char *UNUSED_P(publicId)) {
+                        const XML_Char *base, const XML_Char *systemId,
+                        const XML_Char *publicId) {
   intptr_t callno = 1 + (intptr_t)XML_GetUserData(parser);
   const char *text;
   XML_Parser p2;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   if (callno == 1)
     text = ("<!ELEMENT doc (e+)>\n"
             "<!ATTLIST doc xmlns CDATA #IMPLIED>\n"
@@ -7265,15 +7419,19 @@ typedef struct {
 } DataIssue240;
 
 static void
-start_element_issue_240(void *userData, const XML_Char *UNUSED_P(name),
-                        const XML_Char **UNUSED_P(atts)) {
+start_element_issue_240(void *userData, const XML_Char *name,
+                        const XML_Char **atts) {
   DataIssue240 *mydata = (DataIssue240 *)userData;
+  UNUSED_P(name);
+  UNUSED_P(atts);
   mydata->deep++;
 }
 
 static void
-end_element_issue_240(void *userData, const XML_Char *UNUSED_P(name)) {
+end_element_issue_240(void *userData, const XML_Char *name) {
   DataIssue240 *mydata = (DataIssue240 *)userData;
+
+  UNUSED_P(name);
   mydata->deep--;
   if (mydata->deep == 0) {
     XML_StopParser(mydata->parser, 0);
@@ -7371,10 +7529,12 @@ END_TEST
  * version information to expand the string pool being used.
  */
 static int XMLCALL
-long_encoding_handler(void *UNUSED_P(userData),
-                      const XML_Char *UNUSED_P(encoding), XML_Encoding *info) {
+long_encoding_handler(void *userData, const XML_Char *encoding,
+                      XML_Encoding *info) {
   int i;
 
+  UNUSED_P(userData);
+  UNUSED_P(encoding);
   for (i = 0; i < 256; i++)
     info->map[i] = i;
   info->data = NULL;
@@ -7572,13 +7732,15 @@ END_TEST
 
 static int XMLCALL
 external_entity_duff_loader(XML_Parser parser, const XML_Char *context,
-                            const XML_Char *UNUSED_P(base),
-                            const XML_Char *UNUSED_P(systemId),
-                            const XML_Char *UNUSED_P(publicId)) {
+                            const XML_Char *base, const XML_Char *systemId,
+                            const XML_Char *publicId) {
   XML_Parser new_parser;
   unsigned int i;
   const unsigned int max_alloc_count = 10;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   /* Try a few different allocation levels */
   for (i = 0; i < max_alloc_count; i++) {
     allocation_count = i;
@@ -7649,15 +7811,17 @@ END_TEST
 
 static int XMLCALL
 external_entity_dbl_handler(XML_Parser parser, const XML_Char *context,
-                            const XML_Char *UNUSED_P(base),
-                            const XML_Char *UNUSED_P(systemId),
-                            const XML_Char *UNUSED_P(publicId)) {
+                            const XML_Char *base, const XML_Char *systemId,
+                            const XML_Char *publicId) {
   intptr_t callno = (intptr_t)XML_GetUserData(parser);
   const char *text;
   XML_Parser new_parser;
   int i;
   const int max_alloc_count = 20;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   if (callno == 0) {
     /* First time through, check how many calls to malloc occur */
     text = ("<!ELEMENT doc (e+)>\n"
@@ -7724,14 +7888,16 @@ END_TEST
 
 static int XMLCALL
 external_entity_dbl_handler_2(XML_Parser parser, const XML_Char *context,
-                              const XML_Char *UNUSED_P(base),
-                              const XML_Char *UNUSED_P(systemId),
-                              const XML_Char *UNUSED_P(publicId)) {
+                              const XML_Char *base, const XML_Char *systemId,
+                              const XML_Char *publicId) {
   intptr_t callno = (intptr_t)XML_GetUserData(parser);
   const char *text;
   XML_Parser new_parser;
   enum XML_Status rv;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   if (callno == 0) {
     /* Try different allocation levels for whole exercise */
     text = ("<!ELEMENT doc (e+)>\n"
@@ -7793,15 +7959,18 @@ END_TEST
 /* Test more allocation failure paths */
 static int XMLCALL
 external_entity_alloc_set_encoding(XML_Parser parser, const XML_Char *context,
-                                   const XML_Char *UNUSED_P(base),
-                                   const XML_Char *UNUSED_P(systemId),
-                                   const XML_Char *UNUSED_P(publicId)) {
+                                   const XML_Char *base,
+                                   const XML_Char *systemId,
+                                   const XML_Char *publicId) {
   /* As for external_entity_loader() */
   const char *text = "<?xml encoding='iso-8859-3'?>"
                      "\xC3\xA9";
   XML_Parser ext_parser;
   enum XML_Status status;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     return XML_STATUS_ERROR;
@@ -7845,9 +8014,9 @@ START_TEST(test_alloc_ext_entity_set_encoding) {
 END_TEST
 
 static int XMLCALL
-unknown_released_encoding_handler(void *UNUSED_P(data),
-                                  const XML_Char *encoding,
+unknown_released_encoding_handler(void *data, const XML_Char *encoding,
                                   XML_Encoding *info) {
+  UNUSED_P(data);
   if (! xcstrcmp(encoding, XCS("unsupported-encoding"))) {
     int i;
 
@@ -8018,14 +8187,16 @@ END_TEST
 /* Same test for external entity parsers */
 static int XMLCALL
 external_entity_reallocator(XML_Parser parser, const XML_Char *context,
-                            const XML_Char *UNUSED_P(base),
-                            const XML_Char *UNUSED_P(systemId),
-                            const XML_Char *UNUSED_P(publicId)) {
+                            const XML_Char *base, const XML_Char *systemId,
+                            const XML_Char *publicId) {
   const char *text = get_buffer_test_text;
   XML_Parser ext_parser;
   void *buffer;
   enum XML_Status status;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
@@ -8323,13 +8494,15 @@ END_TEST
 
 static int XMLCALL
 external_entity_alloc(XML_Parser parser, const XML_Char *context,
-                      const XML_Char *UNUSED_P(base),
-                      const XML_Char *UNUSED_P(systemId),
-                      const XML_Char *UNUSED_P(publicId)) {
+                      const XML_Char *base, const XML_Char *systemId,
+                      const XML_Char *publicId) {
   const char *text = (const char *)XML_GetUserData(parser);
   XML_Parser ext_parser;
   int parse_res;
 
+  UNUSED_P(base);
+  UNUSED_P(systemId);
+  UNUSED_P(publicId);
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     return XML_STATUS_ERROR;

--- a/expat/xmlwf/codepage.c
+++ b/expat/xmlwf/codepage.c
@@ -83,12 +83,16 @@ codepageConvert(int cp, const char *p) {
 #else /* not _WIN32 */
 
 int
-codepageMap(int UNUSED_P(cp), int *UNUSED_P(map)) {
+codepageMap(int cp, int *map) {
+  UNUSED_P(cp);
+  UNUSED_P(map);
   return 0;
 }
 
 int
-codepageConvert(int UNUSED_P(cp), const char *UNUSED_P(p)) {
+codepageConvert(int cp, const char *p) {
+  UNUSED_P(cp);
+  UNUSED_P(p);
   return -1;
 }
 

--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -144,13 +144,14 @@ resolveSystemId(const XML_Char *base, const XML_Char *systemId,
 static int
 externalEntityRefFilemap(XML_Parser parser, const XML_Char *context,
                          const XML_Char *base, const XML_Char *systemId,
-                         const XML_Char *UNUSED_P(publicId)) {
+                         const XML_Char *publicId) {
   int result;
   XML_Char *s;
   const XML_Char *filename;
   XML_Parser entParser = XML_ExternalEntityParserCreate(parser, context, 0);
   int filemapRes;
   PROCESS_ARGS args;
+  UNUSED_P(publicId);
   args.retPtr = &result;
   args.parser = entParser;
   filename = resolveSystemId(base, systemId, &s);
@@ -221,11 +222,12 @@ processStream(const XML_Char *filename, XML_Parser parser) {
 static int
 externalEntityRefStream(XML_Parser parser, const XML_Char *context,
                         const XML_Char *base, const XML_Char *systemId,
-                        const XML_Char *UNUSED_P(publicId)) {
+                        const XML_Char *publicId) {
   XML_Char *s;
   const XML_Char *filename;
   int ret;
   XML_Parser entParser = XML_ExternalEntityParserCreate(parser, context, 0);
+  UNUSED_P(publicId);
   filename = resolveSystemId(base, systemId, &s);
   XML_SetBase(entParser, filename);
   ret = processStream(filename, entParser);

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -298,10 +298,12 @@ xcsdup(const XML_Char *s) {
 
 static void XMLCALL
 startDoctypeDecl(void *userData, const XML_Char *doctypeName,
-                 const XML_Char *UNUSED_P(sysid),
-                 const XML_Char *UNUSED_P(publid),
-                 int UNUSED_P(has_internal_subset)) {
+                 const XML_Char *sysid, const XML_Char *publid,
+                 int has_internal_subset) {
   XmlwfUserData *data = (XmlwfUserData *)userData;
+  UNUSED_P(sysid);
+  UNUSED_P(publid);
+  UNUSED_P(has_internal_subset);
   data->currentDoctypeName = xcsdup(doctypeName);
 }
 
@@ -413,13 +415,13 @@ endDoctypeDecl(void *userData) {
 }
 
 static void XMLCALL
-notationDecl(void *userData, const XML_Char *notationName,
-             const XML_Char *UNUSED_P(base), const XML_Char *systemId,
-             const XML_Char *publicId) {
+notationDecl(void *userData, const XML_Char *notationName, const XML_Char *base,
+             const XML_Char *systemId, const XML_Char *publicId) {
   XmlwfUserData *data = (XmlwfUserData *)userData;
   NotationList *entry = malloc(sizeof(NotationList));
   const char *errorMessage = "Unable to store NOTATION for output\n";
 
+  UNUSED_P(base);
   if (entry == NULL) {
     fputs(errorMessage, stderr);
     return; /* Nothing we can really do about this */
@@ -461,46 +463,60 @@ notationDecl(void *userData, const XML_Char *notationName,
 #endif /* not W3C14N */
 
 static void XMLCALL
-defaultCharacterData(void *userData, const XML_Char *UNUSED_P(s),
-                     int UNUSED_P(len)) {
+defaultCharacterData(void *userData, const XML_Char *s, int len) {
+  UNUSED_P(s);
+  UNUSED_P(len);
   XML_DefaultCurrent((XML_Parser)userData);
 }
 
 static void XMLCALL
-defaultStartElement(void *userData, const XML_Char *UNUSED_P(name),
-                    const XML_Char **UNUSED_P(atts)) {
+defaultStartElement(void *userData, const XML_Char *name,
+                    const XML_Char **atts) {
+  UNUSED_P(name);
+  UNUSED_P(atts);
   XML_DefaultCurrent((XML_Parser)userData);
 }
 
 static void XMLCALL
-defaultEndElement(void *userData, const XML_Char *UNUSED_P(name)) {
+defaultEndElement(void *userData, const XML_Char *name) {
+  UNUSED_P(name);
   XML_DefaultCurrent((XML_Parser)userData);
 }
 
 static void XMLCALL
-defaultProcessingInstruction(void *userData, const XML_Char *UNUSED_P(target),
-                             const XML_Char *UNUSED_P(data)) {
+defaultProcessingInstruction(void *userData, const XML_Char *target,
+                             const XML_Char *data) {
+  UNUSED_P(target);
+  UNUSED_P(data);
   XML_DefaultCurrent((XML_Parser)userData);
 }
 
 static void XMLCALL
-nopCharacterData(void *UNUSED_P(userData), const XML_Char *UNUSED_P(s),
-                 int UNUSED_P(len)) {
+nopCharacterData(void *userData, const XML_Char *s, int len) {
+  UNUSED_P(userData);
+  UNUSED_P(s);
+  UNUSED_P(len);
 }
 
 static void XMLCALL
-nopStartElement(void *UNUSED_P(userData), const XML_Char *UNUSED_P(name),
-                const XML_Char **UNUSED_P(atts)) {
+nopStartElement(void *userData, const XML_Char *name, const XML_Char **atts) {
+  UNUSED_P(userData);
+  UNUSED_P(name);
+  UNUSED_P(atts);
 }
 
 static void XMLCALL
-nopEndElement(void *UNUSED_P(userData), const XML_Char *UNUSED_P(name)) {
+nopEndElement(void *userData, const XML_Char *name) {
+  UNUSED_P(userData);
+  UNUSED_P(name);
 }
 
 static void XMLCALL
-nopProcessingInstruction(void *UNUSED_P(userData),
-                         const XML_Char *UNUSED_P(target),
-                         const XML_Char *UNUSED_P(data)) {
+nopProcessingInstruction(void *userData, const XML_Char *target,
+                         const XML_Char *data) {
+  UNUSED_P(userData);
+  UNUSED_P(target);
+  UNUSED_P(data);
 }
 
 static void XMLCALL
@@ -639,12 +655,14 @@ metaCharacterData(void *userData, const XML_Char *s, int len) {
 
 static void XMLCALL
 metaStartDoctypeDecl(void *userData, const XML_Char *doctypeName,
-                     const XML_Char *UNUSED_P(sysid),
-                     const XML_Char *UNUSED_P(pubid),
-                     int UNUSED_P(has_internal_subset)) {
+                     const XML_Char *sysid, const XML_Char *pubid,
+                     int has_internal_subset) {
   XML_Parser parser = (XML_Parser)userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
+  UNUSED_P(sysid);
+  UNUSED_P(pubid);
+  UNUSED_P(has_internal_subset);
   ftprintf(fp, T("<startdoctype name=\"%s\""), doctypeName);
   metaLocation(parser);
   fputts(T("/>\n"), fp);
@@ -662,11 +680,12 @@ metaEndDoctypeDecl(void *userData) {
 
 static void XMLCALL
 metaNotationDecl(void *userData, const XML_Char *notationName,
-                 const XML_Char *UNUSED_P(base), const XML_Char *systemId,
+                 const XML_Char *base, const XML_Char *systemId,
                  const XML_Char *publicId) {
   XML_Parser parser = (XML_Parser)userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
+  UNUSED_P(base);
   ftprintf(fp, T("<notation name=\"%s\""), notationName);
   if (publicId)
     ftprintf(fp, T(" public=\"%s\""), publicId);
@@ -680,14 +699,16 @@ metaNotationDecl(void *userData, const XML_Char *notationName,
 }
 
 static void XMLCALL
-metaEntityDecl(void *userData, const XML_Char *entityName,
-               int UNUSED_P(is_param), const XML_Char *value, int value_length,
-               const XML_Char *UNUSED_P(base), const XML_Char *systemId,
-               const XML_Char *publicId, const XML_Char *notationName) {
+metaEntityDecl(void *userData, const XML_Char *entityName, int is_param,
+               const XML_Char *value, int value_length, const XML_Char *base,
+               const XML_Char *systemId, const XML_Char *publicId,
+               const XML_Char *notationName) {
   XML_Parser parser = (XML_Parser)userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
 
+  UNUSED_P(is_param);
+  UNUSED_P(base);
   if (value) {
     ftprintf(fp, T("<entity name=\"%s\""), entityName);
     metaLocation(parser);
@@ -750,13 +771,13 @@ unknownEncodingConvert(void *data, const char *p) {
 }
 
 static int XMLCALL
-unknownEncoding(void *UNUSED_P(userData), const XML_Char *name,
-                XML_Encoding *info) {
+unknownEncoding(void *userData, const XML_Char *name, XML_Encoding *info) {
   int cp;
   static const XML_Char prefixL[] = T("windows-");
   static const XML_Char prefixU[] = T("WINDOWS-");
   int i;
 
+  UNUSED_P(userData);
   for (i = 0; prefixU[i]; i++)
     if (name[i] != prefixU[i] && name[i] != prefixL[i])
       return 0;
@@ -786,7 +807,8 @@ unknownEncoding(void *UNUSED_P(userData), const XML_Char *name,
 }
 
 static int XMLCALL
-notStandalone(void *UNUSED_P(userData)) {
+notStandalone(void *userData) {
+  UNUSED_P(userData);
   return 0;
 }
 


### PR DESCRIPTION
As originally written, the UNUSED_P macro only worked for GCC.   In particular, more recent VC versions also warn about unused params.    

The typical way to handle this in C (both K&R and ANSI) has been to add a (void)param; statement in the body.     In fact, commit 69746f5ab29f3c2813bf56ccd928009914d1c8c7 that introduced the GCC attribute used the (void)  approach in some of the other test programs.    These patches change just use the (void) method consistently throughout.

Signed-off-by: David Loffredo <loffredo@steptools.com>