### PR TITLE
File expat/fuzz/.gitignore changed to not ignore already-committed source files (fixes #630)

### DIFF
--- a/expat/fuzz/.gitignore
+++ b/expat/fuzz/.gitignore
@@ -1,3 +1,2 @@
 /xml_parse*
-!/xml_parsebuffer_fuzzer.c
-!/xml_parse_fuzzer.c
+!/xml_parse*.c

--- a/expat/fuzz/.gitignore
+++ b/expat/fuzz/.gitignore
@@ -1,1 +1,3 @@
 /xml_parse*
+!/xml_parsebuffer_fuzzer.c
+!/xml_parse_fuzzer.c


### PR DESCRIPTION
issue-630: libexpat/expat/fuzz/.gitignore changed to not ignore alredy-committed source