### PR TITLE
Only define _CRT_RAND_S when not already defined.

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -36,7 +36,9 @@
 
 #ifdef _WIN32
 /* force stdlib to define rand_s() */
-#  define _CRT_RAND_S
+#  if ! defined(_CRT_RAND_S)
+#    define _CRT_RAND_S
+#  endif
 #endif
 
 #include <stddef.h>


### PR DESCRIPTION
There exist builds which go out of their way to define _CRT_RAND_S for
everything by forcing it into the list of macros defined on the command
line to the compiler. Unfortunately, something like "-D_CRT_RAND_S"
implies _CRT_RAND_S is defined to be '1' and defining it to be empty
produces a redefinition.

Since the intention here is to ensure that _CRT_RAND_S is always defined,
only define it if it isn't already defined.