### PR TITLE
Fix -Wimplicit-fallthrough for Clang.

### DIFF
--- a/expat/expat_config.h.cmake
+++ b/expat/expat_config.h.cmake
@@ -108,6 +108,19 @@
 #  define __func__ __FUNCTION__
 #endif
 
+/* Attribute to annotate explicit fallthrough. As noted on
+   https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html ,
+   combining the two tests in one conditional would not be portable. */
+#if defined __has_attribute
+#  if __has_attribute (fallthrough)
+#    define FALLTHROUGH __attribute__ ((fallthrough))
+#  else
+#    define FALLTHROUGH
+#  endif
+#else
+  #define FALLTHROUGH
+#endif
+
 /* Define to `long' if <sys/types.h> does not define. */
 #cmakedefine off_t @OFF_T@
 

--- a/expat/expat_config.h.cmake
+++ b/expat/expat_config.h.cmake
@@ -108,19 +108,6 @@
 #  define __func__ __FUNCTION__
 #endif
 
-/* Attribute to annotate explicit fallthrough. As noted on
-   https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html ,
-   combining the two tests in one conditional would not be portable. */
-#if defined __has_attribute
-#  if __has_attribute (fallthrough)
-#    define FALLTHROUGH __attribute__ ((fallthrough))
-#  else
-#    define FALLTHROUGH
-#  endif
-#else
-  #define FALLTHROUGH
-#endif
-
 /* Define to `long' if <sys/types.h> does not define. */
 #cmakedefine off_t @OFF_T@
 

--- a/expat/lib/internal.h
+++ b/expat/lib/internal.h
@@ -31,6 +31,7 @@
    Copyright (c) 2016-2021 Sebastian Pipping <sebastian@pipping.org>
    Copyright (c) 2018      Yury Gribov <tetra2005@gmail.com>
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
+   Copyright (c) 2021      Peter Kasting <pkasting@chromium.org>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -127,6 +128,16 @@
 #    define EXPAT_FMT_PTRDIFF_T(midpart) "%" midpart "d"
 #    define EXPAT_FMT_SIZE_T(midpart) "%" midpart "u"
 #  endif
+#endif
+
+#ifndef __has_attribute
+#  define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(fallthrough)
+#  define FALLTHROUGH __attribute__((fallthrough))
+#else
+#  define FALLTHROUGH
 #endif
 
 #ifndef UNUSED_P

--- a/expat/lib/siphash.h
+++ b/expat/lib/siphash.h
@@ -11,6 +11,9 @@
  * --------------------------------------------------------------------------
  * HISTORY:
  *
+ * 2021-06-26  (Peter Kasting)
+ *   - Convert fallthrough annotations to macros to support Clang
+ *
  * 2020-10-03  (Sebastian Pipping)
  *   - Drop support for Visual Studio 9.0/2008 and earlier
  *
@@ -100,6 +103,8 @@
 
 #include <stddef.h> /* size_t */
 #include <stdint.h> /* uint64_t uint32_t uint8_t */
+
+#include <expat_config.h>
 
 /*
  * Workaround to not require a C++11 compiler for using ULL suffix
@@ -235,25 +240,25 @@ sip24_final(struct siphash *H) {
   switch (left) {
   case 7:
     b |= (uint64_t)H->buf[6] << 48;
-    /* fall through */
+    FALLTHROUGH;
   case 6:
     b |= (uint64_t)H->buf[5] << 40;
-    /* fall through */
+    FALLTHROUGH;
   case 5:
     b |= (uint64_t)H->buf[4] << 32;
-    /* fall through */
+    FALLTHROUGH;
   case 4:
     b |= (uint64_t)H->buf[3] << 24;
-    /* fall through */
+    FALLTHROUGH;
   case 3:
     b |= (uint64_t)H->buf[2] << 16;
-    /* fall through */
+    FALLTHROUGH;
   case 2:
     b |= (uint64_t)H->buf[1] << 8;
-    /* fall through */
+    FALLTHROUGH;
   case 1:
     b |= (uint64_t)H->buf[0] << 0;
-    /* fall through */
+    FALLTHROUGH;
   case 0:
     break;
   }

--- a/expat/lib/siphash.h
+++ b/expat/lib/siphash.h
@@ -104,7 +104,15 @@
 #include <stddef.h> /* size_t */
 #include <stdint.h> /* uint64_t uint32_t uint8_t */
 
-#include <expat_config.h>
+#ifndef __has_attribute
+#  define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(fallthrough)
+#  define SIPHASH_FALLTHROUGH __attribute__((fallthrough))
+#else
+#  define SIPHASH_FALLTHROUGH
+#endif
 
 /*
  * Workaround to not require a C++11 compiler for using ULL suffix
@@ -240,25 +248,25 @@ sip24_final(struct siphash *H) {
   switch (left) {
   case 7:
     b |= (uint64_t)H->buf[6] << 48;
-    FALLTHROUGH;
+    SIPHASH_FALLTHROUGH;
   case 6:
     b |= (uint64_t)H->buf[5] << 40;
-    FALLTHROUGH;
+    SIPHASH_FALLTHROUGH;
   case 5:
     b |= (uint64_t)H->buf[4] << 32;
-    FALLTHROUGH;
+    SIPHASH_FALLTHROUGH;
   case 4:
     b |= (uint64_t)H->buf[3] << 24;
-    FALLTHROUGH;
+    SIPHASH_FALLTHROUGH;
   case 3:
     b |= (uint64_t)H->buf[2] << 16;
-    FALLTHROUGH;
+    SIPHASH_FALLTHROUGH;
   case 2:
     b |= (uint64_t)H->buf[1] << 8;
-    FALLTHROUGH;
+    SIPHASH_FALLTHROUGH;
   case 1:
     b |= (uint64_t)H->buf[0] << 0;
-    FALLTHROUGH;
+    SIPHASH_FALLTHROUGH;
   case 0:
     break;
   }

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -32,6 +32,7 @@
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
    Copyright (c) 2019-2020 Ben Wagner <bungeman@chromium.org>
    Copyright (c) 2019      Vadim Zeitlin <vadim@zeitlins.org>
+   Copyright (c) 2021      Peter Kasting <pkasting@chromium.org>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -1832,7 +1833,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       return XML_STATUS_ERROR;
     }
-    /* fall through */
+    FALLTHROUGH;
   default:
     parser->m_parsingStatus.parsing = XML_PARSING;
   }
@@ -1875,7 +1876,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
       case XML_INITIALIZED:
       case XML_PARSING:
         parser->m_parsingStatus.parsing = XML_FINISHED;
-        /* fall through */
+        FALLTHROUGH;
       default:
         return XML_STATUS_OK;
       }
@@ -1992,7 +1993,7 @@ XML_ParseBuffer(XML_Parser parser, int len, int isFinal) {
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       return XML_STATUS_ERROR;
     }
-    /* fall through */
+    FALLTHROUGH;
   default:
     parser->m_parsingStatus.parsing = XML_PARSING;
   }
@@ -2022,6 +2023,7 @@ XML_ParseBuffer(XML_Parser parser, int len, int isFinal) {
         parser->m_parsingStatus.parsing = XML_FINISHED;
         return result;
       }
+      FALLTHROUGH;
     default:; /* should not happen */
     }
   }
@@ -2210,6 +2212,7 @@ XML_ResumeParser(XML_Parser parser) {
         parser->m_parsingStatus.parsing = XML_FINISHED;
         return result;
       }
+      FALLTHROUGH;
     default:;
     }
   }
@@ -4511,7 +4514,7 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
         handleDefault = XML_FALSE;
         goto alreadyChecked;
       }
-      /* fall through */
+      FALLTHROUGH;
     case XML_ROLE_ENTITY_PUBLIC_ID:
       if (! XmlIsPublicId(enc, s, next, eventPP))
         return XML_ERROR_PUBLICID;
@@ -4817,7 +4820,7 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
         parser->m_declEntity->publicId = NULL;
       }
 #endif /* XML_DTD */
-      /* fall through */
+      FALLTHROUGH;
     case XML_ROLE_ENTITY_SYSTEM_ID:
       if (dtd->keepProcessing && parser->m_declEntity) {
         parser->m_declEntity->systemId
@@ -5636,7 +5639,7 @@ appendAttributeValue(XML_Parser parser, const ENCODING *enc, XML_Bool isCdata,
       break;
     case XML_TOK_TRAILING_CR:
       next = ptr + enc->minBytesPerChar;
-      /* fall through */
+      FALLTHROUGH;
     case XML_TOK_ATTRIBUTE_VALUE_S:
     case XML_TOK_DATA_NEWLINE:
       if (! isCdata && (poolLength(pool) == 0 || poolLastChar(pool) == 0x20))
@@ -5890,7 +5893,7 @@ storeEntityValue(XML_Parser parser, const ENCODING *enc,
       break;
     case XML_TOK_TRAILING_CR:
       next = entityTextPtr + enc->minBytesPerChar;
-      /* fall through */
+      FALLTHROUGH;
     case XML_TOK_DATA_NEWLINE:
       if (pool->end == pool->ptr && ! poolGrow(pool)) {
         result = XML_ERROR_NO_MEMORY;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1919,7 +1919,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
           parser->m_parsingStatus.parsing = XML_FINISHED;
           return XML_STATUS_OK;
         }
-      /* fall through */
+        FALLTHROUGH;
       default:
         result = XML_STATUS_OK;
       }

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -20,6 +20,7 @@
    Copyright (c) 2017      Benbuck Nason <bnason@netflix.com>
    Copyright (c) 2017      José Gutiérrez de la Concha <jose@zeroc.com>
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
+   Copyright (c) 2021      Peter Kasting <pkasting@chromium.org>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -303,6 +304,9 @@ sb_charMatches(const ENCODING *enc, const char *p, int c) {
 #  define CHAR_MATCHES(enc, p, c) (*(p) == c)
 #endif
 
+/* Fallthrough statements are unreachable. */
+#define MAYBE_FALLTHROUGH
+
 #define PREFIX(ident) normal_##ident
 #define XML_TOK_IMPL_C
 #include "xmltok_impl.c"
@@ -317,6 +321,7 @@ sb_charMatches(const ENCODING *enc, const char *p, int c) {
 #undef IS_NMSTRT_CHAR
 #undef IS_NMSTRT_CHAR_MINBPC
 #undef IS_INVALID_CHAR
+#undef MAYBE_FALLTHROUGH
 
 enum { /* UTF8_cvalN is value of masked first byte of N byte sequence */
        UTF8_cval1 = 0x00,
@@ -642,7 +647,7 @@ unicode_byte_type(char hi, char lo) {
           *(*toP)++ = lo;                                                      \
           break;                                                               \
         }                                                                      \
-        /* fall through */                                                     \
+        FALLTHROUGH;                                                           \
       case 0x1:                                                                \
       case 0x2:                                                                \
       case 0x3:                                                                \
@@ -797,6 +802,8 @@ little2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  define IS_NAME_CHAR_MINBPC(enc, p) LITTLE2_IS_NAME_CHAR_MINBPC(p)
 #  define IS_NMSTRT_CHAR(enc, p, n) (0)
 #  define IS_NMSTRT_CHAR_MINBPC(enc, p) LITTLE2_IS_NMSTRT_CHAR_MINBPC(p)
+/* Fallthrough statements are reachable. */
+#  define MAYBE_FALLTHROUGH FALLTHROUGH
 
 #  define XML_TOK_IMPL_C
 #  include "xmltok_impl.c"
@@ -811,6 +818,7 @@ little2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  undef IS_NMSTRT_CHAR
 #  undef IS_NMSTRT_CHAR_MINBPC
 #  undef IS_INVALID_CHAR
+#  undef MAYBE_FALLTHROUGH
 
 #endif /* not XML_MIN_SIZE */
 
@@ -932,6 +940,8 @@ big2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  define IS_NAME_CHAR_MINBPC(enc, p) BIG2_IS_NAME_CHAR_MINBPC(p)
 #  define IS_NMSTRT_CHAR(enc, p, n) (0)
 #  define IS_NMSTRT_CHAR_MINBPC(enc, p) BIG2_IS_NMSTRT_CHAR_MINBPC(p)
+/* Fallthrough statements are reachable. */
+#  define MAYBE_FALLTHROUGH FALLTHROUGH
 
 #  define XML_TOK_IMPL_C
 #  include "xmltok_impl.c"
@@ -946,6 +956,7 @@ big2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  undef IS_NMSTRT_CHAR
 #  undef IS_NMSTRT_CHAR_MINBPC
 #  undef IS_INVALID_CHAR
+#  undef MAYBE_FALLTHROUGH
 
 #endif /* not XML_MIN_SIZE */
 
@@ -1565,7 +1576,7 @@ initScan(const ENCODING *const *encodingTable, const INIT_ENCODING *enc,
     case 0xEF: /* possibly first byte of UTF-8 BOM */
       if (INIT_ENC_INDEX(enc) == ISO_8859_1_ENC && state == XML_CONTENT_STATE)
         break;
-      /* fall through */
+      FALLTHROUGH;
     case 0x00:
     case 0x3C:
       return XML_TOK_PARTIAL;

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -305,7 +305,7 @@ sb_charMatches(const ENCODING *enc, const char *p, int c) {
 #endif
 
 /* Fallthrough statements are unreachable. */
-#define MAYBE_FALLTHROUGH
+#define FALLTHROUGH_IF_REACHABLE
 
 #define PREFIX(ident) normal_##ident
 #define XML_TOK_IMPL_C
@@ -321,7 +321,7 @@ sb_charMatches(const ENCODING *enc, const char *p, int c) {
 #undef IS_NMSTRT_CHAR
 #undef IS_NMSTRT_CHAR_MINBPC
 #undef IS_INVALID_CHAR
-#undef MAYBE_FALLTHROUGH
+#undef FALLTHROUGH_IF_REACHABLE
 
 enum { /* UTF8_cvalN is value of masked first byte of N byte sequence */
        UTF8_cval1 = 0x00,
@@ -803,7 +803,7 @@ little2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  define IS_NMSTRT_CHAR(enc, p, n) (0)
 #  define IS_NMSTRT_CHAR_MINBPC(enc, p) LITTLE2_IS_NMSTRT_CHAR_MINBPC(p)
 /* Fallthrough statements are reachable. */
-#  define MAYBE_FALLTHROUGH FALLTHROUGH
+#  define FALLTHROUGH_IF_REACHABLE FALLTHROUGH
 
 #  define XML_TOK_IMPL_C
 #  include "xmltok_impl.c"
@@ -818,7 +818,7 @@ little2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  undef IS_NMSTRT_CHAR
 #  undef IS_NMSTRT_CHAR_MINBPC
 #  undef IS_INVALID_CHAR
-#  undef MAYBE_FALLTHROUGH
+#  undef FALLTHROUGH_IF_REACHABLE
 
 #endif /* not XML_MIN_SIZE */
 
@@ -941,7 +941,7 @@ big2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  define IS_NMSTRT_CHAR(enc, p, n) (0)
 #  define IS_NMSTRT_CHAR_MINBPC(enc, p) BIG2_IS_NMSTRT_CHAR_MINBPC(p)
 /* Fallthrough statements are reachable. */
-#  define MAYBE_FALLTHROUGH FALLTHROUGH
+#  define FALLTHROUGH_IF_REACHABLE FALLTHROUGH
 
 #  define XML_TOK_IMPL_C
 #  include "xmltok_impl.c"
@@ -956,7 +956,7 @@ big2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  undef IS_NMSTRT_CHAR
 #  undef IS_NMSTRT_CHAR_MINBPC
 #  undef IS_INVALID_CHAR
-#  undef MAYBE_FALLTHROUGH
+#  undef FALLTHROUGH_IF_REACHABLE
 
 #endif /* not XML_MIN_SIZE */
 

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -304,8 +304,13 @@ sb_charMatches(const ENCODING *enc, const char *p, int c) {
 #  define CHAR_MATCHES(enc, p, c) (*(p) == c)
 #endif
 
-/* Fallthrough statements are unreachable. */
-#define FALLTHROUGH_IF_REACHABLE
+/* Fallthrough statements are unreachable. Clang warns if they are annotated,
+   gcc warns if they are not. */
+#if defined __clang__
+#  define FALLTHROUGH_IF_REACHABLE
+#else
+#  define FALLTHROUGH_IF_REACHABLE FALLTHROUGH
+#endif
 
 #define PREFIX(ident) normal_##ident
 #define XML_TOK_IMPL_C

--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -83,7 +83,7 @@
       *nextTokPtr = ptr;                                                       \
       return XML_TOK_INVALID;                                                  \
     }                                                                          \
-    MAYBE_FALLTHROUGH;                                                         \
+    FALLTHROUGH_IF_REACHABLE;                                                  \
   case BT_NMSTRT:                                                              \
   case BT_HEX:                                                                 \
   case BT_DIGIT:                                                               \
@@ -112,7 +112,7 @@
       *nextTokPtr = ptr;                                                       \
       return XML_TOK_INVALID;                                                  \
     }                                                                          \
-    MAYBE_FALLTHROUGH;                                                         \
+    FALLTHROUGH_IF_REACHABLE;                                                  \
   case BT_NMSTRT:                                                              \
   case BT_HEX:                                                                 \
     ptr += MINBPC(enc);                                                        \

--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -16,6 +16,7 @@
    Copyright (c) 2018      Anton Maklakov <antmak.pub@gmail.com>
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
    Copyright (c) 2020      Boris Kolpackov <boris@codesynthesis.com>
+   Copyright (c) 2021      Peter Kasting <pkasting@chromium.org>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -82,7 +83,7 @@
       *nextTokPtr = ptr;                                                       \
       return XML_TOK_INVALID;                                                  \
     }                                                                          \
-    /* fall through */                                                         \
+    MAYBE_FALLTHROUGH;                                                         \
   case BT_NMSTRT:                                                              \
   case BT_HEX:                                                                 \
   case BT_DIGIT:                                                               \
@@ -111,7 +112,7 @@
       *nextTokPtr = ptr;                                                       \
       return XML_TOK_INVALID;                                                  \
     }                                                                          \
-    /* fall through */                                                         \
+    MAYBE_FALLTHROUGH;                                                         \
   case BT_NMSTRT:                                                              \
   case BT_HEX:                                                                 \
     ptr += MINBPC(enc);                                                        \
@@ -321,7 +322,7 @@ PREFIX(scanPi)(const ENCODING *enc, const char *ptr, const char *end,
         *nextTokPtr = ptr + MINBPC(enc);
         return tok;
       }
-      /* fall through */
+      FALLTHROUGH;
     default:
       *nextTokPtr = ptr;
       return XML_TOK_INVALID;
@@ -613,7 +614,7 @@ PREFIX(scanAtts)(const ENCODING *enc, const char *ptr, const char *end,
           return XML_TOK_INVALID;
         }
       }
-      /* fall through */
+      FALLTHROUGH;
     case BT_EQUALS: {
       int open;
 #  ifdef XML_NS
@@ -896,7 +897,7 @@ PREFIX(contentTok)(const ENCODING *enc, const char *ptr, const char *end,
           return XML_TOK_INVALID;
         }
       }
-      /* fall through */
+      FALLTHROUGH;
     case BT_AMP:
     case BT_LT:
     case BT_NONXML:
@@ -1057,7 +1058,7 @@ PREFIX(prologTok)(const ENCODING *enc, const char *ptr, const char *end,
       /* indicate that this might be part of a CR/LF pair */
       return -XML_TOK_PROLOG_S;
     }
-    /* fall through */
+    FALLTHROUGH;
   case BT_S:
   case BT_LF:
     for (;;) {
@@ -1072,7 +1073,7 @@ PREFIX(prologTok)(const ENCODING *enc, const char *ptr, const char *end,
         /* don't split CR/LF pair */
         if (ptr + MINBPC(enc) != end)
           break;
-        /* fall through */
+        FALLTHROUGH;
       default:
         *nextTokPtr = ptr;
         return XML_TOK_PROLOG_S;
@@ -1183,7 +1184,7 @@ PREFIX(prologTok)(const ENCODING *enc, const char *ptr, const char *end,
       tok = XML_TOK_NMTOKEN;
       break;
     }
-    /* fall through */
+    FALLTHROUGH;
   default:
     *nextTokPtr = ptr;
     return XML_TOK_INVALID;
@@ -1478,7 +1479,7 @@ PREFIX(isPublicId)(const ENCODING *enc, const char *ptr, const char *end,
     case BT_NMSTRT:
       if (! (BYTE_TO_ASCII(enc, ptr) & ~0x7f))
         break;
-      /* fall through */
+      FALLTHROUGH;
     default:
       switch (BYTE_TO_ASCII(enc, ptr)) {
       case 0x24: /* $ */

--- a/expat/qa.sh
+++ b/expat/qa.sh
@@ -102,6 +102,7 @@ populate_environment() {
                 export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:abort_on_error=1"
                 ;;
         esac
+        BASE_COMPILE_FLAGS+=" -Wimplicit-fallthrough"
     fi
 
 

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -17,6 +17,7 @@
    Copyright (c) 2020      Joe Orton <jorton@redhat.com>
    Copyright (c) 2020      Kleber Tarcísio <klebertarcisio@yahoo.com.br>
    Copyright (c) 2021      Tim Bray <tbray@textuality.com>
+   Copyright (c) 2021      Peter Kasting <pkasting@chromium.org>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -51,7 +52,7 @@
 
 #include "expat.h"
 #include "codepage.h"
-#include "internal.h" /* for UNUSED_P only */
+#include "internal.h"
 #include "xmlfile.h"
 #include "xmltchar.h"
 
@@ -1003,7 +1004,7 @@ tmain(int argc, XML_Char **argv) {
       break;
     case T('p'):
       paramEntityParsing = XML_PARAM_ENTITY_PARSING_ALWAYS;
-      /* fall through */
+      FALLTHROUGH;
     case T('x'):
       processFlags |= XML_EXTERNAL_ENTITIES;
       j++;
@@ -1094,7 +1095,7 @@ tmain(int argc, XML_Char **argv) {
         j = 0;
         break;
       }
-      /* fall through */
+      FALLTHROUGH;
     default:
       usage(argv[0], XMLWF_EXIT_USAGE_ERROR);
     }


### PR DESCRIPTION
The existing `/* fall through */` comments sufficed to annotate explicit
fallthrough for gcc, but not clang.  Convert to a macro that expands to
an annotation in supported compilers.

Further complicating this is that one of the #includes of xmltok_impl.c
makes the fallthrough annotations unreachable at compile time, so they
must be #defined away to avoid yet another warning (for an unreachable
fallthrough annotation) in that case.

Bug: [chromium:995993](https://bugs.chromium.org/p/chromium/issues/detail?id=995993)