### PR TITLE
xmlparse.c: Fix undefined behavior for XML_UNICODE (fixes #390)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -3,6 +3,10 @@ NOTE: We are looking for help with a few things:
       If you can help, please get in touch.  Thanks!
 
 Release x.x.x xxx xxxxxxxxx xx xxxx
+        Bug fixes:
+       #390 #395  Fix undefined behavior during parsing when compiled with
+                    -DXML_UNICODE that was introduced with Expat 2.0.1
+
         Other changes:
             #396  Windows: Drop support for Visual Studio <=8.0/2005
        #383 #393  Autotools: Improve handling of user (C|CPP|CXX|LD)FLAGS,

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -48,6 +48,17 @@
 #include <stdio.h>  /* fprintf */
 #include <stdlib.h> /* getenv, rand_s */
 
+#if defined(_WIN32) && defined(_MSC_VER) && (_MSC_VER < 1600)
+/* vs2008/9.0 and earlier lack stdint.h; _MSC_VER 1600 is vs2010/10.0 */
+#  if defined(_WIN64)
+typedef unsigned __int64 uintptr_t;
+#  else
+typedef unsigned __int32 uintptr_t;
+#  endif
+#else
+#  include <stdint.h> /* uintptr_t */
+#endif
+
 #ifdef _WIN32
 #  define getpid GetCurrentProcessId
 #else
@@ -121,9 +132,7 @@
 #  define XmlGetInternalEncoding XmlGetUtf16InternalEncoding
 #  define XmlGetInternalEncodingNS XmlGetUtf16InternalEncodingNS
 #  define XmlEncode XmlUtf16Encode
-/* Using pointer subtraction to convert to integer type. */
-#  define MUST_CONVERT(enc, s)                                                 \
-    (! (enc)->isUtf16 || (((char *)(s) - (char *)NULL) & 1))
+#  define MUST_CONVERT(enc, s) (! (enc)->isUtf16 || (((uintptr_t)(s)) & 1))
 typedef unsigned short ICHAR;
 #else
 #  define XML_ENCODE_MAX XML_UTF8_ENCODE_MAX


### PR DESCRIPTION
Fixes #390

Pointer arithmetic with NULL is undefined behavior.
This reverts c71f27573bd0205558a78792b554764f9c962179

CC @noloader