### PR TITLE
Document the exit codes for xmlwf.

### DIFF
--- a/expat/doc/xmlwf.xml
+++ b/expat/doc/xmlwf.xml
@@ -388,7 +388,7 @@ supports both.
 
   <refsect1>
   <title>EXIT STATUS</title>
-    <para>The following exit status codes are returned:
+    <para>For option <option>-v</option> or <option>-h</option>, <command>&dhpackage;</command> always exits with status code 0.  For other cases, the following exit status codes are returned:
     <variablelist>
       <varlistentry>
         <term><option>0</option></term>
@@ -403,6 +403,11 @@ supports both.
       <varlistentry>
         <term><option>2</option></term>
         <listitem><para>An input file was not well-formed or could not be parsed.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>3</option></term>
+        <listitem><para>If using the <option>-d</option> option, an error occurred opening an output file.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/expat/doc/xmlwf.xml
+++ b/expat/doc/xmlwf.xml
@@ -383,19 +383,35 @@ supports both.
 	<command>&dhpackage;</command> prints a single line describing
 	the problem to standard output.  If a file is well formed,
 	<command>&dhpackage;</command> outputs nothing.
-	Note that the result code is <emphasis>not</emphasis> set.
 	</para>
   </refsect1>
+
+  <refsect1>
+  <title>EXIT STATUS</title>
+    <para>The following exit status codes are returned:
+    <variablelist>
+      <varlistentry>
+        <term><option>0</option></term>
+        <listitem><para>The input files are well-formed.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>1</option></term>
+        <listitem><para>An internal error occurred.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><option>2</option></term>
+        <listitem><para>An input file was not well-formed or could not be parsed.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+	</para>
+  </refsect1>
+
   
   <refsect1>
     <title>BUGS</title>
-	<para>
-	<command>&dhpackage;</command> returns a 0 - noerr result,
-	even if the file is not well-formed.  There is no good way for
-	a program to use <command>&dhpackage;</command> to quickly
-	check a file -- it must parse <command>&dhpackage;</command>'s
-	standard output.
-	</para>
 	<para>
 	The errors should go to standard error, not standard output.
 	</para>

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -1057,7 +1057,7 @@ tmain(int argc, XML_Char **argv) {
       userData.fp = tfopen(outName, T("wb"));
       if (! userData.fp) {
         tperror(outName);
-        exit(1);
+        exit(3);
       }
       setvbuf(userData.fp, NULL, _IOFBF, 16384);
 #ifdef XML_UNICODE


### PR DESCRIPTION
Since 70a4a691fc43644e69d3876ed7d43ab717c9cb43 the exit codes are useful for xmlwf, so update the man page.