### PR TITLE
Prefer size_t over int where possible

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -1082,7 +1082,7 @@ end is not part of that buffer.</p>
 enum XML_Status XMLCALL
 XML_Parse(XML_Parser p,
           const char *s,
-          int len,
+          size_t len,
           int isFinal);
 </pre>
 <pre class="signature">
@@ -1109,7 +1109,7 @@ Otherwise it returns <code>XML_STATUS_OK</code> value.
 <pre class="fcndec">
 enum XML_Status XMLCALL
 XML_ParseBuffer(XML_Parser p,
-                int len,
+                size_t len,
                 int isFinal);
 </pre>
 <div class="fcndef">
@@ -1124,7 +1124,7 @@ copying of the input.
 <pre class="fcndec">
 void * XMLCALL
 XML_GetBuffer(XML_Parser p,
-              int len);
+              size_t len);
 </pre>
 <div class="fcndef">
 Obtain a buffer of size <code>len</code> to read a piece of the document
@@ -1361,7 +1361,7 @@ XML_SetCharacterDataHandler(XML_Parser p,
 typedef void
 (XMLCALL *XML_CharacterDataHandler)(void *userData,
                                     const XML_Char *s,
-                                    int len);
+                                    size_t len);
 </pre>
 <p>Set a text handler. The string your handler receives
 is <em>NOT null-terminated</em>. You have to use the length argument
@@ -1459,7 +1459,7 @@ XML_SetDefaultHandler(XML_Parser p,
 typedef void
 (XMLCALL *XML_DefaultHandler)(void *userData,
                               const XML_Char *s,
-                              int len);
+                              size_t len);
 </pre>
 
 <p>Sets a handler for any characters in the document which wouldn't
@@ -1491,7 +1491,7 @@ XML_SetDefaultHandlerExpand(XML_Parser p,
 typedef void
 (XMLCALL *XML_DefaultHandler)(void *userData,
                               const XML_Char *s,
-                              int len);
+                              size_t len);
 </pre>
 <p>This sets a default handler, but doesn't inhibit the expansion of
 internal entity references.  The entity reference will not be passed

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -293,7 +293,7 @@ typedef void(XMLCALL *XML_EndElementHandler)(void *userData,
 
 /* s is not 0 terminated. */
 typedef void(XMLCALL *XML_CharacterDataHandler)(void *userData,
-                                                const XML_Char *s, int len);
+                                                const XML_Char *s, size_t len);
 
 /* target and data are 0 terminated */
 typedef void(XMLCALL *XML_ProcessingInstructionHandler)(void *userData,
@@ -320,7 +320,7 @@ typedef void(XMLCALL *XML_EndCdataSectionHandler)(void *userData);
    multiple calls.
 */
 typedef void(XMLCALL *XML_DefaultHandler)(void *userData, const XML_Char *s,
-                                          int len);
+                                          size_t len);
 
 /* This is called for the start of the DOCTYPE declaration, before
    any DTD or internal subset is parsed.
@@ -780,13 +780,13 @@ XML_GetAttributeInfo(XML_Parser parser);
    values.
 */
 XMLPARSEAPI(enum XML_Status)
-XML_Parse(XML_Parser parser, const char *s, int len, int isFinal);
+XML_Parse(XML_Parser parser, const char *s, size_t len, int isFinal);
 
 XMLPARSEAPI(void *)
-XML_GetBuffer(XML_Parser parser, int len);
+XML_GetBuffer(XML_Parser parser, size_t len);
 
 XMLPARSEAPI(enum XML_Status)
-XML_ParseBuffer(XML_Parser parser, int len, int isFinal);
+XML_ParseBuffer(XML_Parser parser, size_t len, int isFinal);
 
 /* Stops parsing, causing XML_Parse() or XML_ParseBuffer() to return.
    Must be called from within a call-back handler, except when aborting

--- a/expat/xmlwf/filemap.h
+++ b/expat/xmlwf/filemap.h
@@ -35,7 +35,7 @@
 #include <limits.h> /* INT_MAX */
 #include <stddef.h>
 
-/* The following limit (for XML_Parse's int len) derives from
+/* The following limit (for XML_Parse's len) derives from
  * this loop in xmparse.c:
  *
  *    do {

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -91,9 +91,9 @@ typedef struct xmlwfUserData {
 #define NSSEP T('\001')
 
 static void XMLCALL
-characterData(void *userData, const XML_Char *s, int len) {
+characterData(void *userData, const XML_Char *s, size_t len) {
   FILE *fp = ((XmlwfUserData *)userData)->fp;
-  for (; len > 0; --len, ++s) {
+  for (; len; --len, ++s) {
     switch (*s) {
     case T('&'):
       fputts(T("&amp;"), fp);
@@ -492,7 +492,7 @@ notationDecl(void *userData, const XML_Char *notationName, const XML_Char *base,
 #endif /* not W3C14N */
 
 static void XMLCALL
-defaultCharacterData(void *userData, const XML_Char *s, int len) {
+defaultCharacterData(void *userData, const XML_Char *s, size_t len) {
   UNUSED_P(s);
   UNUSED_P(len);
   XML_DefaultCurrent((XML_Parser)userData);
@@ -521,7 +521,7 @@ defaultProcessingInstruction(void *userData, const XML_Char *target,
 }
 
 static void XMLCALL
-nopCharacterData(void *userData, const XML_Char *s, int len) {
+nopCharacterData(void *userData, const XML_Char *s, size_t len) {
   UNUSED_P(userData);
   UNUSED_P(s);
   UNUSED_P(len);
@@ -549,9 +549,9 @@ nopProcessingInstruction(void *userData, const XML_Char *target,
 }
 
 static void XMLCALL
-markup(void *userData, const XML_Char *s, int len) {
+markup(void *userData, const XML_Char *s, size_t len) {
   FILE *fp = ((XmlwfUserData *)XML_GetUserData((XML_Parser)userData))->fp;
-  for (; len > 0; --len, ++s)
+  for (; len; --len, ++s)
     puttc(*s, fp);
 }
 
@@ -671,7 +671,7 @@ metaEndCdataSection(void *userData) {
 }
 
 static void XMLCALL
-metaCharacterData(void *userData, const XML_Char *s, int len) {
+metaCharacterData(void *userData, const XML_Char *s, size_t len) {
   XML_Parser parser = (XML_Parser)userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;


### PR DESCRIPTION
Casting can cost more instructions.