### PR TITLE
control build options by variables on usage by cmake FetchContent command

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 cmake_minimum_required(VERSION 3.1.3)
 
+if(POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif()
+
 project(expat
     VERSION
         2.2.9


### PR DESCRIPTION
added "new" behaviour for Policy CMP0077 which allows to control the build options by cmake variables if lib is used by FetchContent of a super project

example usage as subproject: 
  FetchContent_Declare(expat
  		 GIT_REPOSITORY https://github.com/gittiver/libexpat.git
		 GIT_TAG master)
  if(NOT expat_POPULATED)

    set(EXPAT_SHARED_LIBS Off)
    set(EXPAT_BUILD_TOOLS Off)
    set(EXPAT_BUILD_EXAMPLES Off)
    set(EXPAT_BUILD_TESTS Off)
    set(EXPAT_SHARED_LIBS Off)
    set(EXPAT_BUILD_DOCS Off)
    set(EXPAT_BUILD_FUZZERS Off)
    set(EXPAT_WITH_LIBBSD Off)
    set(EXPAT_ENABLE_INSTALL On)
    FetchContent_Populate(expat)

    add_subdirectory(${expat_SOURCE_DIR}/expat ${expat_BINARY_DIR})
