### PR TITLE
tests: Address GCC warning -Wmissing-prototypes

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -2,6 +2,10 @@ NOTE: We are looking for help with a few things:
       https://github.com/libexpat/libexpat/labels/help%20wanted
       If you can help, please get in touch.  Thanks!
 
+Release x.x.x xxx xxxxxxxxxxxx xx xxxx
+        Other changes:
+            #648  Address compiler warnings
+
 Release 2.4.9 Tue September 20 2022
         Security fixes:
        #629 #640  CVE-2022-40674 -- Heap use-after-free vulnerability in

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -4990,7 +4990,7 @@ START_TEST(test_suspend_resume_internal_entity) {
 }
 END_TEST
 
-void
+static void XMLCALL
 suspending_comment_handler(void *userData, const XML_Char *data) {
   UNUSED_P(data);
   XML_Parser parser = (XML_Parser)userData;


### PR DESCRIPTION
Symptom:
```
../../../tests/runtests.c:4994:1: warning: no previous prototype for ‘suspending_comment_handler’ [-Wmissing-prototypes]
 4994 | suspending_comment_handler(void *userData, const XML_Char *data) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~
```