### PR TITLE
Update documentation on use of XML_POOR_ENTOPY on Solaris

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -133,7 +133,7 @@
       * BSD / macOS (including <10.7) (arc4random): HAVE_ARC4RANDOM, \
       * libbsd (arc4random_buf): HAVE_ARC4RANDOM_BUF + HAVE_LIBBSD, \
       * libbsd (arc4random): HAVE_ARC4RANDOM + HAVE_LIBBSD, \
-      * Linux (including <3.17) / BSD / macOS (including <10.7) (/dev/urandom): XML_DEV_URANDOM, \
+      * Linux (including <3.17) / BSD / macOS (including <10.7) (/dev/urandom) / Solaris 8: XML_DEV_URANDOM, \
       * Windows >=Vista (rand_s): _WIN32. \
     \
     If insist on not using any of these, bypass this error by defining \


### PR DESCRIPTION
Also see GH #172 and Oracle docs on urandom(4D) at https://docs.oracle.com/cd/E88353_01/html/E37851/urandom-4d.html. According to Oracle docs, Solaris 9 (and Solaris 8 with a patch) support /dev/random and /dev/urandom interfaces.