### PR TITLE
Add -fno-common to ASAN (for global buffer overflows)

### DIFF
--- a/expat/qa.sh
+++ b/expat/qa.sh
@@ -55,7 +55,7 @@ populate_environment() {
         case "${QA_SANITIZER}" in
             address)
                 # http://clang.llvm.org/docs/AddressSanitizer.html
-                BASE_COMPILE_FLAGS+=" -g -fsanitize=address -fno-omit-frame-pointer"
+                BASE_COMPILE_FLAGS+=" -g -fsanitize=address -fno-omit-frame-pointer -fno-common"
                 BASE_LINK_FLAGS+=" -g -Wc,-fsanitize=address"  # "-Wc," is for libtool
                 ;;
             memory)


### PR DESCRIPTION
This adds the -fno-common compile flag to the ASAN tests.

The standard behavior of gcc and clang is to allow multiple uninitialized global variables defined in different objects without properly marking them as extern. This has the sideeffect that these are stored in a special memory area that's not tested by ASAN, thus it can lead to undetected overflows in global variables.

Setting this flag in the QA/CI script thus has two desirable effects:
1. potential buffer overflows in global variables are detected.
2. if global variables are used in multiple files and not properly marked as "extern" the code will not link.