### PR TITLE
Assign LPVOID pointer with NULL before it's being used

### DIFF
--- a/expat/xmlwf/win32filemap.c
+++ b/expat/xmlwf/win32filemap.c
@@ -107,7 +107,7 @@ filemap(const TCHAR *name,
 
 static void
 win32perror(const TCHAR *s) {
-  LPVOID buf;
+  LPVOID buf = NULL;
   if (FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
                     NULL, GetLastError(),
                     MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&buf, 0,


### PR DESCRIPTION
This fixes https://github.com/libexpat/libexpat/issues/592