### PR TITLE
Define XML_STATIC in pkg-config file when building a static expat

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -559,7 +559,10 @@ if(EXPAT_BUILD_PKGCONFIG)
     endforeach()
 
     if(NOT EXPAT_SHARED_LIBS)
-        set_property(TARGET expat PROPERTY "pkgconfig_cflags" "-DXML_STATIC")
+        # The leading space on this value when set is important! We need to
+        # make sure that we don't leave a trailing space in the generated .pc
+        # file, so that we avoid mismatches with what we generate in autotools
+        set_property(TARGET expat PROPERTY "pkgconfig_cflags" " -DXML_STATIC")
     endif()
 
     file(GENERATE

--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -558,6 +558,10 @@ if(EXPAT_BUILD_PKGCONFIG)
         endif()
     endforeach()
 
+    if(NOT EXPAT_SHARED_LIBS)
+        set_property(TARGET expat PROPERTY "pkgconfig_cflags" "-DXML_STATIC")
+    endif()
+
     file(GENERATE
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/expat.pc
         INPUT ${PROJECT_SOURCE_DIR}/expat.pc.cmake)

--- a/expat/expat.pc.cmake
+++ b/expat/expat.pc.cmake
@@ -9,4 +9,4 @@ Description: expat XML parser
 URL: https://libexpat.github.io/
 Libs: -L${libdir} -l$<TARGET_PROPERTY:expat,pkgconfig_$<LOWER_CASE:$<CONFIG>>_output_name>
 Libs.private: $<TARGET_PROPERTY:expat,pkgconfig_libm>
-Cflags: -I${includedir}
+Cflags: -I${includedir} $<TARGET_PROPERTY:expat,pkgconfig_cflags>

--- a/expat/expat.pc.cmake
+++ b/expat/expat.pc.cmake
@@ -9,4 +9,4 @@ Description: expat XML parser
 URL: https://libexpat.github.io/
 Libs: -L${libdir} -l$<TARGET_PROPERTY:expat,pkgconfig_$<LOWER_CASE:$<CONFIG>>_output_name>
 Libs.private: $<TARGET_PROPERTY:expat,pkgconfig_libm>
-Cflags: -I${includedir} $<TARGET_PROPERTY:expat,pkgconfig_cflags>
+Cflags: -I${includedir}$<TARGET_PROPERTY:expat,pkgconfig_cflags>


### PR DESCRIPTION
`XML_STATIC` is required to be defined when using expat as a static library, but it is not set in the generated pkgconfig when expat is built as a static library. This sets it up so that apps using a static expat via pkgconfig will automatically set the right definition.