### PR TITLE
Add Nix CI to build downstream packages

### DIFF
--- a/.github/workflows/downstream-deps.yml
+++ b/.github/workflows/downstream-deps.yml
@@ -1,0 +1,23 @@
+name: "Build Downstream Packages"
+
+permissions: read-all
+
+on:
+  pull_request_target:
+    branches:
+      - master
+
+jobs:
+  nixpkgs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v16
+        with:
+          # explicitly enable sandbox
+          extra_nix_config: sandbox = true
+      - name: Building python3 xmltodict
+        run: nix-build -A python3Packages.xmltodict
+      - name: Building python3 jxmlease
+        run: nix-build -A python3Packages.jxmlease
+      - name: Building python3 moto
+        run: nix-build -A python3Packages.moto

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,30 @@
+let
+  expat-version =
+    let
+      cmakeFile = builtins.readFile ./expat/CMakeLists.txt;
+      captures = builtins.match ".*VERSION[\r\n] *([0-9\.]*).*" cmakeFile;
+    in
+    builtins.elemAt captures 0;
+
+  pkgs = import <nixpkgs> {
+    overlays = [
+      (final: prev: {
+        # normally, a release is consumed
+        expat = prev.expat.overrideAttrs (oldAttrs: {
+          name = "expat-${expat-version}";
+          src = ./.;
+
+          nativeBuildInputs = [ prev.autoreconfHook ];
+          prePatch = ''cd expat'';
+          postFixup = ''
+            substituteInPlace $dev/lib/cmake/expat-${expat-version}/expat-noconfig.cmake \
+              --replace "$"'{_IMPORT_PREFIX}' $out
+          '';
+        });
+      })
+    ];
+  };
+in
+pkgs
+
+


### PR DESCRIPTION
Attempt to add a ci job which will test changes by buliding downstream packages.

Current problems:
  - expat is part of nix's `stdenv`, meaning that it will need to build a few hundred packages (packages are represented as a merkel tree of dependencies, so a whole new tree will be created each change).
  
  But it does work