### PR TITLE
CMake: Support "make package" based on CPack

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -622,6 +622,25 @@ expat_install(
 )
 
 #
+# CPack
+#
+
+# This effectively disables target "package_source".
+# That is done due to CPack's unfortunate choice of an exclusion list
+# rather than inclusion list.  An exclusion list does not protect against
+# unwanted files ending up in the resulting archive in a way that's
+# safe to run from an Expat developer's machine.
+set(CPACK_SOURCE_GENERATOR '')
+
+if(WIN32)
+    set(CPACK_GENERATOR ZIP)
+else()
+    set(CPACK_GENERATOR TGZ)
+endif()
+
+include(CPack)
+
+#
 # Summary
 #
 if(EXPAT_CHAR_TYPE STREQUAL "char")


### PR DESCRIPTION
On Linux, this will create a file `expat-2.2.9-Linux.tar.gz` with the following content:

```
$ tar tf expat-2.2.9-Linux.tar.gz | sort | grep -v '/$'
expat-2.2.9-Linux/bin/xmlwf
expat-2.2.9-Linux/include/expat_config.h
expat-2.2.9-Linux/include/expat_external.h
expat-2.2.9-Linux/include/expat.h
expat-2.2.9-Linux/lib64/cmake/expat-2.2.9/expat.cmake
expat-2.2.9-Linux/lib64/cmake/expat-2.2.9/expat-config.cmake
expat-2.2.9-Linux/lib64/cmake/expat-2.2.9/expat-config-version.cmake
expat-2.2.9-Linux/lib64/cmake/expat-2.2.9/expat-noconfig.cmake
expat-2.2.9-Linux/lib64/libexpat.so
expat-2.2.9-Linux/lib64/libexpat.so.1
expat-2.2.9-Linux/lib64/libexpat.so.1.6.11
expat-2.2.9-Linux/lib64/pkgconfig/expat.pc
expat-2.2.9-Linux/share/doc/expat/AUTHORS
expat-2.2.9-Linux/share/doc/expat/changelog
expat-2.2.9-Linux/share/man/man1/xmlwf.1
```