### PR TITLE
Move definition XML_STATIC to public in target

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -282,9 +282,6 @@ if(EXPAT_SHARED_LIBS)
     endif(MSVC)
 else(EXPAT_SHARED_LIBS)
     set(_SHARED STATIC)
-    if(WIN32)
-        add_definitions(-DXML_STATIC)
-    endif(WIN32)
 endif(EXPAT_SHARED_LIBS)
 
 # Avoid colliding with Expat.dll of Perl's XML::Parser::Expat
@@ -320,6 +317,10 @@ target_include_directories(${EXPAT_TARGET}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
+
+if(NOT EXPAT_SHARED_LIBS AND WIN32)
+    target_compile_definitions(${EXPAT_TARGET} PUBLIC -DXML_STATIC)
+endif()
 
 expat_install(TARGETS ${EXPAT_TARGET} EXPORT expat
                       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
This fix link static libexpat on MSVC.
If you add this definition as public all targets links expat will automatically get this flag and don't get this:

```

> libexpat.vcxproj -> ......\bin\EXPAT\bin\_deps\expat-build\Release\libexpatMD.lib
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_ParserCreate przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_SetElementHandler przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_SetCharacterDataHandler przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_SetUserData przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_Parse przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_GetErrorCode przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_GetCurrentLineNumber przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_ParserFree przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> TestEXPAT.obj : error LNK2019: nierozpoznany zewn?trzny symbol __imp__XML_ErrorString przywo?any w funkcji _main [......\bin\EXPAT\bin\TestEXPAT.vcxproj]
> ......\bin\EXPAT\bin\Release\TestEXPAT.exe : fatal error LNK1120: liczba nierozpoznanych element?w zewn?trznych: 9 [......\bin\EXPAT\bin\TestEXPAT.vcxproj]

```