### PR TITLE
CMake: Support absolute paths for CMAKE_INSTALL_(LIB|INCLUDE)DIR (fixes #458)

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -383,8 +383,19 @@ expat_install(FILES lib/expat.h lib/expat_external.h DESTINATION ${CMAKE_INSTALL
 if(EXPAT_BUILD_PKGCONFIG)
     set(prefix ${CMAKE_INSTALL_PREFIX})
     set(exec_prefix "\${prefix}")
-    set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
-    set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+
+    if(CMAKE_INSTALL_LIBDIR MATCHES "^/")
+        set(libdir "${CMAKE_INSTALL_LIBDIR}")
+    else()
+        set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+    endif()
+
+    if(CMAKE_INSTALL_INCLUDEDIR MATCHES "^/")
+        set(includedir "${CMAKE_INSTALL_INCLUDEDIR}")
+    else()
+        set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif()
+
     configure_file(expat.pc.in ${CMAKE_CURRENT_BINARY_DIR}/expat.pc @ONLY)
     expat_install(FILES ${CMAKE_CURRENT_BINARY_DIR}/expat.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/expat/Changes
+++ b/expat/Changes
@@ -5,6 +5,8 @@ NOTE: We are looking for help with a few things:
 Release X.X.X XXX XXXXX XX XXXX
         Other changes:
             #457  Unexpose symbol _INTERNAL_trim_to_complete_utf8_characters
+       #458 #459  CMake: Support absolute paths for both CMAKE_INSTALL_LIBDIR
+                    and CMAKE_INSTALL_INCLUDEDIR
 
 Release 2.3.0 Thu March 25 2021
         Bug fixes:


### PR DESCRIPTION
Fixes #458

CC @rffontenelle