### PR TITLE
Autotools: Enable clang tool chain to generate libraries (for #312)

### DIFF
--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -94,6 +94,11 @@ AC_LANG_POP([C++])
 AS_IF([test "$GCC" = yes],
   [AX_APPEND_LINK_FLAGS([-fno-strict-aliasing],[LDFLAGS])])
 
+dnl patching ${archive_cmds} to affect generation of file "libtool" to fix linking with clang (issue #312)
+AS_CASE(["$LD"],[*clang*],
+  [AS_CASE(["${host_os}"],
+     [*linux*],[archive_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'])])
+
 EXPATCFG_COMPILER_SUPPORTS_VISIBILITY([
   AX_APPEND_FLAG([-fvisibility=hidden],       [CFLAGS])
   AX_APPEND_FLAG([-DXML_ENABLE_VISIBILITY=1], [CFLAGS])])


### PR DESCRIPTION
Enable clang tool chain for automake to generate shared libexpat libraries.

Signed-off-by: Mohammed Khajapasha <mohammed.khajapasha@intel.com>