### PR TITLE
Make testrunner output more helpful (related to #382)

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -56,7 +56,7 @@ elif [[ ${MODE} = cmake-oos ]]; then
     mkdir build
     cd build
     cmake ${CMAKE_ARGS} ..
-    make VERBOSE=1 all test
+    make VERBOSE=1 CTEST_OUTPUT_ON_FAILURE=1 all test
     make DESTDIR="${PWD}"/ROOT install
     find ROOT -printf "%P\n" | sort
 elif [[ ${MODE} = cppcheck ]]; then

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -187,7 +187,7 @@ srunner_run_all(SRunner *runner, int verbosity) {
     }
     tc = tc->next_tcase;
   }
-  if (verbosity) {
+  if (verbosity != CK_SILENT) {
     int passed = runner->nchecks - runner->nfailures;
     double percentage = ((double)passed) / runner->nchecks;
     int display = (int)(percentage * 100);

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -203,8 +203,8 @@ _fail_unless(int condition, const char *file, int line, const char *msg) {
      it is.
   */
   UNUSED_P(condition);
-  UNUSED_P(file);
-  UNUSED_P(line);
+  _check_current_filename = file;
+  _check_current_lineno = line;
   if (msg != NULL) {
     const int has_newline = (msg[strlen(msg) - 1] == '\n');
     fprintf(stderr, "ERROR: %s%s", msg, has_newline ? "" : "\n");

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -150,7 +150,7 @@ handle_success(int verbosity) {
 static void
 handle_failure(SRunner *runner, int verbosity, const char *phase_info) {
   runner->nfailures++;
-  if (verbosity >= CK_VERBOSE) {
+  if (verbosity != CK_SILENT) {
     printf("FAIL: %s (%s at %s:%d)\n", _check_current_function, phase_info,
            _check_current_filename, _check_current_lineno);
   }


### PR DESCRIPTION
Context is ex-issue #382. @Oleksandr-Popovych any chance you could do review by 2020-10-31?

This pull request is inspired by https://github.com/openembedded/openembedded-core/blob/master/meta/recipes-core/expat/expat/0001-Add-output-of-tests-result.patch