### PR TITLE
pkg-config: Add missing `-DXML_STATIC` for Windows (alternative to #805)

### DIFF
--- a/expat/expat.pc.cmake
+++ b/expat/expat.pc.cmake
@@ -10,3 +10,4 @@ URL: https://libexpat.github.io/
 Libs: -L${libdir} -l$<TARGET_PROPERTY:expat,pkgconfig_$<LOWER_CASE:$<CONFIG>>_output_name>
 Libs.private: $<TARGET_PROPERTY:expat,pkgconfig_libm>
 Cflags: -I${includedir}
+Cflags.private: -DXML_STATIC

--- a/expat/expat.pc.in
+++ b/expat/expat.pc.in
@@ -10,3 +10,4 @@ URL: https://libexpat.github.io/
 Libs: -L${libdir} -l@PACKAGE_NAME@
 Libs.private: @LIBM@
 Cflags: -I${includedir}
+Cflags.private: -DXML_STATIC


### PR DESCRIPTION
Alternative to #805

This affects the output of command `pkg-config --cflags --static expat`.