### PR TITLE
CMake: Fix looking up expact on systems where triplet are part of the path

### DIFF
--- a/expat/cmake/autotools/expat.cmake
+++ b/expat/cmake/autotools/expat.cmake
@@ -51,6 +51,13 @@ get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
 get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
 get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+
+# if there's no include, try again with the parent's parent.
+# This will be useful in distros where they use the triplet (e.g. x86_64-linux-gnu) in the path,
+# thus having something like /usr/lib/x86_64-linux-gnu/cmake/expat-2.4.6/expat.cmake
+if (NOT EXISTS "${_IMPORT_PREFIX}/include")
+  get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+endif()
 if(_IMPORT_PREFIX STREQUAL "/")
   set(_IMPORT_PREFIX "")
 endif()


### PR DESCRIPTION
On systems like Flatpak and Debian, the cmake file is installed under a subdirectory including an extra level for the compiler triplet (e.g. /usr/lib/x86_64-linux-gnu/cmake/expat-2.4.6/expat.cmake). This adds an extra hop in those cases so to cover them.

An alternative would be to generate it at build time (which is what we do in KDE), but I'm not sure this is really feasible considering that expat has two supported build systems and this approach covers them both.

Related to https://github.com/libexpat/libexpat/issues/501