### PR TITLE
Repeat tests with different SINGLE_BYTES chunk sizes

### DIFF
--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -3474,10 +3474,10 @@ END_TEST
 /* Test aborting the parse in an epilog works */
 START_TEST(test_abort_epilog) {
   const char *text = "<doc></doc>\n\r\n";
-  XML_Char match[] = XCS("\r");
+  XML_Char trigger_char = XCS('\r');
 
   XML_SetDefaultHandler(g_parser, selective_aborting_default_handler);
-  XML_SetUserData(g_parser, match);
+  XML_SetUserData(g_parser, &trigger_char);
   g_resumable = XML_FALSE;
   if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
@@ -3490,10 +3490,10 @@ END_TEST
 /* Test a different code path for abort in the epilog */
 START_TEST(test_abort_epilog_2) {
   const char *text = "<doc></doc>\n";
-  XML_Char match[] = XCS("\n");
+  XML_Char trigger_char = XCS('\n');
 
   XML_SetDefaultHandler(g_parser, selective_aborting_default_handler);
-  XML_SetUserData(g_parser, match);
+  XML_SetUserData(g_parser, &trigger_char);
   g_resumable = XML_FALSE;
   expect_failure(text, XML_ERROR_ABORTED, "Abort not triggered");
 }
@@ -3502,10 +3502,10 @@ END_TEST
 /* Test suspension from the epilog */
 START_TEST(test_suspend_epilog) {
   const char *text = "<doc></doc>\n";
-  XML_Char match[] = XCS("\n");
+  XML_Char trigger_char = XCS('\n');
 
   XML_SetDefaultHandler(g_parser, selective_aborting_default_handler);
-  XML_SetUserData(g_parser, match);
+  XML_SetUserData(g_parser, &trigger_char);
   g_resumable = XML_TRUE;
   if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -1839,6 +1839,7 @@ START_TEST(test_default_current) {
                             "<doc>&entity;</doc>";
   CharData storage;
 
+  set_subtest("with defaulting");
   XML_SetDefaultHandler(g_parser, record_default_handler);
   XML_SetCharacterDataHandler(g_parser, record_cdata_handler);
   CharData_Init(&storage);
@@ -1849,6 +1850,7 @@ START_TEST(test_default_current) {
   CharData_CheckXMLChars(&storage, XCS("DCDCDCDCDCDD"));
 
   /* Again, without the defaulting */
+  set_subtest("no defaulting");
   XML_ParserReset(g_parser, NULL);
   XML_SetDefaultHandler(g_parser, record_default_handler);
   XML_SetCharacterDataHandler(g_parser, record_cdata_nodefault_handler);
@@ -1860,6 +1862,7 @@ START_TEST(test_default_current) {
   CharData_CheckXMLChars(&storage, XCS("DcccccD"));
 
   /* Now with an internal entity to complicate matters */
+  set_subtest("with internal entity");
   XML_ParserReset(g_parser, NULL);
   XML_SetDefaultHandler(g_parser, record_default_handler);
   XML_SetCharacterDataHandler(g_parser, record_cdata_handler);
@@ -1873,6 +1876,7 @@ START_TEST(test_default_current) {
   CharData_CheckXMLChars(&storage, XCS("DDDDDDDDDDDDDDDDDDD"));
 
   /* Again, with a skip handler */
+  set_subtest("with skip handler");
   XML_ParserReset(g_parser, NULL);
   XML_SetDefaultHandler(g_parser, record_default_handler);
   XML_SetCharacterDataHandler(g_parser, record_cdata_handler);
@@ -1887,6 +1891,7 @@ START_TEST(test_default_current) {
   CharData_CheckXMLChars(&storage, XCS("DDDDDDDDDDDDDDDDDeD"));
 
   /* This time, allow the entity through */
+  set_subtest("allow entity");
   XML_ParserReset(g_parser, NULL);
   XML_SetDefaultHandlerExpand(g_parser, record_default_handler);
   XML_SetCharacterDataHandler(g_parser, record_cdata_handler);
@@ -1899,6 +1904,7 @@ START_TEST(test_default_current) {
   CharData_CheckXMLChars(&storage, XCS("DDDDDDDDDDDDDDDDDCDD"));
 
   /* Finally, without passing the cdata to the default handler */
+  set_subtest("not passing cdata");
   XML_ParserReset(g_parser, NULL);
   XML_SetDefaultHandlerExpand(g_parser, record_default_handler);
   XML_SetCharacterDataHandler(g_parser, record_cdata_nodefault_handler);

--- a/expat/tests/common.h
+++ b/expat/tests/common.h
@@ -18,6 +18,7 @@
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
    Copyright (c) 2020      Tim Gates <tim.gates@iress.com>
    Copyright (c) 2021      Donghee Na <donghee.na@python.org>
+   Copyright (c) 2023      Sony Corporation / Snild Dolkow <snild@sony.com>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -81,6 +82,8 @@ extern XML_Parser g_parser;
 
 extern XML_Bool g_resumable;
 extern XML_Bool g_abortable;
+
+extern int g_chunkSize;
 
 extern const char *long_character_data_text;
 extern const char *long_cdata_text;

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -1793,10 +1793,17 @@ data_check_comment_handler(void *userData, const XML_Char *data) {
 
 void XMLCALL
 selective_aborting_default_handler(void *userData, const XML_Char *s, int len) {
-  const XML_Char *match = (const XML_Char *)userData;
+  const XML_Char trigger_char = *(const XML_Char *)userData;
 
-  if (match == NULL
-      || (xcstrlen(match) == (unsigned)len && ! xcstrncmp(match, s, len))) {
+  int found = 0;
+  for (int i = 0; i < len; ++i) {
+    if (s[i] == trigger_char) {
+      found = 1;
+      break;
+    }
+  }
+
+  if (found) {
     XML_StopParser(g_parser, g_resumable);
     XML_SetDefaultHandler(g_parser, NULL);
   }

--- a/expat/tests/handlers.h
+++ b/expat/tests/handlers.h
@@ -18,6 +18,7 @@
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
    Copyright (c) 2020      Tim Gates <tim.gates@iress.com>
    Copyright (c) 2021      Donghee Na <donghee.na@python.org>
+   Copyright (c) 2023      Sony Corporation / Snild Dolkow <snild@sony.com>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -471,7 +472,16 @@ extern void XMLCALL byte_character_handler(void *userData, const XML_Char *s,
 extern void XMLCALL ext2_accumulate_characters(void *userData,
                                                const XML_Char *s, int len);
 
-/* Handlers that record their invocation by single characters */
+/* Handlers that record their `len` arg and a single identifying character */
+
+struct handler_record_entry {
+  const char *name;
+  int arg;
+};
+struct handler_record_list {
+  int count;
+  struct handler_record_entry entries[50]; // arbitrary big-enough max count
+};
 
 extern void XMLCALL record_default_handler(void *userData, const XML_Char *s,
                                            int len);
@@ -492,6 +502,22 @@ extern void XMLCALL record_element_start_handler(void *userData,
 
 extern void XMLCALL record_element_end_handler(void *userData,
                                                const XML_Char *name);
+
+extern const struct handler_record_entry *
+_handler_record_get(const struct handler_record_list *storage, const int index,
+                    const char *file, const int line);
+
+#  define handler_record_get(storage, index)                                   \
+    _handler_record_get((storage), (index), __FILE__, __LINE__)
+
+#  define assert_record_handler_called(storage, index, expected_name,          \
+                                       expected_arg)                           \
+    do {                                                                       \
+      const struct handler_record_entry *e                                     \
+          = handler_record_get(storage, index);                                \
+      fail_unless(strcmp(e->name, expected_name) == 0);                        \
+      fail_unless(e->arg == (expected_arg));                                   \
+    } while (0)
 
 /* Entity Declaration Handlers */
 #  define ENTITY_MATCH_FAIL (-1)

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -244,7 +244,9 @@ _fail_unless(int condition, const char *file, int line, const char *msg) {
      we have a failure, so there's no reason to be quiet about what
      it is.
   */
-  UNUSED_P(condition);
+  if (condition) {
+    return;
+  }
   _check_current_filename = file;
   _check_current_lineno = line;
   if (msg != NULL) {

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -176,19 +176,20 @@ handle_success(int verbosity) {
 }
 
 static void
-handle_failure(SRunner *runner, int verbosity, const char *phase_info) {
+handle_failure(SRunner *runner, int verbosity, const char *context,
+               const char *phase_info) {
   runner->nfailures++;
   if (verbosity != CK_SILENT) {
     if (strlen(_check_current_subtest) != 0) {
       phase_info = _check_current_subtest;
     }
-    printf("FAIL: %s (%s at %s:%d)\n", _check_current_function, phase_info,
-           _check_current_filename, _check_current_lineno);
+    printf("FAIL [%s]: %s (%s at %s:%d)\n", context, _check_current_function,
+           phase_info, _check_current_filename, _check_current_lineno);
   }
 }
 
 void
-srunner_run_all(SRunner *runner, int verbosity) {
+srunner_run_all(SRunner *runner, const char *context, int verbosity) {
   Suite *suite;
   TCase *volatile tc;
   assert(runner != NULL);
@@ -203,14 +204,14 @@ srunner_run_all(SRunner *runner, int verbosity) {
       if (tc->setup != NULL) {
         /* setup */
         if (setjmp(env)) {
-          handle_failure(runner, verbosity, "during setup");
+          handle_failure(runner, verbosity, context, "during setup");
           continue;
         }
         tc->setup();
       }
       /* test */
       if (setjmp(env)) {
-        handle_failure(runner, verbosity, "during actual test");
+        handle_failure(runner, verbosity, context, "during actual test");
         continue;
       }
       (tc->tests[i])();
@@ -219,7 +220,7 @@ srunner_run_all(SRunner *runner, int verbosity) {
       /* teardown */
       if (tc->teardown != NULL) {
         if (setjmp(env)) {
-          handle_failure(runner, verbosity, "during teardown");
+          handle_failure(runner, verbosity, context, "during teardown");
           continue;
         }
         tc->teardown();
@@ -229,6 +230,10 @@ srunner_run_all(SRunner *runner, int verbosity) {
     }
     tc = tc->next_tcase;
   }
+}
+
+void
+srunner_summarize(SRunner *runner, int verbosity) {
   if (verbosity != CK_SILENT) {
     int passed = runner->nchecks - runner->nfailures;
     double percentage = ((double)passed) / runner->nchecks;

--- a/expat/tests/minicheck.h
+++ b/expat/tests/minicheck.h
@@ -132,7 +132,8 @@ void tcase_add_checked_fixture(TCase *, tcase_setup_function,
                                tcase_teardown_function);
 void tcase_add_test(TCase *tc, tcase_test_function test);
 SRunner *srunner_create(Suite *suite);
-void srunner_run_all(SRunner *runner, int verbosity);
+void srunner_run_all(SRunner *runner, const char *context, int verbosity);
+void srunner_summarize(SRunner *runner, int verbosity);
 int srunner_ntests_failed(SRunner *runner);
 void srunner_free(SRunner *runner);
 

--- a/expat/tests/minicheck.h
+++ b/expat/tests/minicheck.h
@@ -84,6 +84,8 @@ extern "C" {
 void PRINTF_LIKE(1, 2) set_subtest(char const *fmt, ...);
 
 #  define fail(msg) _fail_unless(0, __FILE__, __LINE__, msg)
+#  define fail_unless(cond)                                                    \
+    _fail_unless((cond), __FILE__, __LINE__, "check failed: " #cond)
 
 typedef void (*tcase_setup_function)(void);
 typedef void (*tcase_teardown_function)(void);

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -18,6 +18,7 @@
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
    Copyright (c) 2020      Tim Gates <tim.gates@iress.com>
    Copyright (c) 2021      Donghee Na <donghee.na@python.org>
+   Copyright (c) 2023      Sony Corporation / Snild Dolkow <snild@sony.com>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -95,7 +96,14 @@ main(int argc, char *argv[]) {
   }
   if (verbosity != CK_SILENT)
     printf("Expat version: %" XML_FMT_STR "\n", XML_ExpatVersion());
-  srunner_run_all(sr, verbosity);
+
+  for (g_chunkSize = 1; g_chunkSize <= 5; g_chunkSize++) {
+    char context[100];
+    snprintf(context, sizeof(context), "chunksize=%d", g_chunkSize);
+    context[sizeof(context) - 1] = '\0';
+    srunner_run_all(sr, context, verbosity);
+  }
+  srunner_summarize(sr, verbosity);
   nf = srunner_ntests_failed(sr);
   srunner_free(sr);
 


### PR DESCRIPTION
Lots of tests use _XML_Parse_SINGLE_BYTES(), which parses the input one byte at a time. Repeating the tests with different chunk sizes (1,2,3,4,5) is a cheap way to get more test coverage.