### PR TITLE
tests/handlers.h: Drop unused type XmlParseFunction

### DIFF
--- a/expat/tests/handlers.h
+++ b/expat/tests/handlers.h
@@ -405,8 +405,6 @@ extern int XMLCALL external_entity_parser_create_alloc_fail_handler(
     const XML_Char *systemId, const XML_Char *publicId);
 
 #  if defined(XML_DTD)
-typedef enum XML_Status (*XmlParseFunction)(XML_Parser, const char *, int, int);
-
 struct AccountingTestCase {
   const char *primaryText;
   const char *firstExternalText;  /* often NULL */


### PR DESCRIPTION
Follow-up to #783

Last use removed in commit b3d14b0d3c96700a81be06e7482d3735245611ca.

CC @Snild-Sony 