### PR TITLE
coverage.sh: Exclude MinGW headers

### DIFF
--- a/expat/coverage.sh
+++ b/expat/coverage.sh
@@ -230,9 +230,12 @@ _merge_coverage_info() {
 
 _clean_coverage_info() {
     local coverage_dir="$1"
-    local dir
-    for dir in CMakeFiles examples tests ; do
-        local pattern="*/${dir}/*"
+    local pattern
+    for pattern in \
+            '*/CMakeFiles/*' \
+            '*/examples/*' \
+            '*/tests/*' \
+        ; do
         (
             set -x
             lcov -q -o "${coverage_dir}/${coverage_info}" -r "${coverage_dir}/${coverage_info}" "${pattern}"

--- a/expat/coverage.sh
+++ b/expat/coverage.sh
@@ -232,6 +232,7 @@ _clean_coverage_info() {
     local coverage_dir="$1"
     local pattern
     for pattern in \
+            '/usr/**mingw**/include/*' \
             '*/CMakeFiles/*' \
             '*/examples/*' \
             '*/tests/*' \


### PR DESCRIPTION
Observed paths include:
- `/usr/share/mingw-w64/include` (on Ubuntu)
- `/usr/i686-w64-mingw32/usr/include` (on Gentoo)