### PR TITLE
Avoid writing to the bytesScanned counter outside of tests.

### DIFF
--- a/expat/lib/internal.h
+++ b/expat/lib/internal.h
@@ -162,7 +162,7 @@ const char *unsignedCharToPrintable(unsigned char c);
 #endif
 
 extern XML_Bool g_reparseDeferralEnabledDefault; // written ONLY in runtests.c
-extern unsigned int g_bytesScanned;              // used for testing only
+extern unsigned int *g_bytesScanned;             // used for testing only
 
 #ifdef __cplusplus
 }

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -630,7 +630,7 @@ static unsigned long getDebugLevel(const char *variableName,
        : ((*((pool)->ptr)++ = c), 1))
 
 XML_Bool g_reparseDeferralEnabledDefault = XML_TRUE; // write ONLY in runtests.c
-unsigned int g_bytesScanned = 0;                     // used for testing only
+unsigned int *g_bytesScanned = NULL;                 // used for testing only
 
 struct XML_ParserStruct {
   /* The first member must be m_userData so that the XML_GetUserData
@@ -1017,7 +1017,8 @@ callProcessor(XML_Parser parser, const char *start, const char *end,
       return XML_ERROR_NONE;
     }
   }
-  g_bytesScanned += (unsigned)have_now;
+  if (g_bytesScanned)
+    *g_bytesScanned += (unsigned)have_now;
   const enum XML_Error ret = parser->m_processor(parser, start, end, endPtr);
   if (ret == XML_ERROR_NONE) {
     // if we consumed nothing, remember what we had on this parse attempt.


### PR DESCRIPTION
When used in multi-threaded programs, expat will create data races by performing unsynchronized writes to the same `g_bytesScanned` variable.  This causes no problems in execution, but is technically illegal and causes thread sanitizers, such as clang TSAN, to complain.
