### PR TITLE
Fix doProlog() memory leak

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -5485,6 +5485,7 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
           parser->m_elementDeclHandler(
               parser->m_handlerArg, parser->m_declElementType->name, content);
           handleDefault = XML_FALSE;
+          FREE(parser,content);
         }
         dtd->in_eldecl = XML_FALSE;
       }


### PR DESCRIPTION
I found the problem in expat-2.1.0 and this problem looks like existing in the upstream. 
Here is leak dump:
`=================================================================
==21594==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f73d736f602 in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x98602)
    #1 0x7f73d708da09 in doProlog ../lib/xmlparse.c:4930
    #2 0x7f73d7090cdc in prologProcessor ../lib/xmlparse.c:4073
    #3 0x7f73d709c3b2 in XML_ParseBuffer ../lib/xmlparse.c:1676
    #4 0x404358 in _run_character_check ../tests/runtests.c:358
    #5 0x4072f4 in srunner_run_all ../tests/minicheck.c:154
    #6 0x40218d in main ../tests/runtests.c:1806
    #7 0x7f73d6ccc83f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2083f)
    #8 0x402548 in _start (/opt/expat-2.1.0-7ubuntu0.16.04.5+tuxcare.els2/expat-2.1.0/build/tests/.libs/lt-runtests+0x402548)
`