### PR TITLE
Autotools: Re-work handling of xmlwf.1 (fixes #821)

### DIFF
--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -357,11 +357,22 @@ AS_IF([test "x${DOCBOOK_TO_MAN}" != x -a "x$with_docbook" != xno],
   page for xmlwf.])])])
 
 dnl This will make sure that a release tarball shipping a pre-rendered xmlwf man page will
-dnl get it installed, independent of whether some flavor of docbook2man is available.
+dnl get it installed, when no working flavor of docbook2man is available (or wanted).
 dnl This relies on file xmlwf.1 being at least as recent as its source file xmlwf.xml.
 AS_IF([test -f "${srcdir}"/doc/xmlwf.1],
-  [AM_CONDITIONAL(WITH_DOCBOOK, [true])],
-  [AM_CONDITIONAL(WITH_DOCBOOK, [test "x${DOCBOOK_TO_MAN}" != x])])
+  [AM_CONDITIONAL(WITH_MANPAGE, [true])
+   AS_IF([test "x$with_docbook" = xno -o "x${DOCBOOK_TO_MAN}" = x],
+     [AM_CONDITIONAL(WITH_PREBUILT_MANPAGE, [true])
+      AM_CONDITIONAL(WITH_DISTRIBUTABLE_MANPAGE, [false])],
+     [AM_CONDITIONAL(WITH_PREBUILT_MANPAGE, [false])
+      AM_CONDITIONAL(WITH_DISTRIBUTABLE_MANPAGE, [true])])
+   ],
+  [AS_IF([test "x$with_docbook" != xno -a "x${DOCBOOK_TO_MAN}" != x],
+     [AM_CONDITIONAL(WITH_MANPAGE, [true])
+      AM_CONDITIONAL(WITH_DISTRIBUTABLE_MANPAGE, [true])],
+     [AM_CONDITIONAL(WITH_MANPAGE, [false])
+      AM_CONDITIONAL(WITH_DISTRIBUTABLE_MANPAGE, [false])])
+   AM_CONDITIONAL(WITH_PREBUILT_MANPAGE, [false])])
 
 dnl Configure CMake file templates
 dnl NOTE: The *_TRUE variables read here are Automake conditionals

--- a/expat/doc/Makefile.am
+++ b/expat/doc/Makefile.am
@@ -32,26 +32,24 @@
 
 .PHONY: dist-hook  # not inside conditional to avoid automake warning
 
-if WITH_DOCBOOK
+if WITH_MANPAGE
 dist_man_MANS = xmlwf.1
 
 xmlwf.1: xmlwf.xml
 	-rm -f $@
-	$(DOCBOOK_TO_MAN) $<
+	test x$(DOCBOOK_TO_MAN) != x && $(DOCBOOK_TO_MAN) $<
 	test -f $@ || mv XMLWF.1 $@
-else
+endif
+
+if !WITH_DISTRIBUTABLE_MANPAGE
 dist-hook:
 	@echo 'ERROR: Configure with --with-docbook for "make dist".' 1>&2
 	@false
 endif
 
-# https://www.gnu.org/software/automake/manual/automake.html#What-Gets-Cleaned
-.PHONY: clean-local
-clean-local: clean-local-check
-
-.PHONY: clean-local-check
-clean-local-check:
-	$(RM) xmlwf.1
+if !WITH_PREBUILT_MANPAGE
+CLEANFILES = xmlwf.1
+endif
 
 EXTRA_DIST = \
     ok.min.css \


### PR DESCRIPTION
Fixes #821

File `doc/xmlwf.1` should not be cleaned when building with `./configure --without-docbook`, and re-compilation of the file  hould take precedence over a pre-built copy where available.

Also, variable `CLEANFILES` can be used to simplify things a bit in `Makefile.am`.