### PR TITLE
Actions: Set permissions to "contents: read" to avoid permissive workflows

### DIFF
--- a/.github/workflows/autotools-cmake.yml
+++ b/.github/workflows/autotools-cmake.yml
@@ -35,6 +35,9 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Ensure that GNU Autotools and CMake build systems agree

--- a/.github/workflows/cmake-required-version.yml
+++ b/.github/workflows/cmake-required-version.yml
@@ -35,6 +35,8 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
+permissions: write-all
+
 jobs:
   checks:
     name: Ensure realistic minimum CMake version requirement

--- a/.github/workflows/cmake-required-version.yml
+++ b/.github/workflows/cmake-required-version.yml
@@ -35,7 +35,8 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   checks:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,6 +35,9 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Collect test coverage

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -35,6 +35,9 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Run Cppcheck

--- a/.github/workflows/expat_config_h.yml
+++ b/.github/workflows/expat_config_h.yml
@@ -35,6 +35,9 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Check expat_config.h.{in,cmake} for regressions

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,6 +35,9 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Perform checks

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,6 +35,9 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Perform checks

--- a/.github/workflows/valid-xml.yml
+++ b/.github/workflows/valid-xml.yml
@@ -35,6 +35,9 @@ on:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Ensure well-formed and valid XML


### PR DESCRIPTION
Closes #693 

### Changes

- expat_config_h.yml: success https://github.com/joycebrum/libexpat/actions/runs/4344532736
- cmake-required-version: success https://github.com/joycebrum/libexpat/actions/runs/4344532730
- autotools-cmake: success https://github.com/joycebrum/libexpat/actions/runs/4344532740
- valid-xml: success https://github.com/joycebrum/libexpat/actions/runs/4344532737
- cppcheck: success https://github.com/joycebrum/libexpat/actions/runs/4344532733
- linux: success https://github.com/joycebrum/libexpat/actions/runs/4344532739
- macos: success https://github.com/joycebrum/libexpat/actions/runs/4344532745
- coverage: error due to lack of access to travis https://github.com/joycebrum/libexpat/actions/runs/4344532726, but the reading permission seems to be enough