### PR TITLE
CI: Pin all GitHub Actions to specific commits for security

### DIFF
--- a/.github/workflows/autotools-cmake.yml
+++ b/.github/workflows/autotools-cmake.yml
@@ -58,7 +58,7 @@ jobs:
         shell: bash
     runs-on: "${{ matrix.os }}"
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
     - name: (Linux) Install build dependencies
       if: "${{ runner.os == 'Linux' }}"

--- a/.github/workflows/cmake-required-version.yml
+++ b/.github/workflows/cmake-required-version.yml
@@ -43,7 +43,7 @@ jobs:
     name: Ensure realistic minimum CMake version requirement
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
     - name: Install ancient CMake
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       CFLAGS: -g3 -pipe
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
     - name: Install build dependencies
       run: |-
         set -x -u
@@ -81,7 +81,7 @@ jobs:
         exec ./.travis.sh
 
     - name: Store coverage .info and HTML report
-      uses: actions/upload-artifact@v3.1.2
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: coverage
         path: expat/coverage__*/

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -43,7 +43,7 @@ jobs:
     name: Run Cppcheck
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
     - name: Install runtime dependencies
       run: |
         exec brew install cppcheck findutils

--- a/.github/workflows/expat_config_h.yml
+++ b/.github/workflows/expat_config_h.yml
@@ -43,7 +43,7 @@ jobs:
     name: Check expat_config.h.{in,cmake} for regressions
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
     - name: Check expat_config.h.{in,cmake} for regressions
       run: |
         set -v

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,7 +83,7 @@ jobs:
     env:
       CFLAGS: -g3 -pipe
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
     - name: Install build dependencies (MinGW)
       if: "${{ contains(matrix.FLAT_ENV, 'mingw') }}"
       run: |-

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,7 +53,7 @@ jobs:
             FLAT_ENV: CC=clang CXX=clang++ LD=clang++ QA_SANITIZER=address
     runs-on: macos-11
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
     - name: Install build dependencies
       run: |
         sudo rm /usr/local/bin/2to3  # so that "brew link" will work

--- a/.github/workflows/valid-xml.yml
+++ b/.github/workflows/valid-xml.yml
@@ -43,7 +43,7 @@ jobs:
     name: Ensure well-formed and valid XML
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
     - name: Install build dependencies
       run: |-


### PR DESCRIPTION
For proof that GitHub Dependabot can still keep things up to date for us with the new format see https://github.com/gentoo-ev/www.gentoo-ev.org/pull/5/files .

CC @joycebrum 