### PR TITLE
runtests.c: Initialize storage prior to usage (cppcheck 2.11) + autotools: Sync CMake templates with CMake 3.25

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -5,7 +5,7 @@ NOTE: We are looking for help with a few things:
 Release 2.5.1 xxx xxxxxxx xx xxxx
         Other changes:
             #673  examples: Add new example "element_declarations.c"
-            #678  Autotools: Sync CMake templates with CMake 3.23
+  #678 #706 #733  Autotools: Sync CMake templates with CMake 3.25
 
         Infrastructure:
        #698 #721  CI: Resolve some Travis CI leftovers

--- a/expat/cmake/autotools/expat.cmake
+++ b/expat/cmake/autotools/expat.cmake
@@ -7,7 +7,7 @@ if(CMAKE_VERSION VERSION_LESS "2.8.3")
    message(FATAL_ERROR "CMake >= 2.8.3 required")
 endif()
 cmake_policy(PUSH)
-cmake_policy(VERSION 2.8.3...3.24)
+cmake_policy(VERSION 2.8.3...3.25)
 #----------------------------------------------------------------
 # Generated CMake target import file.
 #----------------------------------------------------------------

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -6814,10 +6814,11 @@ START_TEST(test_nested_entity_suspend) {
   const XML_Char *const expected = XCS("start") XCS("e3 head") XCS("e2 head")
       XCS("e1") XCS("e2 tail") XCS("e3 tail") XCS("end");
   CharData storage;
+  CharData_Init(&storage);
+
   XML_Parser parser = XML_ParserCreate(NULL);
   ParserPlusStorage parserPlusStorage = {parser, &storage};
 
-  CharData_Init(&storage);
   XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetCommentHandler(parser, accumulate_and_suspend_comment_handler);
   XML_SetUserData(parser, &parserPlusStorage);


### PR DESCRIPTION
Error was:
```
expat/tests/runtests.c:6818:50: error: Uninitialized variable: &storage [uninitvar]
  ParserPlusStorage parserPlusStorage = {parser, &storage};
                                                 ^
```