### PR TITLE
GitHub Actions: Avoid error "would clobber existing tag" when triggered by pushing a new Git tag

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,7 +68,7 @@ jobs:
             wine32
     - name: Unshallow Git clone
       run: |
-        git fetch --tags --unshallow origin  # for "git describe" in coverage.sh
+        git fetch --force --tags --unshallow origin  # for "git describe" in coverage.sh
     - name: Collect test coverage
       env:
         MODE: coverage-sh


### PR DESCRIPTION
Sample case at https://github.com/libexpat/libexpat/runs/2647710794?check_suite_focus=true#step:5:37