### PR TITLE
Drop support for MSVC 2003 (related to #323)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -8,6 +8,7 @@ Release x.x.x xxx xxx xx xxxx
                     when called from inside of an end element handler
 
         Other changes:
+            #325  Windows: Drop support for Visual Studio <=7.1/2003
             #286  Windows: Remove COM code from xmlwf; in case it turns
                     out needed later, there will be a dedicated repository
                     below https://github.com/libexpat/ for that code

--- a/expat/Changes
+++ b/expat/Changes
@@ -9,6 +9,7 @@ Release x.x.x xxx xxx xx xxxx
 
         Other changes:
             #325  Windows: Drop support for Visual Studio <=7.1/2003
+                    and document supported compilers in README.md
             #286  Windows: Remove COM code from xmlwf; in case it turns
                     out needed later, there will be a dedicated repository
                     below https://github.com/libexpat/ for that code

--- a/expat/README.md
+++ b/expat/README.md
@@ -13,6 +13,11 @@ are called when the parser discovers the associated structures in the
 document being parsed.  A start tag is an example of the kind of
 structures for which you may register handlers.
 
+Expat supports the following compilers:
+- GNU GCC >=4.5
+- LLVM Clang >=3.5
+- Microsoft Visual Studio >=8.0/2005
+
 Windows users should use the
 [`expat_win32` package](https://sourceforge.net/projects/expat/files/expat_win32/),
 which includes both precompiled libraries and executables, and source code for

--- a/expat/examples/elements.c
+++ b/expat/examples/elements.c
@@ -38,11 +38,7 @@
 #include <expat.h>
 
 #ifdef XML_LARGE_SIZE
-#  if defined(XML_USE_MSC_EXTENSIONS) && _MSC_VER < 1400
-#    define XML_FMT_INT_MOD "I64"
-#  else
-#    define XML_FMT_INT_MOD "ll"
-#  endif
+#  define XML_FMT_INT_MOD "ll"
 #else
 #  define XML_FMT_INT_MOD "l"
 #endif

--- a/expat/examples/outline.c
+++ b/expat/examples/outline.c
@@ -36,11 +36,7 @@
 #include <expat.h>
 
 #ifdef XML_LARGE_SIZE
-#  if defined(XML_USE_MSC_EXTENSIONS) && _MSC_VER < 1400
-#    define XML_FMT_INT_MOD "I64"
-#  else
-#    define XML_FMT_INT_MOD "ll"
-#  endif
+#  define XML_FMT_INT_MOD "ll"
 #else
 #  define XML_FMT_INT_MOD "l"
 #endif

--- a/expat/lib/expat_external.h
+++ b/expat/lib/expat_external.h
@@ -148,13 +148,8 @@ typedef char XML_LChar;
 #endif   /* XML_UNICODE */
 
 #ifdef XML_LARGE_SIZE /* Use large integers for file/stream positions. */
-#  if defined(XML_USE_MSC_EXTENSIONS) && _MSC_VER < 1400
-typedef __int64 XML_Index;
-typedef unsigned __int64 XML_Size;
-#  else
 typedef long long XML_Index;
 typedef unsigned long long XML_Size;
-#  endif
 #else
 typedef long XML_Index;
 typedef unsigned long XML_Size;

--- a/expat/lib/expat_external.h
+++ b/expat/lib/expat_external.h
@@ -35,10 +35,6 @@
 
 /* External API definitions */
 
-#if defined(_MSC_EXTENSIONS) && ! defined(__BEOS__) && ! defined(__CYGWIN__)
-#  define XML_USE_MSC_EXTENSIONS 1
-#endif
-
 /* Expat tries very hard to make the API boundary very specifically
    defined.  There are two macros defined to control this boundary;
    each of these can be defined before including this header to
@@ -85,7 +81,7 @@
 #  ifndef XML_BUILDING_EXPAT
 /* using Expat from an application */
 
-#    ifdef XML_USE_MSC_EXTENSIONS
+#    if defined(_MSC_EXTENSIONS) && ! defined(__BEOS__) && ! defined(__CYGWIN__)
 #      define XMLIMPORT __declspec(dllimport)
 #    endif
 

--- a/expat/xmlwf/xmlfile.h
+++ b/expat/xmlwf/xmlfile.h
@@ -34,11 +34,7 @@
 #define XML_EXTERNAL_ENTITIES 02
 
 #ifdef XML_LARGE_SIZE
-#  if defined(XML_USE_MSC_EXTENSIONS) && _MSC_VER < 1400
-#    define XML_FMT_INT_MOD "I64"
-#  else
-#    define XML_FMT_INT_MOD "ll"
-#  endif
+#  define XML_FMT_INT_MOD "ll"
 #else
 #  define XML_FMT_INT_MOD "l"
 #endif


### PR DESCRIPTION
- Drop support for Visual Studio <=7.1/2003
- Document supported compilers in `README.md`
- Resolve internal pre-processor macro `XML_USE_MSC_EXTENSIONS` (#323)

