### PR TITLE
[2.4.9] CMake: Fix static library name when building with MinGW

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -459,7 +459,7 @@ if(NOT WIN32)
     endif()
 endif()
 
-if(MINGW)
+if(MINGW AND EXPAT_SHARED_LIBS)
     set_target_properties(expat PROPERTIES SUFFIX "-${LIBCURRENT_MINUS_AGE}.dll")
 endif()
 


### PR DESCRIPTION
When building static library with mingw the output file name should be `libexpat.a`, not `libexpat-1.dll`.
This is a regression from https://github.com/libexpat/libexpat/pull/624, reported in https://github.com/microsoft/vcpkg/issues/27132.