### PR TITLE
Use C99 syntax to declare variable length arrays at the end of a struct

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -323,7 +323,7 @@ typedef struct {
 typedef struct block {
   struct block *next;
   int size;
-  XML_Char s[1];
+  XML_Char s[];
 } BLOCK;
 
 typedef struct {


### PR DESCRIPTION
This is standard in C99, and rather than confuse the compiler by having a size of [1], we can mark it so the compiler knows the array at the end is not a fixed size.