### PR TITLE
Make XML_SetBillionLaughsAttackProtection* functions available despite EXPAT_DTD=OFF

### DIFF
--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -1038,7 +1038,6 @@ typedef struct {
 XMLPARSEAPI(const XML_Feature *)
 XML_GetFeatureList(void);
 
-#ifdef XML_DTD
 /* Added in Expat 2.4.0. */
 XMLPARSEAPI(XML_Bool)
 XML_SetBillionLaughsAttackProtectionMaximumAmplification(
@@ -1048,7 +1047,6 @@ XML_SetBillionLaughsAttackProtectionMaximumAmplification(
 XMLPARSEAPI(XML_Bool)
 XML_SetBillionLaughsAttackProtectionActivationThreshold(
     XML_Parser parser, unsigned long long activationThresholdBytes);
-#endif
 
 /* Expat follows the semantic versioning convention.
    See http://semver.org.

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2528,10 +2528,10 @@ XML_GetFeatureList(void) {
   return features;
 }
 
-#ifdef XML_DTD
 XML_Bool XMLCALL
 XML_SetBillionLaughsAttackProtectionMaximumAmplification(
     XML_Parser parser, float maximumAmplificationFactor) {
+#ifdef XML_DTD
   if ((parser == NULL) || (parser->m_parentParser != NULL)
       || isnan(maximumAmplificationFactor)
       || (maximumAmplificationFactor < 1.0f)) {
@@ -2539,18 +2539,24 @@ XML_SetBillionLaughsAttackProtectionMaximumAmplification(
   }
   parser->m_accounting.maximumAmplificationFactor = maximumAmplificationFactor;
   return XML_TRUE;
+#else
+  return XML_FALSE;
+#endif /* XML_DTD */
 }
 
 XML_Bool XMLCALL
 XML_SetBillionLaughsAttackProtectionActivationThreshold(
     XML_Parser parser, unsigned long long activationThresholdBytes) {
+#ifdef XML_DTD
   if ((parser == NULL) || (parser->m_parentParser != NULL)) {
     return XML_FALSE;
   }
   parser->m_accounting.activationThresholdBytes = activationThresholdBytes;
   return XML_TRUE;
-}
+#else
+  return XML_FALSE;
 #endif /* XML_DTD */
+}
 
 /* Initially tag->rawName always points into the parse buffer;
    for those TAG instances opened while the current parse buffer was

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -4287,7 +4287,7 @@ processXmlDecl(XML_Parser parser, int isGeneralTextEntity, const char *s,
   const XML_Char *storedEncName = NULL;
   const ENCODING *newEncoding = NULL;
   const char *version = NULL;
-  const char *versionend;
+  const char *versionend = NULL;
   const XML_Char *storedversion = NULL;
   int standalone = -1;
 

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2535,11 +2535,15 @@ XML_SetBillionLaughsAttackProtectionMaximumAmplification(
   if ((parser == NULL) || (parser->m_parentParser != NULL)
       || isnan(maximumAmplificationFactor)
       || (maximumAmplificationFactor < 1.0f)) {
+    if (parser != NULL)
+      parser->m_errorCode = XML_ERROR_INVALID_ARGUMENT;
     return XML_FALSE;
   }
   parser->m_accounting.maximumAmplificationFactor = maximumAmplificationFactor;
   return XML_TRUE;
 #else
+  if (parser != NULL)
+    parser->m_errorCode = XML_ERROR_FEATURE_REQUIRES_XML_DTD;
   return XML_FALSE;
 #endif /* XML_DTD */
 }
@@ -2549,11 +2553,15 @@ XML_SetBillionLaughsAttackProtectionActivationThreshold(
     XML_Parser parser, unsigned long long activationThresholdBytes) {
 #ifdef XML_DTD
   if ((parser == NULL) || (parser->m_parentParser != NULL)) {
+    if (parser != NULL)
+      parser->m_errorCode = XML_ERROR_INVALID_ARGUMENT;
     return XML_FALSE;
   }
   parser->m_accounting.activationThresholdBytes = activationThresholdBytes;
   return XML_TRUE;
 #else
+  if (parser != NULL)
+    parser->m_errorCode = XML_ERROR_FEATURE_REQUIRES_XML_DTD;
   return XML_FALSE;
 #endif /* XML_DTD */
 }

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2542,6 +2542,7 @@ XML_SetBillionLaughsAttackProtectionMaximumAmplification(
   parser->m_accounting.maximumAmplificationFactor = maximumAmplificationFactor;
   return XML_TRUE;
 #else
+  UNUSED_P(maximumAmplificationFactor);
   if (parser != NULL)
     parser->m_errorCode = XML_ERROR_FEATURE_REQUIRES_XML_DTD;
   return XML_FALSE;
@@ -2560,6 +2561,7 @@ XML_SetBillionLaughsAttackProtectionActivationThreshold(
   parser->m_accounting.activationThresholdBytes = activationThresholdBytes;
   return XML_TRUE;
 #else
+  UNUSED_P(activationThresholdBytes);
   if (parser != NULL)
     parser->m_errorCode = XML_ERROR_FEATURE_REQUIRES_XML_DTD;
   return XML_FALSE;


### PR DESCRIPTION
The 2 methods for setting BLA options are added/skipped at compile time. This changes the behaviour to have them always available, but returning an error at runtime when the feature is unavailable.

An error code will be set to determine the reason of the failure.

Fixes #512 