### PR TITLE
tests/handlers.h: Be explicit about direct dependency expat_config.h

### DIFF
--- a/expat/tests/handlers.h
+++ b/expat/tests/handlers.h
@@ -47,6 +47,8 @@ extern "C" {
 #ifndef XML_HANDLERS_H
 #  define XML_HANDLERS_H
 
+#  include "expat_config.h"
+
 #  include "expat.h"
 
 /* Variable holding the expected handler userData */


### PR DESCRIPTION
Follow-up to #738

The file checks for `XML_DTD` being defined.

