### PR TITLE
Ensure raw tagnames are safe exiting internalEntityParser

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -5826,10 +5826,15 @@ internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
   {
     parser->m_processor = contentProcessor;
     /* see externalEntityContentProcessor vs contentProcessor */
-    return doContent(parser, parser->m_parentParser ? 1 : 0, parser->m_encoding,
-                     s, end, nextPtr,
-                     (XML_Bool)! parser->m_parsingStatus.finalBuffer,
-                     XML_ACCOUNT_DIRECT);
+    result = doContent(parser, parser->m_parentParser ? 1 : 0,
+                       parser->m_encoding, s, end, nextPtr,
+                       (XML_Bool)! parser->m_parsingStatus.finalBuffer,
+                       XML_ACCOUNT_DIRECT);
+    if (result == XML_ERROR_NONE) {
+      if (! storeRawNames(parser))
+        return XML_ERROR_NO_MEMORY;
+    }
+    return result;
   }
 }
 


### PR DESCRIPTION
It is possible to concoct a situation in which parsing is suspended while substituting in an internal entity, so that `XML_ResumeParser` directly uses `internalEntityProcessor` as its processor.  If the subsequent parse includes some unclosed tags, this will return without calling `storeRawNames` to ensure that the raw versions of the tag names are stored in memory other
than the parse buffer itself.  If the parse buffer is then changed or reallocated (for example if processing a file line by line), badness will ensue.

This patch ensures `storeRawNames` is always called when needed after calling `doContent`.  The earlier call to `doContent` does not need the same protection; it only deals with entity substitution, which cannot leave unbalanced tags, and in any case the raw names will be pointing into the stored entity value (memory that is going to stick around) not the parse buffer.