### PR TITLE
coverage.sh: Be robust towards absence of Git tags

### DIFF
--- a/expat/coverage.sh
+++ b/expat/coverage.sh
@@ -262,7 +262,7 @@ _show_summary() {
 
 
 _main() {
-    version="$(git describe --tags)"
+    version="$(git describe --tags 2>/dev/null || echo HEAD)"
     coverage_info=coverage.info
 
     local build_dirs=()


### PR DESCRIPTION
.. e.g. when someone forks the Git repository in a way that only copies the `master` branch but no tags.