### PR TITLE
CMake: Ensure libexpat*.lib filenames with MSVC

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -401,7 +401,10 @@ if(WIN32 AND NOT MINGW)
     # NOTE: This avoids a name collision with Expat.dll of Perl's XML::Parser::Expat
     #       on Windows by resorting to filename libexpat.dll since Expat 1.95.3.
     #       Everything but MSVC is already adding prefix "lib", automatically.
-    set_property(TARGET expat PROPERTY PREFIX lib)
+    # NOTE: "set_property(TARGET expat PROPERTY PREFIX lib)" would only affect *.dll
+    #       files but not *.lib files, so we have to rely on propert OUTPUT_NAME, instead.
+    #       Property CMAKE_*_POSTFIX still applies.
+    set_property(TARGET expat PROPERTY OUTPUT_NAME libexpat)
 endif()
 
 target_include_directories(expat

--- a/expat/Changes
+++ b/expat/Changes
@@ -9,7 +9,7 @@ Release 2.4.2 xxx xxx xx xxxx
             #497  Autotools: Include files with release archives:
                     - buildconf.sh
                     - fuzz/*.c
-            #495  CMake: MinGW: Fix pkg-config section "Libs" for
+       #495 #524  CMake: MinGW: Fix pkg-config section "Libs" for
                     - non-release build types (e.g. -DCMAKE_BUILD_TYPE=Debug)
                     - multi-config CMake generators (e.g. Ninja Multi-Config)
        #522 #523  docs: Fix return value docs for both


### PR DESCRIPTION
This fixes a post-2.4.1 regression from commit 3486fd6e3d2bc269660cedd3befa1ae649d1dcf4 introduced by pull request #495.