### PR TITLE
doc: Fix documentation of XML_EndDoctypeDeclHandler in <expat.h>

### DIFF
--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -319,7 +319,7 @@ typedef void(XMLCALL *XML_StartDoctypeDeclHandler)(void *userData,
                                                    const XML_Char *pubid,
                                                    int has_internal_subset);
 
-/* This is called for the start of the DOCTYPE declaration when the
+/* This is called for the end of the DOCTYPE declaration when the
    closing > is encountered, but after processing any external
    subset.
 */


### PR DESCRIPTION
This has already been corrected in the official API reference docs