### PR TITLE
Fix CI / coverage.yml: Drop ppa:ondrej/php removal

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v3.1.0
     - name: Install build dependencies
       run: |-
-        set -x -u -o pipefail
+        set -x -u
         source /etc/os-release
 
         sudo apt-get update
@@ -59,18 +59,6 @@ jobs:
             libbsd-dev \
             lzip \
             moreutils
-
-        # Get rid of packages installed from ppa:ondrej/php so that we will be able to install wine32:i386 without conflicts
-        # (see issue https://github.com/actions/virtual-environments/issues/4589)
-        # In detail we:
-        #   1. Remove all packages that ppa:ondrej/php has but plain Ubuntu doesn't, e.g. everything PHP
-        #   2. Revert (remaining) packages that ppa:ondrej/php and plain Ubuntu share, back to the plain Ubuntu version
-        #   3. Assert that no packages from ppa:ondrej/php are left installed
-        dpkg -l | grep '^ii' | grep -F deb.sury.org | awk '{print $2}' | grep '^php' \
-          | xargs -r -t sudo apt-get remove --yes libpcre2-posix3 libzip4
-        dpkg -l | grep '^ii' | grep -F deb.sury.org | awk '{print $2}' | sed "s,\$,/${UBUNTU_CODENAME}," \
-          | xargs -r -t sudo apt-get install --yes --no-install-recommends --allow-downgrades -V
-        ! dpkg -l | grep '^ii' | grep -F deb.sury.org
 
         # Install 32bit Wine
         sudo dpkg --add-architecture i386  # for wine32


### PR DESCRIPTION
.. because image `ubuntu-22.04` just stopped adding repository `ppa:ondrej/php`. Related commit: https://github.com/actions/runner-images/commit/cc71c8b504a5efec7d25054a016dbe7f34553df4