### PR TITLE
parsebuffer fuzzer: Bail out on empty fuzzer input

### DIFF
--- a/expat/fuzz/xml_parsebuffer_fuzzer.c
+++ b/expat/fuzz/xml_parsebuffer_fuzzer.c
@@ -45,6 +45,9 @@ end(void *userData, const XML_Char *name) {
 
 int
 LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  if (size == 0)
+    return 0;
+
   XML_Parser p = XML_ParserCreate(xstr(ENCODING_FOR_FUZZING));
   assert(p);
   XML_SetElementHandler(p, start, end);


### PR DESCRIPTION
For empty fuzzer input, The call to `XML_GetBuffer` here

https://github.com/libexpat/libexpat/blob/f56a55b32c182c7e5c41f6d07b31440ff198931a/expat/fuzz/xml_parsebuffer_fuzzer.c#L56

returns a null pointer, leading to the assertion on the following line failing. 

https://github.com/libexpat/libexpat/blob/f56a55b32c182c7e5c41f6d07b31440ff198931a/expat/fuzz/xml_parsebuffer_fuzzer.c#L57

This PR fixes this issue by bailing out early if fuzzer input is empty.