### PR TITLE
Fix miscellaneous Clang and Cppcheck 2.9 style warnings

### DIFF
--- a/expat/lib/siphash.h
+++ b/expat/lib/siphash.h
@@ -106,7 +106,7 @@
  * if this code is included and compiled as C++; related GCC warning is:
  * warning: use of C++11 long long integer constant [-Wlong-long]
  */
-#define _SIP_ULL(high, low) ((((uint64_t)high) << 32) | (low))
+#define SIP_ULL(high, low) ((((uint64_t)high) << 32) | (low))
 
 #define SIP_ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
 
@@ -190,10 +190,10 @@ sip_round(struct siphash *H, const int rounds) {
 
 static struct siphash *
 sip24_init(struct siphash *H, const struct sipkey *key) {
-  H->v0 = _SIP_ULL(0x736f6d65U, 0x70736575U) ^ key->k[0];
-  H->v1 = _SIP_ULL(0x646f7261U, 0x6e646f6dU) ^ key->k[1];
-  H->v2 = _SIP_ULL(0x6c796765U, 0x6e657261U) ^ key->k[0];
-  H->v3 = _SIP_ULL(0x74656462U, 0x79746573U) ^ key->k[1];
+  H->v0 = SIP_ULL(0x736f6d65U, 0x70736575U) ^ key->k[0];
+  H->v1 = SIP_ULL(0x646f7261U, 0x6e646f6dU) ^ key->k[1];
+  H->v2 = SIP_ULL(0x6c796765U, 0x6e657261U) ^ key->k[0];
+  H->v3 = SIP_ULL(0x74656462U, 0x79746573U) ^ key->k[1];
 
   H->p = H->buf;
   H->c = 0;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -61,8 +61,10 @@
 
 #include <expat_config.h>
 
-#if ! defined(_GNU_SOURCE)
-#  define _GNU_SOURCE 1 /* syscall prototype */
+#if defined(HAVE_SYSCALL_GETRANDOM)
+#  if ! defined(_GNU_SOURCE)
+#    define _GNU_SOURCE 1 /* syscall prototype */
+#  endif
 #endif
 
 #ifdef _WIN32

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -590,7 +590,6 @@ static unsigned long getDebugLevel(const char *variableName,
                                    unsigned long defaultDebugLevel);
 
 #define poolStart(pool) ((pool)->start)
-#define poolEnd(pool) ((pool)->ptr)
 #define poolLength(pool) ((pool)->ptr - (pool)->start)
 #define poolChop(pool) ((void)--(pool->ptr))
 #define poolLastChar(pool) (((pool)->ptr)[-1])

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -715,25 +715,21 @@ unicode_byte_type(char hi, char lo) {
       return res;                                                              \
   }
 
-#define SET2(ptr, ch) (((ptr)[0] = ((ch)&0xff)), ((ptr)[1] = ((ch) >> 8)))
 #define GET_LO(ptr) ((unsigned char)(ptr)[0])
 #define GET_HI(ptr) ((unsigned char)(ptr)[1])
 
 DEFINE_UTF16_TO_UTF8(little2_)
 DEFINE_UTF16_TO_UTF16(little2_)
 
-#undef SET2
 #undef GET_LO
 #undef GET_HI
 
-#define SET2(ptr, ch) (((ptr)[0] = ((ch) >> 8)), ((ptr)[1] = ((ch)&0xFF)))
 #define GET_LO(ptr) ((unsigned char)(ptr)[1])
 #define GET_HI(ptr) ((unsigned char)(ptr)[0])
 
 DEFINE_UTF16_TO_UTF8(big2_)
 DEFINE_UTF16_TO_UTF16(big2_)
 
-#undef SET2
 #undef GET_LO
 #undef GET_HI
 

--- a/expat/tests/chardata.c
+++ b/expat/tests/chardata.c
@@ -80,13 +80,13 @@ CharData_AppendXMLChars(CharData *storage, const XML_Char *s, int len) {
 
 int
 CharData_CheckXMLChars(CharData *storage, const XML_Char *expected) {
-  char buffer[1024];
   int len = xmlstrlen(expected);
   int count;
 
   assert(storage != NULL);
   count = (storage->count < 0) ? 0 : storage->count;
   if (len != count) {
+    char buffer[1024];
     sprintf(buffer, "wrong number of data characters: got %d, expected %d",
             count, len);
     fail(buffer);

--- a/expat/tests/chardata.c
+++ b/expat/tests/chardata.c
@@ -87,8 +87,9 @@ CharData_CheckXMLChars(CharData *storage, const XML_Char *expected) {
   count = (storage->count < 0) ? 0 : storage->count;
   if (len != count) {
     char buffer[1024];
-    sprintf(buffer, "wrong number of data characters: got %d, expected %d",
-            count, len);
+    snprintf(buffer, sizeof(buffer),
+             "wrong number of data characters: got %d, expected %d", count,
+             len);
     fail(buffer);
     return 0;
   }

--- a/expat/tests/memcheck.c
+++ b/expat/tests/memcheck.c
@@ -49,7 +49,7 @@ typedef struct allocation_entry {
 static AllocationEntry *alloc_head = NULL;
 static AllocationEntry *alloc_tail = NULL;
 
-static AllocationEntry *find_allocation(void *ptr);
+static AllocationEntry *find_allocation(const void *ptr);
 
 /* Allocate some memory and keep track of it. */
 void *
@@ -82,7 +82,7 @@ tracking_malloc(size_t size) {
 }
 
 static AllocationEntry *
-find_allocation(void *ptr) {
+find_allocation(const void *ptr) {
   AllocationEntry *entry;
 
   for (entry = alloc_head; entry != NULL; entry = entry->next) {

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -129,11 +129,11 @@ static void
 _xml_failure(XML_Parser parser, const char *file, int line) {
   char buffer[1024];
   enum XML_Error err = XML_GetErrorCode(parser);
-  sprintf(buffer,
-          "    %d: %" XML_FMT_STR " (line %" XML_FMT_INT_MOD
-          "u, offset %" XML_FMT_INT_MOD "u)\n    reported from %s, line %d\n",
-          err, XML_ErrorString(err), XML_GetCurrentLineNumber(parser),
-          XML_GetCurrentColumnNumber(parser), file, line);
+  snprintf(buffer, sizeof(buffer),
+           "    %d: %" XML_FMT_STR " (line %" XML_FMT_INT_MOD
+           "u, offset %" XML_FMT_INT_MOD "u)\n    reported from %s, line %d\n",
+           err, XML_ErrorString(err), XML_GetCurrentLineNumber(parser),
+           XML_GetCurrentColumnNumber(parser), file, line);
   _fail_unless(0, file, line, buffer);
 }
 
@@ -746,11 +746,12 @@ START_TEST(test_illegal_utf8) {
   int i;
 
   for (i = 128; i <= 255; ++i) {
-    sprintf(text, "<e>%ccd</e>", i);
+    snprintf(text, sizeof(text), "<e>%ccd</e>", i);
     if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
         == XML_STATUS_OK) {
-      sprintf(text, "expected token error for '%c' (ordinal %d) in UTF-8 text",
-              i, i);
+      snprintf(text, sizeof(text),
+               "expected token error for '%c' (ordinal %d) in UTF-8 text", i,
+               i);
       fail(text);
     } else if (XML_GetErrorCode(g_parser) != XML_ERROR_INVALID_TOKEN)
       xml_failure(g_parser);
@@ -1058,7 +1059,8 @@ START_TEST(test_line_number_after_parse) {
   lineno = XML_GetCurrentLineNumber(g_parser);
   if (lineno != 4) {
     char buffer[100];
-    sprintf(buffer, "expected 4 lines, saw %" XML_FMT_INT_MOD "u", lineno);
+    snprintf(buffer, sizeof(buffer),
+             "expected 4 lines, saw %" XML_FMT_INT_MOD "u", lineno);
     fail(buffer);
   }
 }
@@ -1075,7 +1077,8 @@ START_TEST(test_column_number_after_parse) {
   colno = XML_GetCurrentColumnNumber(g_parser);
   if (colno != 11) {
     char buffer[100];
-    sprintf(buffer, "expected 11 columns, saw %" XML_FMT_INT_MOD "u", colno);
+    snprintf(buffer, sizeof(buffer),
+             "expected 11 columns, saw %" XML_FMT_INT_MOD "u", colno);
     fail(buffer);
   }
 }
@@ -1144,7 +1147,8 @@ START_TEST(test_line_number_after_error) {
   lineno = XML_GetCurrentLineNumber(g_parser);
   if (lineno != 3) {
     char buffer[100];
-    sprintf(buffer, "expected 3 lines, saw %" XML_FMT_INT_MOD "u", lineno);
+    snprintf(buffer, sizeof(buffer),
+             "expected 3 lines, saw %" XML_FMT_INT_MOD "u", lineno);
     fail(buffer);
   }
 }
@@ -1163,7 +1167,8 @@ START_TEST(test_column_number_after_error) {
   colno = XML_GetCurrentColumnNumber(g_parser);
   if (colno != 4) {
     char buffer[100];
-    sprintf(buffer, "expected 4 columns, saw %" XML_FMT_INT_MOD "u", colno);
+    snprintf(buffer, sizeof(buffer),
+             "expected 4 columns, saw %" XML_FMT_INT_MOD "u", colno);
     fail(buffer);
   }
 }
@@ -1358,10 +1363,10 @@ check_attr_contains_normalized_whitespace(void *userData, const XML_Char *name,
         || xcstrcmp(XCS("refs"), attrname) == 0) {
       if (! is_whitespace_normalized(value, 0)) {
         char buffer[256];
-        sprintf(buffer,
-                "attribute value not normalized: %" XML_FMT_STR
-                "='%" XML_FMT_STR "'",
-                attrname, value);
+        snprintf(buffer, sizeof(buffer),
+                 "attribute value not normalized: %" XML_FMT_STR
+                 "='%" XML_FMT_STR "'",
+                 attrname, value);
         fail(buffer);
       }
     }
@@ -2362,10 +2367,10 @@ START_TEST(test_bad_cdata) {
 
     if (actualError != cases[i].expectedError) {
       char message[100];
-      sprintf(message,
-              "Expected error %d but got error %d for case %u: \"%s\"\n",
-              cases[i].expectedError, actualError, (unsigned int)i + 1,
-              cases[i].text);
+      snprintf(message, sizeof(message),
+               "Expected error %d but got error %d for case %u: \"%s\"\n",
+               cases[i].expectedError, actualError, (unsigned int)i + 1,
+               cases[i].text);
       fail(message);
     }
 
@@ -2435,12 +2440,12 @@ START_TEST(test_bad_cdata_utf16) {
     if (actual_error != cases[i].expected_error) {
       char message[1024];
 
-      sprintf(message,
-              "Expected error %d (%" XML_FMT_STR "), got %d (%" XML_FMT_STR
-              ") for case %lu\n",
-              cases[i].expected_error, XML_ErrorString(cases[i].expected_error),
-              actual_error, XML_ErrorString(actual_error),
-              (long unsigned)(i + 1));
+      snprintf(message, sizeof(message),
+               "Expected error %d (%" XML_FMT_STR "), got %d (%" XML_FMT_STR
+               ") for case %lu\n",
+               cases[i].expected_error,
+               XML_ErrorString(cases[i].expected_error), actual_error,
+               XML_ErrorString(actual_error), (long unsigned)(i + 1));
       fail(message);
     }
     XML_ParserReset(g_parser, NULL);
@@ -6208,7 +6213,8 @@ START_TEST(test_utf8_in_start_tags) {
     for (; j < sizeof(atNameStart) / sizeof(atNameStart[0]); j++) {
       const bool expectedSuccess
           = atNameStart[j] ? cases[i].goodNameStart : cases[i].goodName;
-      sprintf(doc, "<%s%s><!--", atNameStart[j] ? "" : "a", cases[i].tagName);
+      snprintf(doc, sizeof(doc), "<%s%s><!--", atNameStart[j] ? "" : "a",
+               cases[i].tagName);
       XML_Parser parser = XML_ParserCreate(NULL);
 
       const enum XML_Status status
@@ -6858,11 +6864,13 @@ triplet_start_checker(void *userData, const XML_Char *name,
   XML_Char **elemstr = (XML_Char **)userData;
   char buffer[1024];
   if (xcstrcmp(elemstr[0], name) != 0) {
-    sprintf(buffer, "unexpected start string: '%" XML_FMT_STR "'", name);
+    snprintf(buffer, sizeof(buffer),
+             "unexpected start string: '%" XML_FMT_STR "'", name);
     fail(buffer);
   }
   if (xcstrcmp(elemstr[1], atts[0]) != 0) {
-    sprintf(buffer, "unexpected attribute string: '%" XML_FMT_STR "'", atts[0]);
+    snprintf(buffer, sizeof(buffer),
+             "unexpected attribute string: '%" XML_FMT_STR "'", atts[0]);
     fail(buffer);
   }
   triplet_start_flag = XML_TRUE;
@@ -6877,7 +6885,8 @@ triplet_end_checker(void *userData, const XML_Char *name) {
   XML_Char **elemstr = (XML_Char **)userData;
   if (xcstrcmp(elemstr[0], name) != 0) {
     char buffer[1024];
-    sprintf(buffer, "unexpected end string: '%" XML_FMT_STR "'", name);
+    snprintf(buffer, sizeof(buffer),
+             "unexpected end string: '%" XML_FMT_STR "'", name);
     fail(buffer);
   }
   triplet_end_flag = XML_TRUE;

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -75,7 +75,6 @@
 #endif
 
 #ifdef XML_UNICODE_WCHAR_T
-#  define XML_FMT_CHAR "lc"
 #  define XML_FMT_STR "ls"
 #  include <wchar.h>
 #  define xcstrlen(s) wcslen(s)
@@ -87,7 +86,6 @@
 #  ifdef XML_UNICODE
 #    error "No support for UTF-16 character without wchar_t in tests"
 #  else
-#    define XML_FMT_CHAR "c"
 #    define XML_FMT_STR "s"
 #    define xcstrlen(s) strlen(s)
 #    define xcstrcmp(s, t) strcmp((s), (t))

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -8326,7 +8326,7 @@ external_entity_dbl_handler(XML_Parser parser, const XML_Char *context,
                             const XML_Char *publicId) {
   intptr_t callno = (intptr_t)XML_GetUserData(parser);
   const char *text;
-  XML_Parser new_parser;
+  XML_Parser new_parser = NULL;
   int i;
   const int max_alloc_count = 20;
 

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -507,7 +507,7 @@ START_TEST(test_siphash_spec) {
   const char message[] = "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09"
                          "\x0a\x0b\x0c\x0d\x0e";
   const size_t len = sizeof(message) - 1;
-  const uint64_t expected = _SIP_ULL(0xa129ca61U, 0x49be45e5U);
+  const uint64_t expected = SIP_ULL(0xa129ca61U, 0x49be45e5U);
   struct siphash state;
   struct sipkey key;
 
@@ -4932,7 +4932,7 @@ START_TEST(test_hash_collision) {
    * tests invoked from qa.sh usually provide a hash collision, but
    * not always.  This is an attempt to provide insurance.
    */
-#define COLLIDING_HASH_SALT (unsigned long)_SIP_ULL(0xffffffffU, 0xff99fc90U)
+#define COLLIDING_HASH_SALT (unsigned long)SIP_ULL(0xffffffffU, 0xff99fc90U)
   const char *text
       = "<doc>\n"
         "<a1/><a2/><a3/><a4/><a5/><a6/><a7/><a8/>\n"

--- a/expat/tests/structdata.c
+++ b/expat/tests/structdata.c
@@ -107,8 +107,9 @@ StructData_CheckItems(StructData *storage, const StructDataEntry *expected,
   assert(storage != NULL);
   assert(expected != NULL);
   if (count != storage->count) {
-    sprintf(buffer, "wrong number of entries: got %d, expected %d",
-            storage->count, count);
+    snprintf(buffer, sizeof(buffer),
+             "wrong number of entries: got %d, expected %d", storage->count,
+             count);
     StructData_Dispose(storage);
     fail(buffer);
   } else {
@@ -125,11 +126,11 @@ StructData_CheckItems(StructData *storage, const StructDataEntry *expected,
       } else {
         if (got->data0 != want->data0 || got->data1 != want->data1
             || got->data2 != want->data2) {
-          sprintf(buffer,
-                  "struct '%" XML_FMT_STR
-                  "' expected (%d,%d,%d), got (%d,%d,%d)",
-                  got->str, want->data0, want->data1, want->data2, got->data0,
-                  got->data1, got->data2);
+          snprintf(buffer, sizeof(buffer),
+                   "struct '%" XML_FMT_STR
+                   "' expected (%d,%d,%d), got (%d,%d,%d)",
+                   got->str, want->data0, want->data1, want->data2, got->data0,
+                   got->data1, got->data2);
           StructData_Dispose(storage);
           fail(buffer);
         }

--- a/expat/tests/structdata.c
+++ b/expat/tests/structdata.c
@@ -103,7 +103,6 @@ void
 StructData_CheckItems(StructData *storage, const StructDataEntry *expected,
                       int count) {
   char buffer[1024];
-  int i;
 
   assert(storage != NULL);
   assert(expected != NULL);
@@ -113,7 +112,7 @@ StructData_CheckItems(StructData *storage, const StructDataEntry *expected,
     StructData_Dispose(storage);
     fail(buffer);
   } else {
-    for (i = 0; i < count; i++) {
+    for (int i = 0; i < count; i++) {
       const StructDataEntry *got = &storage->entries[i];
       const StructDataEntry *want = &expected[i];
 

--- a/expat/xmlwf/readfilemap.c
+++ b/expat/xmlwf/readfilemap.c
@@ -50,14 +50,14 @@
 #if defined(_MSC_VER)
 #  include <io.h>
 /* https://msdn.microsoft.com/en-us/library/wyssk1bs(v=vs.100).aspx */
-#  define _EXPAT_read _read
-#  define _EXPAT_read_count_t int
-#  define _EXPAT_read_req_t unsigned int
+#  define EXPAT_read _read
+#  define EXPAT_read_count_t int
+#  define EXPAT_read_req_t unsigned int
 #else /* POSIX */
 /* http://pubs.opengroup.org/onlinepubs/009695399/functions/read.html */
-#  define _EXPAT_read read
-#  define _EXPAT_read_count_t ssize_t
-#  define _EXPAT_read_req_t size_t
+#  define EXPAT_read read
+#  define EXPAT_read_count_t ssize_t
+#  define EXPAT_read_req_t size_t
 #endif
 
 #ifndef S_ISREG
@@ -87,7 +87,7 @@ filemap(const tchar *name,
         void *arg) {
   size_t nbytes;
   int fd;
-  _EXPAT_read_count_t n;
+  EXPAT_read_count_t n;
   struct stat sb;
   void *p;
 
@@ -125,14 +125,14 @@ filemap(const tchar *name,
     close(fd);
     return 0;
   }
-  n = _EXPAT_read(fd, p, (_EXPAT_read_req_t)nbytes);
+  n = EXPAT_read(fd, p, (EXPAT_read_req_t)nbytes);
   if (n < 0) {
     tperror(name);
     free(p);
     close(fd);
     return 0;
   }
-  if (n != (_EXPAT_read_count_t)nbytes) {
+  if (n != (EXPAT_read_count_t)nbytes) {
     ftprintf(stderr, T("%s: read unexpected number of bytes\n"), name);
     free(p);
     close(fd);

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -964,7 +964,7 @@ tmain(int argc, XML_Char **argv) {
   int continueOnError = 0;
 
   float attackMaximumAmplification = -1.0f; /* signaling "not set" */
-  unsigned long long attackThresholdBytes;
+  unsigned long long attackThresholdBytes = 0;
   XML_Bool attackThresholdGiven = XML_FALSE;
 
   int exitCode = XMLWF_EXIT_SUCCESS;


### PR DESCRIPTION
I'm really not familiar with the codebase, so please review carefully.  libexpat is a dependency of a dependency of a dependency for me, and I'm just trying to get everything building with more warnings fixed.

The `_GNU_SOURCE` thing in particular could maybe be addressed differently.  Perhaps it doesn't need to be defined at all?