### PR TITLE
CMake: Only set CMAKE_CXX_FLAGS after enable_language(CXX)

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -112,6 +112,11 @@ if(MSVC OR _EXPAT_HELP)
     set(EXPAT_MSVC_STATIC_CRT OFF CACHE BOOL "Use /MT flag (static CRT) when compiling in MSVC")
 endif()
 
+if(EXPAT_BUILD_TESTS)
+    # We have to call enable_language() before modifying any CMAKE_CXX_* variables
+    enable_language(CXX)
+endif()
+
 #
 # Environment checks
 #
@@ -426,7 +431,6 @@ endif()
 #
 if(EXPAT_BUILD_TESTS)
     ## these are unittests that can be run on any platform
-    enable_language(CXX)
     enable_testing()
 
     set(test_SRCS


### PR DESCRIPTION
Otherwise flags specified in a CMake cross-compilation toolchain (such as
CMAKE_CXX_FLAGS_INIT) will not be added. This could also affect native
builds but is much more likely to be noticed when cross-compiling due to
missing essential flags.