### PR TITLE
docs: fix simple typo, wtihout -> without

### DIFF
--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -1761,7 +1761,7 @@ START_TEST(test_not_standalone_handler_accept) {
   XML_SetNotStandaloneHandler(g_parser, accept_not_standalone_handler);
   run_ext_character_check(text, &test_data, XCS(""));
 
-  /* Repeat wtihout the external entity handler */
+  /* Repeat without the external entity handler */
   XML_ParserReset(g_parser, NULL);
   XML_SetNotStandaloneHandler(g_parser, accept_not_standalone_handler);
   run_character_check(text, XCS(""));


### PR DESCRIPTION
There is a small typo in expat/tests/runtests.c.

Should read `without` rather than `wtihout`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md