### PR TITLE
tests: Rename fail_unless to assert_true for clarity

### DIFF
--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -1855,16 +1855,16 @@ START_TEST(test_default_current) {
     while (cdata_len_remaining > 0) {
       const struct handler_record_entry *c_entry
           = handler_record_get(&storage, i++);
-      fail_unless(strcmp(c_entry->name, "record_cdata_handler") == 0);
-      fail_unless(c_entry->arg > 0);
-      fail_unless(c_entry->arg <= cdata_len_remaining);
+      assert_true(strcmp(c_entry->name, "record_cdata_handler") == 0);
+      assert_true(c_entry->arg > 0);
+      assert_true(c_entry->arg <= cdata_len_remaining);
       cdata_len_remaining -= c_entry->arg;
       // default handler must follow, with the exact same len argument.
       assert_record_handler_called(&storage, i++, "record_default_handler",
                                    c_entry->arg);
     }
     assert_record_handler_called(&storage, i++, "record_default_handler", 6);
-    fail_unless(storage.count == i);
+    assert_true(storage.count == i);
   }
 
   /* Again, without the defaulting */
@@ -1886,13 +1886,13 @@ START_TEST(test_default_current) {
     while (cdata_len_remaining > 0) {
       const struct handler_record_entry *c_entry
           = handler_record_get(&storage, i++);
-      fail_unless(strcmp(c_entry->name, "record_cdata_nodefault_handler") == 0);
-      fail_unless(c_entry->arg > 0);
-      fail_unless(c_entry->arg <= cdata_len_remaining);
+      assert_true(strcmp(c_entry->name, "record_cdata_nodefault_handler") == 0);
+      assert_true(c_entry->arg > 0);
+      assert_true(c_entry->arg <= cdata_len_remaining);
       cdata_len_remaining -= c_entry->arg;
     }
     assert_record_handler_called(&storage, i++, "record_default_handler", 6);
-    fail_unless(storage.count == i);
+    assert_true(storage.count == i);
   }
 
   /* Now with an internal entity to complicate matters */
@@ -1928,7 +1928,7 @@ START_TEST(test_default_current) {
     assert_record_handler_called(&storage, 16, "record_default_handler", 5);
     assert_record_handler_called(&storage, 17, "record_default_handler", 8);
     assert_record_handler_called(&storage, 18, "record_default_handler", 6);
-    fail_unless(storage.count == 19);
+    assert_true(storage.count == 19);
   }
 
   /* Again, with a skip handler */
@@ -1965,7 +1965,7 @@ START_TEST(test_default_current) {
     assert_record_handler_called(&storage, 16, "record_default_handler", 5);
     assert_record_handler_called(&storage, 17, "record_skip_handler", 0);
     assert_record_handler_called(&storage, 18, "record_default_handler", 6);
-    fail_unless(storage.count == 19);
+    assert_true(storage.count == 19);
   }
 
   /* This time, allow the entity through */
@@ -2001,7 +2001,7 @@ START_TEST(test_default_current) {
     assert_record_handler_called(&storage, 17, "record_cdata_handler", 1);
     assert_record_handler_called(&storage, 18, "record_default_handler", 1);
     assert_record_handler_called(&storage, 19, "record_default_handler", 6);
-    fail_unless(storage.count == 20);
+    assert_true(storage.count == 20);
   }
 
   /* Finally, without passing the cdata to the default handler */
@@ -2037,7 +2037,7 @@ START_TEST(test_default_current) {
     assert_record_handler_called(&storage, 17, "record_cdata_nodefault_handler",
                                  1);
     assert_record_handler_called(&storage, 18, "record_default_handler", 6);
-    fail_unless(storage.count == 19);
+    assert_true(storage.count == 19);
   }
 }
 END_TEST

--- a/expat/tests/common.c
+++ b/expat/tests/common.c
@@ -174,7 +174,7 @@ _xml_failure(XML_Parser parser, const char *file, int line) {
            "u, offset %" XML_FMT_INT_MOD "u)\n    reported from %s, line %d\n",
            err, XML_ErrorString(err), XML_GetCurrentLineNumber(parser),
            XML_GetCurrentColumnNumber(parser), file, line);
-  _fail_unless(0, file, line, buffer);
+  _assert_true(0, file, line, buffer);
 }
 
 enum XML_Status
@@ -200,9 +200,9 @@ _expect_failure(const char *text, enum XML_Error errorCode,
                 const char *errorMessage, const char *file, int lineno) {
   if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
       == XML_STATUS_OK)
-    /* Hackish use of _fail_unless() macro, but let's us report
+    /* Hackish use of _assert_true() macro, but let's us report
        the right filename and line number. */
-    _fail_unless(0, file, lineno, errorMessage);
+    _assert_true(0, file, lineno, errorMessage);
   if (XML_GetErrorCode(g_parser) != errorCode)
     _xml_failure(g_parser, file, lineno);
 }

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -1658,7 +1658,7 @@ static void
 record_call(struct handler_record_list *const rec, const char *funcname,
             const int arg) {
   const int max_entries = sizeof(rec->entries) / sizeof(rec->entries[0]);
-  fail_unless(rec->count < max_entries);
+  assert_true(rec->count < max_entries);
   struct handler_record_entry *const e = &rec->entries[rec->count++];
   e->name = funcname;
   e->arg = arg;

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -1709,7 +1709,7 @@ record_element_end_handler(void *userData, const XML_Char *name) {
 const struct handler_record_entry *
 _handler_record_get(const struct handler_record_list *storage, const int index,
                     const char *file, const int line) {
-  _fail_unless(storage->count > index, file, line, "too few handler calls");
+  _assert_true(storage->count > index, file, line, "too few handler calls");
   return &storage->entries[index];
 }
 

--- a/expat/tests/handlers.h
+++ b/expat/tests/handlers.h
@@ -515,8 +515,8 @@ _handler_record_get(const struct handler_record_list *storage, const int index,
     do {                                                                       \
       const struct handler_record_entry *e                                     \
           = handler_record_get(storage, index);                                \
-      fail_unless(strcmp(e->name, expected_name) == 0);                        \
-      fail_unless(e->arg == (expected_arg));                                   \
+      assert_true(strcmp(e->name, expected_name) == 0);                        \
+      assert_true(e->arg == (expected_arg));                                   \
     } while (0)
 
 /* Entity Declaration Handlers */

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -244,7 +244,7 @@ srunner_summarize(SRunner *runner, int verbosity) {
 }
 
 void
-_fail_unless(int condition, const char *file, int line, const char *msg) {
+_assert_true(int condition, const char *file, int line, const char *msg) {
   /* Always print the error message so it isn't lost.  In this case,
      we have a failure, so there's no reason to be quiet about what
      it is.

--- a/expat/tests/minicheck.h
+++ b/expat/tests/minicheck.h
@@ -83,9 +83,9 @@ extern "C" {
 
 void PRINTF_LIKE(1, 2) set_subtest(char const *fmt, ...);
 
-#  define fail(msg) _fail_unless(0, __FILE__, __LINE__, msg)
+#  define fail(msg) _assert_true(0, __FILE__, __LINE__, msg)
 #  define fail_unless(cond)                                                    \
-    _fail_unless((cond), __FILE__, __LINE__, "check failed: " #cond)
+    _assert_true((cond), __FILE__, __LINE__, "check failed: " #cond)
 
 typedef void (*tcase_setup_function)(void);
 typedef void (*tcase_teardown_function)(void);
@@ -124,7 +124,7 @@ void _check_set_test_info(char const *function, char const *filename,
  * Prototypes for the actual implementation.
  */
 
-void _fail_unless(int condition, const char *file, int line, const char *msg);
+void _assert_true(int condition, const char *file, int line, const char *msg);
 Suite *suite_create(const char *name);
 TCase *tcase_create(const char *name);
 void suite_add_tcase(Suite *suite, TCase *tc);

--- a/expat/tests/minicheck.h
+++ b/expat/tests/minicheck.h
@@ -84,7 +84,7 @@ extern "C" {
 void PRINTF_LIKE(1, 2) set_subtest(char const *fmt, ...);
 
 #  define fail(msg) _assert_true(0, __FILE__, __LINE__, msg)
-#  define fail_unless(cond)                                                    \
+#  define assert_true(cond)                                                    \
     _assert_true((cond), __FILE__, __LINE__, "check failed: " #cond)
 
 typedef void (*tcase_setup_function)(void);


### PR DESCRIPTION
Naming [inspired by GoogleTest](https://github.com/google/googletest/blob/main/docs/reference/assertions.md#expect_true-expect_true).

CC @Snild-Sony 