### PR TITLE
tests: Resolve use of macros NAN and INFINITY for GNU G++ 4.8.2 (fixes #569)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -2,6 +2,11 @@ NOTE: We are looking for help with a few things:
       https://github.com/libexpat/libexpat/labels/help%20wanted
       If you can help, please get in touch.  Thanks!
 
+Release x.x.x xxx xxxxxxxx xx xxxx
+        Other changes:
+       #569 #571  tests: Resolve use of macros NAN and INFINITY for GNU G++
+                    4.8.2 on Solaris.
+
 Release 2.4.6 Sun February 20 2022
         Bug fixes:
             #566  Fix a regression introduced by the fix for CVE-2022-25313

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -54,7 +54,6 @@
 #include <ctype.h>
 #include <limits.h>
 #include <stdint.h> /* intptr_t uint64_t */
-#include <math.h>   /* NAN, INFINITY, isnan */
 
 #if ! defined(__cplusplus)
 #  include <stdbool.h>
@@ -11762,6 +11761,16 @@ START_TEST(test_accounting_precision) {
 }
 END_TEST
 
+static float
+portableNAN() {
+  return strtof("nan", NULL);
+}
+
+static float
+portableINFINITY() {
+  return strtof("infinity", NULL);
+}
+
 START_TEST(test_billion_laughs_attack_protection_api) {
   XML_Parser parserWithoutParent = XML_ParserCreate(NULL);
   XML_Parser parserWithParent
@@ -11780,7 +11789,7 @@ START_TEST(test_billion_laughs_attack_protection_api) {
       == XML_TRUE)
     fail("Call with non-root parser is NOT supposed to succeed");
   if (XML_SetBillionLaughsAttackProtectionMaximumAmplification(
-          parserWithoutParent, NAN)
+          parserWithoutParent, portableNAN())
       == XML_TRUE)
     fail("Call with NaN limit is NOT supposed to succeed");
   if (XML_SetBillionLaughsAttackProtectionMaximumAmplification(
@@ -11802,7 +11811,7 @@ START_TEST(test_billion_laughs_attack_protection_api) {
       == XML_FALSE)
     fail("Call with positive limit >=1.0 is supposed to succeed");
   if (XML_SetBillionLaughsAttackProtectionMaximumAmplification(
-          parserWithoutParent, INFINITY)
+          parserWithoutParent, portableINFINITY())
       == XML_FALSE)
     fail("Call with positive limit >=1.0 is supposed to succeed");
 


### PR DESCRIPTION
Fixes #569 

CC @noloader 