### PR TITLE
lib: Address GCC 11.2.1 compiler warning

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -2,6 +2,10 @@ NOTE: We are looking for help with a few things:
       https://github.com/libexpat/libexpat/labels/help%20wanted
       If you can help, please get in touch.  Thanks!
 
+Release x.x.x xxx xxxxxxxx xx xxxx
+        Other changes:
+            #527  Address compiler warnings
+
 Release 2.4.2 Sun December 19 2021
         Other changes:
        #509 #510  Link againgst libm for function "isnan"

--- a/expat/lib/xmltok_ns.c
+++ b/expat/lib/xmltok_ns.c
@@ -93,7 +93,7 @@ NS(XmlInitEncoding)(INIT_ENCODING *p, const ENCODING **encPtr,
 static const ENCODING *
 NS(findEncoding)(const ENCODING *enc, const char *ptr, const char *end) {
 #  define ENCODING_MAX 128
-  char buf[ENCODING_MAX];
+  char buf[ENCODING_MAX] = "";
   char *p = buf;
   int i;
   XmlUtf8Convert(enc, &ptr, end, &p, p + ENCODING_MAX - 1);


### PR DESCRIPTION
Symptom was:
```
In file included from xmltok.c:58:
xmltok_ns.c: In function ‘findEncodingNS’:
xmltok.h:276:10: warning: ‘buf’ may be used uninitialized [-Wmaybe-uninitialized]
  276 |   (((enc)->utf8Convert)(enc, fromP, fromLim, toP, toLim))
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
xmltok_ns.c:99:3: note: in expansion of macro ‘XmlUtf8Convert’
   99 |   XmlUtf8Convert(enc, &ptr, end, &p, p + ENCODING_MAX - 1);
      |   ^~~~~~~~~~~~~~
xmltok.h:276:10: note: by argument 5 of type ‘const char *’ to ‘enum XML_Convert_Result(const ENCODING *, const char **, const char *, char **, const char *)’ {aka ‘enum XML_Convert_Result(const struct encoding *, const char **, const char *, char **, const char *)’}
  276 |   (((enc)->utf8Convert)(enc, fromP, fromLim, toP, toLim))
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
xmltok_ns.c:99:3: note: in expansion of macro ‘XmlUtf8Convert’
   99 |   XmlUtf8Convert(enc, &ptr, end, &p, p + ENCODING_MAX - 1);
      |   ^~~~~~~~~~~~~~
In file included from xmltok.c:1666:
xmltok_ns.c:96:8: note: ‘buf’ declared here
   96 |   char buf[ENCODING_MAX];
      |        ^~~
```