### PR TITLE
fuzz: Improve coverage by maybe stopping the parser

### DIFF
--- a/expat/fuzz/xml_parse_fuzzer.c
+++ b/expat/fuzz/xml_parse_fuzzer.c
@@ -47,6 +47,14 @@ end(void *userData, const XML_Char *name) {
   (void)name;
 }
 
+static void XMLCALL
+may_stop_character_handler(void *userData, const XML_Char *s, int len) {
+  XML_Parser parser = (XML_Parser)userData;
+  if (len > 1 && s[0] == 's') {
+    XML_StopParser(parser, s[1] == 'r' ? XML_FALSE : XML_TRUE);
+  }
+}
+
 static void
 ParseOneInput(XML_Parser p, const uint8_t *data, size_t size) {
   // Set the hash salt using siphash to generate a deterministic hash.
@@ -54,7 +62,9 @@ ParseOneInput(XML_Parser p, const uint8_t *data, size_t size) {
   XML_SetHashSalt(p, (unsigned long)siphash24(data, size, key));
   (void)sip24_valid;
 
+  XML_SetUserData(p, p);
   XML_SetElementHandler(p, start, end);
+  XML_SetCharacterDataHandler(p, may_stop_character_handler);
   XML_Parse(p, (const XML_Char *)data, size, 0);
   if (XML_Parse(p, (const XML_Char *)data, size, 1) == XML_STATUS_ERROR) {
     XML_ErrorString(XML_GetErrorCode(p));

--- a/expat/fuzz/xml_parsebuffer_fuzzer.c
+++ b/expat/fuzz/xml_parsebuffer_fuzzer.c
@@ -71,7 +71,9 @@ ParseOneInput(XML_Parser p, const uint8_t *data, size_t size) {
   memcpy(buf, data, size);
   XML_ParseBuffer(p, size, 0);
   buf = XML_GetBuffer(p, size);
-  assert(buf);
+  if (buf == NULL) {
+    return;
+  }
   memcpy(buf, data, size);
   if (XML_ParseBuffer(p, size, 1) == XML_STATUS_ERROR) {
     XML_ErrorString(XML_GetErrorCode(p));

--- a/expat/fuzz/xml_parsebuffer_fuzzer.c
+++ b/expat/fuzz/xml_parsebuffer_fuzzer.c
@@ -48,6 +48,14 @@ end(void *userData, const XML_Char *name) {
   (void)name;
 }
 
+static void XMLCALL
+may_stop_character_handler(void *userData, const XML_Char *s, int len) {
+  XML_Parser parser = (XML_Parser)userData;
+  if (len > 1 && s[0] == 's') {
+    XML_StopParser(parser, s[1] == 'r' ? XML_FALSE : XML_TRUE);
+  }
+}
+
 static void
 ParseOneInput(XML_Parser p, const uint8_t *data, size_t size) {
   // Set the hash salt using siphash to generate a deterministic hash.
@@ -55,7 +63,9 @@ ParseOneInput(XML_Parser p, const uint8_t *data, size_t size) {
   XML_SetHashSalt(p, (unsigned long)siphash24(data, size, key));
   (void)sip24_valid;
 
+  XML_SetUserData(p, p);
   XML_SetElementHandler(p, start, end);
+  XML_SetCharacterDataHandler(p, may_stop_character_handler);
   void *buf = XML_GetBuffer(p, size);
   assert(buf);
   memcpy(buf, data, size);


### PR DESCRIPTION
@hartwork what do you think about this to make `internalEntityProcessor` reachable by fuzzing ?

If it looks good, I will put it in xml_parsebuffer_fuzzer.c as well