### PR TITLE
RFE: bulk xml facilities

### DIFF
--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -350,6 +350,16 @@ typedef void(XMLCALL *XML_EntityDeclHandler)(
 XMLPARSEAPI(void)
 XML_SetEntityDeclHandler(XML_Parser parser, XML_EntityDeclHandler handler);
 
+
+/* This is called for the end of the XML when the parser is working
+   in bulk mode (parse data or stream containing multiple XML chunks).
+*/
+typedef void(XMLCALL *XML_BulkXMLEndHandler)(void *userData);
+XMLPARSEAPI(void)
+
+XML_SetBulkXMLEndHandler(XML_Parser parser, XML_BulkXMLEndHandler handler);
+
+
 /* OBSOLETE -- OBSOLETE -- OBSOLETE
    This handler has been superseded by the EntityDeclHandler above.
    It is provided here for backward compatibility.

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -5328,11 +5328,6 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
       case XML_TOK_BOM:
         handleDefault = XML_FALSE;
         break;
-#if 0 /* todo: avoid infinite loop on certain (wrong) conditions */
-      default:
-        /* unexpected role token combination retrieved */
-        return XML_ERROR_SYNTAX;
-#endif
       }
       break;
     case XML_ROLE_DOCTYPE_NONE:
@@ -5355,11 +5350,6 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
       if (parser->m_elementDeclHandler)
         handleDefault = XML_FALSE;
       break;
-#if 0 /* todo: avoid infinite loop on certain (wrong) conditions */
-    default:
-      /* unexpected role retrieved */
-      return XML_ERROR_SYNTAX;
-#endif
     } /* end of big switch */
 
     if (handleDefault && parser->m_defaultHandler)


### PR DESCRIPTION
This PR proposes an enhancement for ability to parse multiple XMLs in single stream, file, dump or data buffer in one go (so called bulk-XML parsing).

This solution is part of similar [RFE for tdom Tcl-module](tdom.org/index.html/timeline?r=experimental%2Fbulk-xml-parse), which is using libexpat. Thus to avoid possible maintenance or merge issue, we'd like to see the related changes as part of libexpat.

The change is totally backwards compatible and behaves completely as before if the BulkXMLEnd-handler is not set (it'd still throw an error `XML_ERROR_JUNK_AFTER_DOC_ELEMENT` by further XML data in stream as libexpat always did it).
If BulkXMLEnd-handler becomes set (with new function `XML_SetBulkXMLEndHandler`), the bulk-parsing will be enabled and parser is able to process multiple XMLs in single stream in one go. In this case the BulkXMLEnd-handler will be invoked after every fulfilled chunk XML if it was successfully parsed to the end of chunk. 
So if stream or file contains 100 XMLs, this handler will be called 100 times after every processed XML.

The test-cases of tdom (tcl-side) illustrating the behavior could be found [here](http://tdom.org/index.html/artifact?name=19b73d012b9afa8b&ln=912-990).