### PR TITLE
run.sh.in: Do not use Wine with Cygwin and MSYS2

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -20,11 +20,15 @@ Release x.x.x xxx xxxxxxxx xx xxxx
         Other changes:
             #535  CMake: Make call to file(GENERATE [..]) work for CMake <3.19
        #527 #528  Address compiler warnings
+            #541  Autotools|CMake: MinGW: Make run.sh(.in) work for Cygwin
+                    and MSYS2 by not going through Wine on these platforms
 
         Infrastructure:
             #536  CI: Check for realistic minimum CMake version
 
         Special thanks to:
+            Christopher Degawa
+            J. Peter Mugaas
             Tyson Smith
                  and
             GCC Farm Project

--- a/expat/run.sh.in
+++ b/expat/run.sh.in
@@ -30,7 +30,16 @@
 
 case "@host@" in
 *-mingw*)
-    exec wine "$@"
+    case "$(uname -o)" in
+    Cygwin|Msys)
+        # Windows binary on Windows host
+        exec "$@"
+        ;;
+    *)
+        # Windows binary on non-Windows host
+        exec wine "$@"
+        ;;
+    esac
     ;;
 *)
     exec "$@"


### PR DESCRIPTION
Inspired by https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-expat/002-fix-tests.patch.

CC @1480c1 @JPeterMugaas