### PR TITLE
Add Android testing to Travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #                          __  __            _
 #                       ___\ \/ /_ __   __ _| |_
 #                      / _ \\  /| '_ \ / _` | __|
@@ -30,11 +30,11 @@
 
 set -e
 
-if [[ ${TRAVIS_OS_NAME} = osx ]]; then
+if [[ ${TRAVIS_OS_NAME} == osx ]] && [[ ${MODE} != android ]]; then
     latest_brew_python3_bin="$(ls -1d /usr/local/Cellar/python/3.*/bin | sort -n | tail -n1)"
     export PATH="${latest_brew_python3_bin}${PATH:+:}${PATH}"
     export PATH="/usr/local/opt/coreutils/libexec/gnubin${PATH:+:}${PATH}"
-elif [[ ${TRAVIS_OS_NAME} = linux ]]; then
+elif [[ ${TRAVIS_OS_NAME} == linux ]] && [[ ${MODE} != android ]]; then
     export PATH="/usr/lib/llvm-9/bin:${PATH}"
 fi
 
@@ -48,23 +48,31 @@ set -x
 cd expat
 ./buildconf.sh
 
-if [[ ${MODE} = distcheck ]]; then
+if [[ ${MODE} == distcheck ]]; then
     ./configure ${CONFIGURE_ARGS}
     make distcheck
-elif [[ ${MODE} = cmake-oos ]]; then
+elif [[ ${MODE} == cmake-oos ]]; then
     mkdir build
     cd build
     cmake ${CMAKE_ARGS} ..
     make VERBOSE=1 all test
     make DESTDIR="${PWD}"/ROOT install
     find ROOT -printf "%P\n" | sort
-elif [[ ${MODE} = cppcheck ]]; then
+elif [[ ${MODE} == cppcheck ]]; then
     cppcheck --quiet --error-exitcode=1 .
-elif [[ ${MODE} = clang-format ]]; then
+elif [[ ${MODE} == clang-format ]]; then
     ./apply-clang-format.sh
     git diff --exit-code
-elif [[ ${MODE} = coverage-sh ]]; then
+elif [[ ${MODE} == coverage-sh ]]; then
     ./coverage.sh
+elif [[ ${MODE} == android ]]; then
+    ./contrib/install_ndk.sh
+    source ./contrib/setenv_android.sh
+    ./configure \
+      --build=$(./config.guess) --host="$AUTOTOOLS_HOST" \
+      --prefix="$HOME/android$ANDROID_API-$ANDROID_CPU"
+    make -j 3
+    make install
 else
     ./qa.sh ${CMAKE_ARGS}
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,30 @@ matrix:
       env: MODE=qa-sh CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ LD=i686-w64-mingw32-ld QA_PROCESSOR=gcov CMAKE_ARGS="-DCMAKE_SYSTEM_NAME=Windows -DWIN32=ON -DMINGW=ON -DEXPAT_ATTR_INFO=ON"
     - os: linux
       env: MODE=qa-sh CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ LD=i686-w64-mingw32-ld QA_PROCESSOR=gcov CMAKE_ARGS="-DCMAKE_SYSTEM_NAME=Windows -DWIN32=ON -DMINGW=ON -DEXPAT_ATTR_INFO=ON -DEXPAT_CHAR_TYPE=wchar_t"
+    - name: Android, Linux, armv7a
+      os: linux
+      env: MODE=android ANDROID_NDK_ROOT="$HOME/ndk" ANDROID_SDK_ROOT="$HOME/sdk" ANDROID_API=26 ANDROID_CPU=armv7a AUTOTOOLS_HOST=armv7a-linux-androideabi
+    - name: Android, Linux, arm64
+      os: linux
+      env: MODE=android ANDROID_NDK_ROOT="$HOME/ndk" ANDROID_SDK_ROOT="$HOME/sdk" ANDROID_API=26 ANDROID_CPU=arm64 AUTOTOOLS_HOST=aarch64-linux-android
+    - name: Android, Linux, x86
+      os: linux
+      env: MODE=android ANDROID_NDK_ROOT="$HOME/ndk" ANDROID_SDK_ROOT="$HOME/sdk" ANDROID_API=26 ANDROID_CPU=x86 AUTOTOOLS_HOST=i686-linux-android
+    - name: Android, Linux, x86_64
+      os: linux
+      env: MODE=android ANDROID_NDK_ROOT="$HOME/ndk" ANDROID_SDK_ROOT="$HOME/sdk" ANDROID_API=26 ANDROID_CPU=x86_64 AUTOTOOLS_HOST=x86_64-linux-android
+    - name: Android, OS X, armv7a
+      os: osx
+      env: MODE=android ANDROID_NDK_ROOT="$HOME/ndk" ANDROID_SDK_ROOT="$HOME/sdk" ANDROID_API=26 ANDROID_CPU=armv7a AUTOTOOLS_HOST=armv7a-linux-androideabi
+    - name: Android, OS X, arm64
+      os: osx
+      env: MODE=android ANDROID_NDK_ROOT="$HOME/ndk" ANDROID_SDK_ROOT="$HOME/sdk" ANDROID_API=26 ANDROID_CPU=arm64 AUTOTOOLS_HOST=aarch64-linux-android
+    - name: Android, OS X, x86
+      os: osx
+      env: MODE=android ANDROID_NDK_ROOT="$HOME/ndk" ANDROID_SDK_ROOT="$HOME/sdk" ANDROID_API=26 ANDROID_CPU=x86 AUTOTOOLS_HOST=i686-linux-android
+    - name: Android, OS X, x86_64
+      os: osx
+      env: MODE=android ANDROID_NDK_ROOT="$HOME/ndk" ANDROID_SDK_ROOT="$HOME/sdk" ANDROID_API=26 ANDROID_CPU=x86_64 AUTOTOOLS_HOST=x86_64-linux-android
 
 addons:
   homebrew:

--- a/expat/contrib/install_ndk.sh
+++ b/expat/contrib/install_ndk.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# ====================================================================
+# Tests Android cross-compiles
+#
+# This script installs a SDK and NDK to test Android cross-compiles.
+# Written by Jeffrey Walton.
+# ====================================================================
+
+# NDK-r19: https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip
+# SDK for r19: https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip
+# SDK for Mac: https://dl.google.com/android/repository/sdk-tools-mac-4333796.zip
+
+# NDK-r20: https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
+# SDK for r20: https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip
+# SDK for Mac: https://dl.google.com/android/repository/commandlinetools-mac-6200805_latest.zip
+
+# NDK-r21: https://dl.google.com/android/repository/android-ndk-r21-linux-x86_64.zip
+# SDK for r21: https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip
+# SDK for Mac: https://dl.google.com/android/repository/commandlinetools-mac-6200805_latest.zip
+
+if [ -z "$ANDROID_SDK_ROOT" ]; then
+    echo "ERROR: ANDROID_SDK_ROOT is not set. Please set it."
+    echo "SDK root is $ANDROID_SDK_ROOT"
+    exit 1
+fi
+
+if [ -z "$ANDROID_NDK_ROOT" ]; then
+    echo "ERROR: ANDROID_NDK_ROOT is not set. Please set it."
+    echo "NDK root is $ANDROID_NDK_ROOT"
+    exit 1
+fi
+
+IS_DARWIN=$(uname -s 2>/dev/null | grep -i -c darwin)
+IS_LINUX=$(uname -s 2>/dev/null | grep -i -c linux)
+
+# Keep this in sync with the move at the end.
+if [ "$IS_LINUX" -eq 1 ]; then
+    SDK_URL=https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip
+    NDK_URL=https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
+elif [ "$IS_DARWIN" -eq 1 ]; then
+    SDK_URL=https://dl.google.com/android/repository/commandlinetools-mac-6200805_latest.zip
+    NDK_URL=https://dl.google.com/android/repository/android-ndk-r20b-darwin-x86_64.zip
+else
+    echo "Unknown platform: \"$(uname -s 2>/dev/null)\". Please fix this script."
+fi
+
+# install android deps
+if [ -n "$(command -v apt-get)" ]; then
+    apt-get -qq update 2>/dev/null
+    apt-get -qq install --no-install-recommends openjdk-8-jdk unzip curl 2>/dev/null
+fi
+
+echo "Downloading SDK"
+if ! curl -k -s -o android-sdk.zip "$SDK_URL";
+then
+    echo "Failed to download SDK"
+    exit 1
+fi
+
+echo "Downloading NDK"
+if ! curl -k -s -o android-ndk.zip "$NDK_URL";
+then
+    echo "Failed to download NDK"
+    exit 1
+fi
+
+echo "Unpacking SDK to $ANDROID_SDK_ROOT"
+if ! unzip -qq android-sdk.zip -d "$ANDROID_SDK_ROOT";
+then
+    echo "Failed to unpack SDK"
+    exit 1
+fi
+
+echo "Unpacking NDK to $ANDROID_NDK_ROOT"
+if ! unzip -qq android-ndk.zip -d "$HOME";
+then
+    echo "Failed to unpack NDK"
+    exit 1
+fi
+
+if ! mv "$HOME/android-ndk-r20b" "$ANDROID_NDK_ROOT";
+then
+    echo "Failed to move $HOME/android-ndk-r20b to $ANDROID_NDK_ROOT"
+    exit 1
+fi
+
+rm -f android-sdk.zip
+rm -f android-ndk.zip
+
+# We don't set ANDROID_HOME to ANDROID_SDK_ROOT.
+# https://stackoverflow.com/a/47028911/608639
+touch "$ANDROID_SDK_ROOT/repositories.cfg"
+
+echo "Finished preparing SDK and NDK"
+
+exit 0

--- a/expat/contrib/setenv_android.sh
+++ b/expat/contrib/setenv_android.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+# ====================================================================
+# Sets the cross compile environment for Android
+#
+# Based upon OpenSSL's setenv-android.sh by TH, JW, and SM.
+# Heavily modified by JW for Crypto++.
+# Modified by Skycoder42 Android NDK-r19.
+# Modified by JW for Android NDK-r20 and above.
+# ====================================================================
+
+#####################################################################
+
+# Some validation
+
+if [ -z "$ANDROID_API" ]; then
+    echo "ANDROID_API is not set. Please set it"
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+fi
+
+if [ -z "$ANDROID_CPU" ]; then
+    echo "ANDROID_CPU is not set. Please set it"
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+fi
+
+# In case a user runs this script without sourcing.
+if [ "$0" = "${BASH_SOURCE[0]}" ]; then
+    echo "setenv_android.sh is usually sourced, but not this time."
+fi
+
+#####################################################################
+
+# Need to set THIS_HOST to darwin-x86_64, linux-x86_64,
+# windows, or windows-x86_64
+
+if [[ "$(uname -s | grep -i -c darwin)" -ne 0 ]]; then
+    THIS_HOST=darwin-x86_64
+elif [[ "$(uname -s | grep -i -c linux)" -ne 0 ]]; then
+    THIS_HOST=linux-x86_64
+else
+    echo "ERROR: Unknown host"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+ANDROID_TOOLCHAIN="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$THIS_HOST/bin"
+ANDROID_SYSROOT="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$THIS_HOST/sysroot"
+
+# Error checking
+if [ ! -d "$ANDROID_TOOLCHAIN" ]; then
+    echo "ERROR: ANDROID_TOOLCHAIN is not a valid path. Please set it."
+    echo "Path is $ANDROID_TOOLCHAIN"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+if [ ! -d "$ANDROID_SYSROOT" ]; then
+    echo "ERROR: ANDROID_SYSROOT is not a valid path. Please set it."
+    echo "Path is $ANDROID_SYSROOT"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+#####################################################################
+
+THIS_ARCH=$(tr '[:upper:]' '[:lower:]' <<< "$ANDROID_CPU")
+
+# https://developer.android.com/ndk/guides/abis.html
+case "$THIS_ARCH" in
+  armv7*|armeabi*)
+    CC="armv7a-linux-androideabi$ANDROID_API-clang"
+    CXX="armv7a-linux-androideabi$ANDROID_API-clang++"
+    LD="arm-linux-androideabi-ld"
+    AS="arm-linux-androideabi-as"
+    AR="arm-linux-androideabi-ar"
+    RANLIB="arm-linux-androideabi-ranlib"
+    STRIP="arm-linux-androideabi-strip"
+
+    ANDROID_CFLAGS="-march=armv7-a -mthumb -mfloat-abi=softfp -funwind-tables -fexceptions"
+    ANDROID_CXXFLAGS="-march=armv7-a -mthumb -mfloat-abi=softfp -funwind-tables -fexceptions -frtti"
+    ;;
+
+  armv8*|aarch64|arm64)
+    CC="aarch64-linux-android$ANDROID_API-clang"
+    CXX="aarch64-linux-android$ANDROID_API-clang++"
+    LD="aarch64-linux-android-ld"
+    AS="aarch64-linux-android-as"
+    AR="aarch64-linux-android-ar"
+    RANLIB="aarch64-linux-android-ranlib"
+    STRIP="aarch64-linux-android-strip"
+
+    ANDROID_CFLAGS="-funwind-tables -fexceptions"
+    ANDROID_CXXFLAGS="-funwind-tables -fexceptions -frtti"
+    ;;
+
+  x86)
+    CC="i686-linux-android$ANDROID_API-clang"
+    CXX="i686-linux-android$ANDROID_API-clang++"
+    LD="i686-linux-android-ld"
+    AS="i686-linux-android-as"
+    AR="i686-linux-android-ar"
+    RANLIB="i686-linux-android-ranlib"
+    STRIP="i686-linux-android-strip"
+
+    ANDROID_CXXFLAGS="-mtune=intel -mssse3 -mfpmath=sse -funwind-tables -fexceptions"
+    ANDROID_CXXFLAGS="-mtune=intel -mssse3 -mfpmath=sse -funwind-tables -fexceptions -frtti"
+    ;;
+
+  x86_64|x64)
+    CC="x86_64-linux-android$ANDROID_API-clang"
+    CXX="x86_64-linux-android$ANDROID_API-clang++"
+    LD="x86_64-linux-android-ld"
+    AS="x86_64-linux-android-as"
+    AR="x86_64-linux-android-ar"
+    RANLIB="x86_64-linux-android-ranlib"
+    STRIP="x86_64-linux-android-strip"
+
+    ANDROID_CFLAGS="-march=x86-64 -msse4.2 -mpopcnt -mtune=intel -funwind-tables -fexceptions"
+    ANDROID_CXXFLAGS="-march=x86-64 -msse4.2 -mpopcnt -mtune=intel -funwind-tables -fexceptions -frtti"
+    ;;
+
+  *)
+    echo "ERROR: Unknown architecture $ANDROID_CPU"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+    ;;
+esac
+
+#####################################################################
+
+export CPP CC CXX LD AS AR RANLIB STRIP
+
+export CPPFLAGS="-D__ANDROID_API__=$ANDROID_API"
+export CFLAGS="$ANDROID_CFLAGS --sysroot=$ANDROID_SYSROOT"
+export CXXFLAGS="$ANDROID_CXXFLAGS -stdlib=libc++ --sysroot=$ANDROID_SYSROOT"
+
+export ANDROID_API ANDROID_CPU ANDROID_SYSROOT
+
+# Do NOT use ANDROID_SYSROOT_INC or ANDROID_SYSROOT_LD
+# https://github.com/android/ndk/issues/894#issuecomment-470837964
+
+#####################################################################
+
+# Error checking
+if [ ! -e "$ANDROID_TOOLCHAIN/$CC" ]; then
+    echo "ERROR: Failed to find Android clang. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+if [ ! -e "$ANDROID_TOOLCHAIN/$CXX" ]; then
+    echo "ERROR: Failed to find Android clang++. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+if [ ! -e "$ANDROID_TOOLCHAIN/$RANLIB" ]; then
+    echo "ERROR: Failed to find Android ranlib. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+if [ ! -e "$ANDROID_TOOLCHAIN/$AR" ]; then
+    echo "ERROR: Failed to find Android ar. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+if [ ! -e "$ANDROID_TOOLCHAIN/$AS" ]; then
+    echo "ERROR: Failed to find Android as. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+if [ ! -e "$ANDROID_TOOLCHAIN/$LD" ]; then
+    echo "ERROR: Failed to find Android ld. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+#####################################################################
+
+# Add tools to head of path, if not present already
+LENGTH=${#ANDROID_TOOLCHAIN}
+SUBSTR=${PATH:0:$LENGTH}
+if [ "$SUBSTR" != "$ANDROID_TOOLCHAIN" ]; then
+    export PATH="$ANDROID_TOOLCHAIN:$PATH"
+fi
+
+#####################################################################
+
+echo "ANDROID_TOOLCHAIN: $ANDROID_TOOLCHAIN"
+
+echo "CC: $(command -v "$CC")"
+echo "CXX: $(command -v "$CXX")"
+echo "LD: $(command -v "$LD")"
+echo "AS: $(command -v "$AS")"
+echo "AR: $(command -v "$AR")"
+
+echo "ANDROID_SYSROOT: $ANDROID_SYSROOT"
+
+echo "CPPFLAGS: $CPPFLAGS"
+echo "CFLAGS: $CFLAGS"
+echo "CXXFLAGS: $CXXFLAGS"
+
+[ "$0" = "${BASH_SOURCE[0]}" ] && exit 0 || return 0


### PR DESCRIPTION
This PR adds Android testing to Expat using Travis.

Testing occurs on both Linux and OS X for Android platforms armv7a, arm64, x86 and x86_64. Testing is limited to a configure, make and make install.

* `install_ndk.sh` is a script that installs the NDK and SDK. The script depends upon `ANDROID_NDK_ROOT` and `ANDROID_SDK_ROOT`, which are set in the Travis environment.
* `setenv_android.sh` is a script that sets `CC`, `CXX`, `CFLAGS`, `CXXFLAGS` and friends. The script must be sourced so the variables are available in the calling shell.

After the SDK and NDK are installed, and the cross-compile environment is set, we just `./configure --host=... --build=...` to test the build and install.

With Android testing in place you can move onto CMake testing on Android. See [NDK | CMake](https://developer.android.com/ndk/guides/cmake) in the NDK docs.

Also see Issue 383, [Warnings for Android NDK build](https://github.com/libexpat/libexpat/issues/383) and Pull Request 387, [Update Autotools to use AM_CPPFLAGS, AM_CFLAGS, and AM_CXXFLAGS](https://github.com/libexpat/libexpat/pull/387).