### PR TITLE
[CVE-2022-23990] lib: Prevent integer overflow in function doProlog

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -10,12 +10,18 @@ Release x.x.x xxx xxxxxxx xx xxxx
                     for when XML_CONTEXT_BYTES is defined to >0 (which is both
                     common and default).
                     Impact is denial of service or more.
+            #551  CVE-2022-23990 -- Fix unsigned integer overflow in function
+                    doProlog triggered by large content in element type
+                    declarations when there is an element declaration handler
+                    present (from a prior call to XML_SetElementDeclHandler).
+                    Impact is denial of service or more.
 
         Bug fixes:
        #544 #545  xmlwf: Fix a memory leak on output file opening error
 
         Special thanks to:
             hwt0415
+            Roland Illig
             Samanta Navarro
                  and
             Clang LeakSan and the Clang team

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -5372,7 +5372,7 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
       if (dtd->in_eldecl) {
         ELEMENT_TYPE *el;
         const XML_Char *name;
-        int nameLen;
+        size_t nameLen;
         const char *nxt
             = (quant == XML_CQUANT_NONE ? next : next - enc->minBytesPerChar);
         int myindex = nextScaffoldPart(parser);
@@ -5388,7 +5388,13 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
         nameLen = 0;
         for (; name[nameLen++];)
           ;
-        dtd->contentStringLen += nameLen;
+
+        /* Detect and prevent integer overflow */
+        if (nameLen > UINT_MAX - dtd->contentStringLen) {
+          return XML_ERROR_NO_MEMORY;
+        }
+
+        dtd->contentStringLen += (unsigned)nameLen;
         if (parser->m_elementDeclHandler)
           handleDefault = XML_FALSE;
       }


### PR DESCRIPTION
The related code has been introduced by commit cb8a4c756d057b948c1b41e7185dd69ef3ade3fb about 20 years ago.
A CVE has been requested from Mitre just now.

CC @rillig