### PR TITLE
Bugfixes

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1028,10 +1028,12 @@ parserCreate(const XML_Char *encodingName,
   }
   parser->m_dataBufEnd = parser->m_dataBuf + INIT_DATA_BUF_SIZE;
 
-  if (dtd)
+  if (dtd) {
     parser->m_dtd = dtd;
-  else {
+    parser->m_isParamEntity = XML_TRUE;
+  } else {
     parser->m_dtd = dtdCreate(&parser->m_mem);
+    parser->m_isParamEntity = XML_FALSE;
     if (parser->m_dtd == NULL) {
       FREE(parser, parser->m_dataBuf);
       FREE(parser, parser->m_atts);
@@ -1148,7 +1150,6 @@ parserInit(XML_Parser parser, const XML_Char *encodingName) {
   parser->m_parentParser = NULL;
   parser->m_parsingStatus.parsing = XML_INITIALIZED;
 #ifdef XML_DTD
-  parser->m_isParamEntity = XML_FALSE;
   parser->m_useForeignDTD = XML_FALSE;
   parser->m_paramEntityParsing = XML_PARAM_ENTITY_PARSING_NEVER;
 #endif
@@ -1406,7 +1407,6 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
        pointers in parser->m_dtd with ones that get destroyed with the external
        PE parser. This would leave those prefixes with dangling pointers.
     */
-    parser->m_isParamEntity = XML_TRUE;
     XmlPrologStateInitExternalEntity(&parser->m_prologState);
     parser->m_processor = externalParEntInitProcessor;
   }

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -3018,6 +3018,8 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
         len = XmlNameLength(enc, rawName);
         if (len != tag->rawNameLength
             || memcmp(tag->rawName, rawName, len) != 0) {
+          moveToFreeBindingList(parser, tag->bindings);
+          tag->bindings = NULL;
           *eventPP = rawName;
           return XML_ERROR_TAG_MISMATCH;
         }

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1030,10 +1030,14 @@ parserCreate(const XML_Char *encodingName,
 
   if (dtd) {
     parser->m_dtd = dtd;
+#ifdef XML_DTD
     parser->m_isParamEntity = XML_TRUE;
+#endif
   } else {
     parser->m_dtd = dtdCreate(&parser->m_mem);
+#ifdef XML_DTD
     parser->m_isParamEntity = XML_FALSE;
+#endif
     if (parser->m_dtd == NULL) {
       FREE(parser, parser->m_dataBuf);
       FREE(parser, parser->m_atts);


### PR DESCRIPTION
Two fixes for minor issues, see the commit messages for explanations of the issues being fixed.

An alternative fix for the memory leak would be to delay moving the tag from m_tagStack to m_freeTagList until after the check has passed; I opted for this approach as it only changes code in the error path.