### PR TITLE
Fix source comment typos

### DIFF
--- a/expat/configure-ac-style.md
+++ b/expat/configure-ac-style.md
@@ -6,7 +6,7 @@ Version `2019.08.09.21.54`
 ## Purpose
 
 Define a small set of rules for style used in Expat's `configure.ac`
-so that we have a commen ground and something documented to refer to
+so that we have a common ground and something documented to refer to
 in pull requests, when style is off.
 
 

--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -1298,7 +1298,7 @@ typedef void
                                     int len);
 </pre>
 <p>Set a text handler. The string your handler receives
-is <em>NOT nul-terminated</em>. You have to use the length argument
+is <em>NOT null-terminated</em>. You have to use the length argument
 to deal with the end of the string. A single block of contiguous text
 free of markup may still result in a sequence of calls to this handler.
 In other words, if you're searching for a pattern in the text, it may
@@ -1576,7 +1576,7 @@ call to the function pointed at by convert. This function may return -1
 if the sequence itself is invalid. The convert pointer may be null if
 there are only single byte codes. The data parameter passed to the convert
 function is the data pointer from <code>XML_Encoding</code>. The
-string s is <em>NOT</em> nul-terminated and points at the sequence of
+string s is <em>NOT</em> null-terminated and points at the sequence of
 bytes to be converted.</p>
 
 <p>The function pointed at by <code>release</code> is called by the
@@ -1904,7 +1904,7 @@ of errors. The position reported is the byte position (in the original
 document or entity encoding) of the first of the sequence of
 characters that generated the current event (or the error that caused
 the parse functions to return <code>XML_STATUS_ERROR</code>.)  The
-exceptions are callbacks trigged by declarations in the document
+exceptions are callbacks triggered by declarations in the document
 prologue, in which case they exact position reported is somewhere in the
 relevant markup, but not necessarily as meaningful as for other
 events.</p>

--- a/expat/fuzz/xml_parse_fuzzer.c
+++ b/expat/fuzz/xml_parse_fuzzer.c
@@ -32,7 +32,7 @@
 #  error "ENCODING_FOR_FUZZING was not provided to this fuzz target."
 #endif
 
-// 16-byte determinstic hash key.
+// 16-byte deterministic hash key.
 static unsigned char hash_key[16] = "FUZZING IS FUN!";
 
 static void XMLCALL

--- a/expat/fuzz/xml_parsebuffer_fuzzer.c
+++ b/expat/fuzz/xml_parsebuffer_fuzzer.c
@@ -33,7 +33,7 @@
 #  error "ENCODING_FOR_FUZZING was not provided to this fuzz target."
 #endif
 
-// 16-byte determinstic hash key.
+// 16-byte deterministic hash key.
 static unsigned char hash_key[16] = "FUZZING IS FUN!";
 
 static void XMLCALL

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -318,7 +318,7 @@ typedef void(XMLCALL *XML_EndDoctypeDeclHandler)(void *userData);
 
    For internal entities (<!ENTITY foo "bar">), value will
    be non-NULL and systemId, publicID, and notationName will be NULL.
-   The value string is NOT nul-terminated; the length is provided in
+   The value string is NOT null-terminated; the length is provided in
    the value_length argument. Since it is legal to have zero-length
    values, do not use this argument to test for internal entities.
 
@@ -707,7 +707,7 @@ XML_GetBase(XML_Parser parser);
 /* Returns the number of the attribute/value pairs passed in last call
    to the XML_StartElementHandler that were specified in the start-tag
    rather than defaulted. Each attribute/value pair counts as 2; thus
-   this correspondds to an index into the atts array passed to the
+   this corresponds to an index into the atts array passed to the
    XML_StartElementHandler.  Returns -1 if parser == NULL.
 */
 XMLPARSEAPI(int)
@@ -716,7 +716,7 @@ XML_GetSpecifiedAttributeCount(XML_Parser parser);
 /* Returns the index of the ID attribute passed in the last call to
    XML_StartElementHandler, or -1 if there is no ID attribute or
    parser == NULL.  Each attribute/value pair counts as 2; thus this
-   correspondds to an index into the atts array passed to the
+   corresponds to an index into the atts array passed to the
    XML_StartElementHandler.
 */
 XMLPARSEAPI(int)

--- a/expat/win32/MANIFEST.txt
+++ b/expat/win32/MANIFEST.txt
@@ -17,7 +17,7 @@ directory you specified to the installer.
                       The XML well-formedness checker xmlwf.
 
   <top>\Source\       Source code, which may interest some developers,
-                      including a workspace for Microsft Visual C++.
+                      including a workspace for Microsoft Visual C++.
                       The source code includes the parser, the well-
                       formedness checker, and a couple of small sample
                       applications.

--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -176,7 +176,7 @@ externalEntityRefFilemap(XML_Parser parser, const XML_Char *context,
 
 static int
 processStream(const XML_Char *filename, XML_Parser parser) {
-  /* passing NULL for filename means read intput from stdin */
+  /* passing NULL for filename means read input from stdin */
   int fd = 0; /* 0 is the fileno for stdin */
 
   if (filename != NULL) {


### PR DESCRIPTION
Found via `codespell -q 3 -S ./testdata,./expat/Changes`