### PR TITLE
winconfig: Avoid redefinition of WIN32_LEAN_AND_MEAN

### DIFF
--- a/expat/lib/winconfig.h
+++ b/expat/lib/winconfig.h
@@ -35,7 +35,9 @@
 #ifndef WINCONFIG_H
 #define WINCONFIG_H
 
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
 


### PR DESCRIPTION
If it is already defined externally, do not define it again.