### PR TITLE
Fix Linux CI / Make sure that AddressSanitizer Clang files are always available

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,7 +118,7 @@ jobs:
         sudo apt-get install --yes --no-install-recommends -V \
             clang-15 \
             clang-format-15 \
-            llvm-15
+            libclang-rt-15-dev
     - name: Install build dependencies (common)
       run: |-
         sudo apt-get install --yes --no-install-recommends -V \


### PR DESCRIPTION
Symptom was:
> /usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan_static-x86_64.a: No such file or directory
> /usr/bin/ld: cannot find /usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan-x86_64.a: No such file or directory

Related:
https://github.com/llvm/llvm-project/issues/60008