### PR TITLE
Make inclusion to expat_config.h consistent

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -61,7 +61,7 @@
 
 #define XML_BUILDING_EXPAT 1
 
-#include <expat_config.h>
+#include "expat_config.h"
 
 #if defined(HAVE_SYSCALL_GETRANDOM)
 #  if ! defined(_GNU_SOURCE)

--- a/expat/lib/xmlrole.c
+++ b/expat/lib/xmlrole.c
@@ -38,7 +38,7 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <expat_config.h>
+#include "expat_config.h"
 
 #include <stddef.h>
 

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -44,7 +44,7 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <expat_config.h>
+#include "expat_config.h"
 
 #include <stddef.h>
 #include <string.h> /* memcpy */

--- a/expat/tests/chardata.c
+++ b/expat/tests/chardata.c
@@ -38,7 +38,7 @@
 #  undef NDEBUG /* because test suite relies on assert(...) at the moment */
 #endif
 
-#include <expat_config.h>
+#include "expat_config.h"
 #include "minicheck.h"
 
 #include <assert.h>

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -41,7 +41,7 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <expat_config.h>
+#include "expat_config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -37,7 +37,7 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <expat_config.h>
+#include "expat_config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -40,7 +40,7 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <expat_config.h>
+#include "expat_config.h"
 
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
.. and priorize the local build over the system header.