### PR TITLE
apply-clang-format.sh: Add support for BSD find

### DIFF
--- a/expat/apply-clang-format.sh
+++ b/expat/apply-clang-format.sh
@@ -46,7 +46,7 @@ fi
 
 expand --tabs=2 --initial lib/siphash.h | sponge lib/siphash.h
 
-find \
+find . \
         -name '*.[ch]' \
         -o -name '*.cpp' \
         -o -name '*.cxx' \


### PR DESCRIPTION
Found with shellcheck:

SC2185: Some finds don't have a default path. Specify '.' explicitly.

Signed-off-by: Rosen Penev <rosenp@gmail.com>