### PR TITLE
[>=2.3.0] xmlwf: Fix a memory leak on output file opening error (fixes #544)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -11,8 +11,14 @@ Release x.x.x xxx xxxxxxx xx xxxx
                     common and default).
                     Impact is denial of service or more.
 
+        Bug fixes:
+       #544 #545  xmlwf: Fix a memory leak on output file opening error
+
         Special thanks to:
+            hwt0415
             Samanta Navarro
+                 and
+            Clang LeakSan and the Clang team
 
 Release 2.4.3 Sun January 16 2022
         Security fixes:

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -1175,9 +1175,9 @@ tmain(int argc, XML_Char **argv) {
       if (! userData.fp) {
         tperror(outName);
         exitCode = XMLWF_EXIT_OUTPUT_ERROR;
+        free(outName);
+        XML_ParserFree(parser);
         if (continueOnError) {
-          free(outName);
-          cleanupUserData(&userData);
           continue;
         } else {
           break;


### PR DESCRIPTION
Fixes issue #544 

Related to pull request #439

CC @hwt0415 @timbray 