### PR TITLE
Update autoconf to 2.71 from 2.69

### DIFF
--- a/expat/configure-ac-style.md
+++ b/expat/configure-ac-style.md
@@ -23,7 +23,7 @@ Parameters to functions either go
 - (b) align vertically or
 - (c) go to the next line, with the first character indented 2 spaces more
   than the first *non-`[`*(!) parent level character,
-  i.e. 2 or [3 columns further right](https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Autoconf-Language.html):
+  i.e. 2 or [3 columns further right](https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/Autoconf-Language.html):
 
 ```
 CALL([parameter], [parameter], [parameter])

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -43,8 +43,8 @@ dnl   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
 dnl   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 dnl   USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-dnl Ensure that Expat is configured with autoconf 2.69 or newer.
-AC_PREREQ([2.69])
+dnl Ensure that Expat is configured with autoconf 2.71 or newer.
+AC_PREREQ([2.71])
 
 dnl Get the version number of Expat, using m4's esyscmd() command to run
 dnl the command at m4-generation time. This allows us to create an m4
@@ -60,7 +60,7 @@ m4_define([expat_version],
   m4_ifdef([__gnu__],
            [esyscmd(conftools/get-version.sh lib/expat.h)],
            [2.2.x]))
-AC_INIT([expat], expat_version, [expat-bugs@libexpat.org])
+AC_INIT([expat],[expat_version],[expat-bugs@libexpat.org])
 m4_undefine([expat_version])
 
 AC_CONFIG_SRCDIR([Makefile.in])
@@ -103,7 +103,7 @@ AC_SUBST(LIBREVISION)
 AC_SUBST(LIBAGE)
 
 AC_LANG([C])
-AC_PROG_CC_C99
+AC_PROG_CC
 
 AS_IF([test "$GCC" = yes],
   [AX_APPEND_COMPILE_FLAGS([-Wall -Wextra], [AM_CFLAGS])


### PR DESCRIPTION
This update also requires replacing AC_PROG_CC_C99 with AC_PROG_CC, as AC_PROG_CC checks for the version as well.