### PR TITLE
Get rid of unsigned integer overflow in column calculation

### DIFF
--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -1768,13 +1768,14 @@ PREFIX(updatePosition)(const ENCODING *enc, const char *ptr, const char *end,
 #  define LEAD_CASE(n)                                                         \
   case BT_LEAD##n:                                                             \
     ptr += n;                                                                  \
+    pos->columnNumber++;                                                       \
     break;
       LEAD_CASE(2)
       LEAD_CASE(3)
       LEAD_CASE(4)
 #  undef LEAD_CASE
     case BT_LF:
-      pos->columnNumber = (XML_Size)-1;
+      pos->columnNumber = 0;
       pos->lineNumber++;
       ptr += MINBPC(enc);
       break;
@@ -1783,13 +1784,13 @@ PREFIX(updatePosition)(const ENCODING *enc, const char *ptr, const char *end,
       ptr += MINBPC(enc);
       if (HAS_CHAR(enc, ptr, end) && BYTE_TYPE(enc, ptr) == BT_LF)
         ptr += MINBPC(enc);
-      pos->columnNumber = (XML_Size)-1;
+      pos->columnNumber = 0;
       break;
     default:
       ptr += MINBPC(enc);
+      pos->columnNumber++;
       break;
     }
-    pos->columnNumber++;
   }
 }
 


### PR DESCRIPTION
While unsigned integer overflow is well-defined, Android sanitizers treat it
as an error. We also have some in the SipHash implementation but those won't
be easy to get rid of.