### PR TITLE
Run SINGLE_BYTES with no chunking, too

### DIFF
--- a/expat/tests/alloc_tests.c
+++ b/expat/tests/alloc_tests.c
@@ -18,6 +18,7 @@
    Copyright (c) 2019      David Loffredo <loffredo@steptools.com>
    Copyright (c) 2020      Tim Gates <tim.gates@iress.com>
    Copyright (c) 2021      Donghee Na <donghee.na@python.org>
+   Copyright (c) 2023      Sony Corporation / Snild Dolkow <snild@sony.com>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -1645,7 +1646,7 @@ START_TEST(test_alloc_nested_entities) {
          "ABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOPABCDEFGHIJKLMNOP"
          "'>\n"
          "<!ENTITY % pe2 '%pe1;'>\n"
-         "%pe2;",
+         "<!ENTITY % pe3 '%pe2;'>",
          "Memory Fail not faulted", NULL, XML_ERROR_NO_MEMORY};
 
   /* Causes an allocation error in a nested storeEntityValue() */

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -1573,6 +1573,11 @@ parser_stop_character_handler(void *userData, const XML_Char *s, int len) {
   UNUSED_P(userData);
   UNUSED_P(s);
   UNUSED_P(len);
+  XML_ParsingStatus status;
+  XML_GetParsingStatus(g_parser, &status);
+  if (status.parsing == XML_FINISHED) {
+    return; // the parser was stopped by a previous call to this handler.
+  }
   XML_StopParser(g_parser, g_resumable);
   XML_SetCharacterDataHandler(g_parser, NULL);
   if (! g_resumable) {

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -97,7 +97,7 @@ main(int argc, char *argv[]) {
   if (verbosity != CK_SILENT)
     printf("Expat version: %" XML_FMT_STR "\n", XML_ExpatVersion());
 
-  for (g_chunkSize = 1; g_chunkSize <= 5; g_chunkSize++) {
+  for (g_chunkSize = 0; g_chunkSize <= 5; g_chunkSize++) {
     char context[100];
     snprintf(context, sizeof(context), "chunksize=%d", g_chunkSize);
     context[sizeof(context) - 1] = '\0';


### PR DESCRIPTION
...including one test that needed fixing to get it passing in these new conditions.