### PR TITLE
CMake: Drop leading whitespace from a #cmakedefine line in file expat_config.h.cmake to workaround issues with Meson

### DIFF
--- a/expat/apply-clang-format.sh
+++ b/expat/apply-clang-format.sh
@@ -56,6 +56,6 @@ find \
 
 sed \
         -e 's, @$,@,' \
-        -e 's,#\( \+\)cmakedefine,\1#cmakedefine,' \
+        -e 's,#\( \+\)cmakedefine,#cmakedefine,' \
         -i \
         expat_config.h.cmake

--- a/expat/expat_config.h.cmake
+++ b/expat/expat_config.h.cmake
@@ -94,7 +94,7 @@
 
 #if ! defined(_WIN32)
 /* Define to include code reading entropy from `/dev/urandom'. */
-  #cmakedefine XML_DEV_URANDOM
+#cmakedefine XML_DEV_URANDOM
 #endif
 
 /* Define to make parameter entity parsing functionality available. */


### PR DESCRIPTION
meson has a bug where #cmakedefine with leading whitespace is not transformed.

For consistency, remove whitespace from the second define.