### PR TITLE
CMake: Lowercase off_t and size_t

### DIFF
--- a/expat/ConfigureChecks.cmake
+++ b/expat/ConfigureChecks.cmake
@@ -46,11 +46,11 @@ else(WORDS_BIGENDIAN)
 endif(WORDS_BIGENDIAN)
 
 if(HAVE_SYS_TYPES_H)
-    check_symbol_exists("off_t" "sys/types.h" OFF_T)
-    check_symbol_exists("size_t" "sys/types.h" SIZE_T)
+    check_symbol_exists("off_t" "sys/types.h" off_t)
+    check_symbol_exists("size_t" "sys/types.h" size_t)
 else(HAVE_SYS_TYPES_H)
-    set(OFF_T "long")
-    set(SIZE_T "unsigned")
+    set(off_t "long")
+    set(size_t "unsigned")
 endif(HAVE_SYS_TYPES_H)
 
 check_c_source_compiles("

--- a/expat/expat_config.h.cmake
+++ b/expat/expat_config.h.cmake
@@ -112,9 +112,9 @@
 #endif
 
 /* Define to `long' if <sys/types.h> does not define. */
-#cmakedefine off_t @OFF_T@
+#cmakedefine off_t @off_t@
 
 /* Define to `unsigned' if <sys/types.h> does not define. */
-#cmakedefine size_t @SIZE_T@
+#cmakedefine size_t @size_t@
 
 #endif // ndef EXPAT_CONFIG_H


### PR DESCRIPTION
Because of a bug in meson, defines need to be the same case.

Signed-off-by: Rosen Penev <rosenp@gmail.com>