### PR TITLE
Fix .def files syntax for MinGW

### DIFF
--- a/expat/lib/libexpat.def
+++ b/expat/lib/libexpat.def
@@ -1,6 +1,5 @@
 ; DEF file for MS VC++
 
-LIBRARY
 EXPORTS
   XML_DefaultCurrent @1
   XML_ErrorString @2

--- a/expat/lib/libexpatw.def
+++ b/expat/lib/libexpatw.def
@@ -1,6 +1,5 @@
 ; DEF file for MS VC++
 
-LIBRARY
 EXPORTS
   XML_DefaultCurrent @1
   XML_ErrorString @2


### PR DESCRIPTION
MinGW expects a populated LIBRARY field. Alternatively it can just be
removed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>