### PR TITLE
Fix interpolation of @_EXPAT_TARGET@ in expat.pc.in with GNU Autoconf (fixes #361)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -14,6 +14,7 @@ Release x.x.x xxx xxxxxxxxx xx xxxx
   #354 #355 #356  Address compiler warnings
 
         Special thanks to:
+            asavah
             Ma Lin
             Vadim Zeitlin
 

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -307,6 +307,12 @@ AS_IF([test "x${DOCBOOK_TO_MAN}" != x -a "x$with_docbook" != xno],
 
 AM_CONDITIONAL(WITH_DOCBOOK, [test "x${DOCBOOK_TO_MAN}" != x])
 
+dnl This allows use of @_EXPAT_TARGET@ inside expat.pc.in.
+dnl CMake makes use of expat.pc.in as well: it interpolates @_EXPAT_TARGET@
+dnl with "expat" for -DEXPAT_CHAR_TYPE=char
+dnl or "expatw" for -DEXPAT_CHAR_TYPE=(ushort|wchar_t)
+AC_SUBST([_EXPAT_TARGET], [expat])
+
 AC_CONFIG_FILES([Makefile]
   [expat.pc]
   [doc/Makefile]


### PR DESCRIPTION
For #361