### PR TITLE
Don't add to NULL in iterator.

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -6506,7 +6506,7 @@ hashTableInit(HASH_TABLE *p, const XML_Memory_Handling_Suite *ms) {
 static void FASTCALL
 hashTableIterInit(HASH_TABLE_ITER *iter, const HASH_TABLE *table) {
   iter->p = table->v;
-  iter->end = iter->p + table->size;
+  iter->end = iter->p ? iter->p + table->size : NULL;
 }
 
 static NAMED *FASTCALL


### PR DESCRIPTION
In C it is undefined to add anything to NULL. Clang recently began
taking advantage of this and can assume that if anything is added or
subtracted from a pointer that the pointer can be assumed non-NULL. The
Address Sanitizer has been updated to report when this happens at
runtime and produces messages like

expat/lib/xmlparse.c:6509:23: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior expat/lib/xmlparse.c:6509:23

This can be mitigated with 'p ? p + n : NULL' which optimizes to just
the add in all optimizing compilers, but avoids the undefined behavior.