### PR TITLE
lib: Address Cppcheck 2.8.1 warning / fix CI

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -6,6 +6,7 @@ Release x.x.x xxx xxxxx xx xxxx
         Other changes:
        #597 #599  Windows|CMake: Add missing -DXML_STATIC to test runners
                     and fuzzers
+            #610  Address Cppcheck 2.8.1 warning
 
         Infrastructure:
        #597 #598  CI: Windows: Start covering MSVC 2022

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -4271,7 +4271,7 @@ processXmlDecl(XML_Parser parser, int isGeneralTextEntity, const char *s,
   const XML_Char *storedEncName = NULL;
   const ENCODING *newEncoding = NULL;
   const char *version = NULL;
-  const char *versionend;
+  const char *versionend = NULL;
   const XML_Char *storedversion = NULL;
   int standalone = -1;
 


### PR DESCRIPTION
```
expat/lib/xmlparse.c:4288:21: error: Uninitialized variable: &versionend [uninitvar]
          &version, &versionend, &encodingName, &newEncoding, &standalone)) {
                    ^
```