### PR TITLE
cmake: Add include dir to cmake package

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -322,7 +322,8 @@ endif()
 expat_install(TARGETS ${EXPAT_TARGET} EXPORT expat
                       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 expat_install(FILES lib/expat.h lib/expat_external.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 


### PR DESCRIPTION
This change allows people using the cmake package to determine the include directory when linking the library target.

It is part of my changes for updating the libexpat in hunter package manager (which uses CMake for everything and therefore exercises some of this stuff quite well).