### PR TITLE
CMake: Make call to file(GENERATE [..]) work for CMake <3.19

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -481,8 +481,7 @@ if(EXPAT_BUILD_PKGCONFIG)
 
     file(GENERATE
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/expat.pc
-        INPUT ${PROJECT_SOURCE_DIR}/expat.pc.cmake
-        TARGET expat)
+        INPUT ${PROJECT_SOURCE_DIR}/expat.pc.cmake)
 
     expat_install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/expat.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/expat/Changes
+++ b/expat/Changes
@@ -4,6 +4,7 @@ NOTE: We are looking for help with a few things:
 
 Release x.x.x xxx xxxxxxxx xx xxxx
         Other changes:
+            #535  CMake: Make call to file(GENERATE [..]) work for CMake <3.19
        #527 #528  Address compiler warnings
 
 Release 2.4.2 Sun December 19 2021

--- a/expat/expat.pc.cmake
+++ b/expat/expat.pc.cmake
@@ -1,11 +1,11 @@
-prefix=$<TARGET_PROPERTY:pkgconfig_prefix>
-exec_prefix=$<TARGET_PROPERTY:pkgconfig_exec_prefix>
-libdir=$<TARGET_PROPERTY:pkgconfig_libdir>
-includedir=$<TARGET_PROPERTY:pkgconfig_includedir>
+prefix=$<TARGET_PROPERTY:expat,pkgconfig_prefix>
+exec_prefix=$<TARGET_PROPERTY:expat,pkgconfig_exec_prefix>
+libdir=$<TARGET_PROPERTY:expat,pkgconfig_libdir>
+includedir=$<TARGET_PROPERTY:expat,pkgconfig_includedir>
 
-Name: $<TARGET_PROPERTY:pkgconfig_$<LOWER_CASE:$<CONFIG>>_name>
-Version: $<TARGET_PROPERTY:pkgconfig_version>
+Name: $<TARGET_PROPERTY:expat,pkgconfig_$<LOWER_CASE:$<CONFIG>>_name>
+Version: $<TARGET_PROPERTY:expat,pkgconfig_version>
 Description: expat XML parser
 URL: https://libexpat.github.io/
-Libs: -L${libdir} -l$<TARGET_PROPERTY:pkgconfig_$<LOWER_CASE:$<CONFIG>>_name> $<TARGET_PROPERTY:pkgconfig_libm>
+Libs: -L${libdir} -l$<TARGET_PROPERTY:expat,pkgconfig_$<LOWER_CASE:$<CONFIG>>_name> $<TARGET_PROPERTY:expat,pkgconfig_libm>
 Cflags: -I${includedir}


### PR DESCRIPTION
Error from CMake 3.7.2 was:

```
CMake Error at CMakeLists.txt:482 (file):
  file Incorrect arguments to GENERATE subcommand.
```