### PR TITLE
CMake: Require CMake >=3.5.0

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -34,7 +34,7 @@
 # Unlike most of Expat,
 # this file is copyrighted under the BSD-license for buildsystem files of KDE.
 
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(expat
     VERSION


### PR DESCRIPTION
Related CMake output:
> ```
> CMake Deprecation Warning at CMakeLists.txt:37 (cmake_minimum_required):
>   Compatibility with CMake < 3.5 will be removed from a future version of
>   CMake.
>
>   Update the VERSION argument <min> value or use a ...<max> suffix to tell
>   CMake that the project does not need compatibility with older versions.
> ```