### PR TITLE
conftools: Use -Werror when checking compile flags

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -5,6 +5,8 @@ NOTE: We are looking for help with a few things:
 Release x.x.x xxx xxxxxxxxx xx xxxx
         Other changes:
             #396  Windows: Drop support for Visual Studio <=8.0/2005
+       #383 #392  Autotools: Use -Werror while configure tests the compiler
+                    for supported compile flags to avoid false positives
        #383 #393  Autotools: Improve handling of user (C|CPP|CXX|LD)FLAGS,
                     e.g. ensure that they have the last word over flags added
                     while running ./configure

--- a/expat/conftools/ax-check-compile-flag.m4
+++ b/expat/conftools/ax-check-compile-flag.m4
@@ -8,8 +8,8 @@
 #
 # DESCRIPTION
 #
-#   Check whether the given FLAG works with the current language's compiler
-#   or gives an error.  (Warnings, however, are ignored)
+#   Check whether the given FLAG plus -Werror works with the current
+#   language's compiler or gives an error.
 #
 #   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
 #   success/failure.
@@ -28,6 +28,7 @@
 #
 #   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
 #   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#   Copyright (c) 2020 Sebastian Pipping <sebastian@pipping.org>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -55,14 +56,14 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 4
+#serial 5
 
 AC_DEFUN([AX_CHECK_COMPILE_FLAG],
 [AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
 AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
 AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
-  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 -Werror $1"
   AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
     [AS_VAR_SET(CACHEVAR,[yes])],
     [AS_VAR_SET(CACHEVAR,[no])])

--- a/expat/conftools/ax-check-compile-flag.m4
+++ b/expat/conftools/ax-check-compile-flag.m4
@@ -9,7 +9,7 @@
 # DESCRIPTION
 #
 #   Check whether the given FLAG plus -Werror works with the current
-#   language's compiler or gives an error.
+#   language's compiler — C or C++ — or gives an error.
 #
 #   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
 #   success/failure.
@@ -56,7 +56,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 5
+#serial 6
 
 AC_DEFUN([AX_CHECK_COMPILE_FLAG],
 [AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
@@ -64,7 +64,9 @@ AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
 AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
   ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
   _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 -Werror $1"
-  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+  AC_COMPILE_IFELSE([m4_default([$5],
+                                [AC_LANG_SOURCE(
+                                   [[int main(void) { return 0; }]])])],
     [AS_VAR_SET(CACHEVAR,[yes])],
     [AS_VAR_SET(CACHEVAR,[no])])
   _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])


### PR DESCRIPTION
CC @noloader 

~Potential new base for pull request #387~, related to issue #383.

Before and after for Clang 9:
```diff
-checking whether C compiler accepts -Wduplicated-cond... yes
-checking whether C compiler accepts -Wduplicated-branches... yes
-checking whether C compiler accepts -Wlogical-op... yes
-checking whether C compiler accepts -Wrestrict... yes
+checking whether C compiler accepts -Wduplicated-cond... no
+checking whether C compiler accepts -Wduplicated-branches... no
+checking whether C compiler accepts -Wlogical-op... no
+checking whether C compiler accepts -Wrestrict... no
@@ -90 +90 @@
-checking whether C compiler accepts -Wjump-misses-init... yes
+checking whether C compiler accepts -Wjump-misses-init... no
@@ -94 +94 @@
-checking whether C compiler accepts -Wmisleading-indentation... yes
+checking whether C compiler accepts -Wmisleading-indentation... no
```