### PR TITLE
[CVE-2022-43680] Fix overeager DTD destruction (fixes #649)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -3,6 +3,11 @@ NOTE: We are looking for help with a few things:
       If you can help, please get in touch.  Thanks!
 
 Release x.x.x xxx xxxxxxxxxxxx xx xxxx
+        Security fixes:
+  #616 #649 #650  CVE-2022-43680 -- Fix heap use-after-free after overeager
+                    destruction of a shared DTD in function
+                    XML_ExternalEntityParserCreate in out-of-memory situations
+
         Bug fixes:
        #612 #645  Fix curruption from undefined entities
        #613 #654  Fix case when parsing was suspended while processing nested

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1068,6 +1068,14 @@ parserCreate(const XML_Char *encodingName,
   parserInit(parser, encodingName);
 
   if (encodingName && ! parser->m_protocolEncodingName) {
+    if (dtd) {
+      // We need to stop the upcoming call to XML_ParserFree from happily
+      // destroying parser->m_dtd because the DTD is shared with the parent
+      // parser and the only guard that keeps XML_ParserFree from destroying
+      // parser->m_dtd is parser->m_isParamEntity but it will be set to
+      // XML_TRUE only later in XML_ExternalEntityParserCreate (or not at all).
+      parser->m_dtd = NULL;
+    }
     XML_ParserFree(parser);
     return NULL;
   }


### PR DESCRIPTION
Fixes #649

Alternative patch + reproducer test case