### PR TITLE
CMake: Fix warning due to if statement with mismatching arguments

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -457,7 +457,7 @@ if(EXPAT_BUILD_FUZZERS)
                 set_target_properties(${target_name} PROPERTIES LINKER_LANGUAGE "CXX")
             else()
                 set_target_properties(${target_name} PROPERTIES LINK_FLAGS -fsanitize=fuzzer)
-            endif(NOT EXPAT_OSSFUZZ_BUILD)
+            endif(EXPAT_OSSFUZZ_BUILD)
             set_property(
                 TARGET ${target_name} PROPERTY RUNTIME_OUTPUT_DIRECTORY fuzz)
         endforeach()


### PR DESCRIPTION
Hello,

A tiny cmake error slipped through from #366 to master which is the following

```
CMake Warning (dev) in CMakeLists.txt:
Step #3:   A logical block opening on the line
Step #3: 
Step #3:     /src/expat/expat/CMakeLists.txt:455 (if)
Step #3: 
Step #3:   closes on the line
Step #3: 
Step #3:     /src/expat/expat/CMakeLists.txt:460 (endif)
Step #3: 
Step #3:   with mis-matching arguments.
Step #3: This warning is for project developers.  Use -Wno-dev to suppress it.
```

The error was introduced because I forgot to update the argument of `endif` cmake statement after flipping the condition of the said `if` statement (to address this comment https://github.com/libexpat/libexpat/pull/366#discussion_r347652619)

This PR fixes it :)