### PR TITLE
Hide test-only code behind new (internal) macro `XML_TESTING` (alternative to #826)

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -676,6 +676,8 @@ if(EXPAT_BUILD_TESTS)
     )
 
     foreach(_target ${_EXPAT_TEST_TARGETS})
+        target_compile_definitions(${_target} PRIVATE -DXML_TESTING)
+
         set_property(TARGET ${_target} PROPERTY RUNTIME_OUTPUT_DIRECTORY tests)
         expat_add_test(${_target} $<TARGET_FILE:${_target}>)
 

--- a/expat/apply-clang-tidy.sh
+++ b/expat/apply-clang-tidy.sh
@@ -68,6 +68,7 @@ flags=(
     -DXML_DTD
     -DXML_GE
     -DXML_NS
+    -DXML_TESTING
 )
 
 if [[ $# -gt 0 ]]; then

--- a/expat/lib/Makefile.am
+++ b/expat/lib/Makefile.am
@@ -52,6 +52,8 @@ libexpat_la_SOURCES = \
     xmlrole.c
 
 if WITH_TESTS
+libtestpat_la_CPPFLAGS = -DXML_TESTING
+
 libtestpat_la_SOURCES = $(libexpat_la_SOURCES)
 endif
 

--- a/expat/lib/Makefile.am
+++ b/expat/lib/Makefile.am
@@ -36,7 +36,9 @@ include_HEADERS = \
     expat_external.h
 
 lib_LTLIBRARIES = libexpat.la
-noinst_LTLIBRARIES = libexpatinternal.la
+if WITH_TESTS
+noinst_LTLIBRARIES = libtestpat.la
+endif
 
 libexpat_la_LDFLAGS = \
     @AM_LDFLAGS@ \
@@ -44,17 +46,14 @@ libexpat_la_LDFLAGS = \
     -no-undefined \
     -version-info @LIBCURRENT@:@LIBREVISION@:@LIBAGE@
 
-libexpat_la_SOURCES =
-
-# This layer of indirection allows
-# the test suite to access internal symbols
-# despite compiling with -fvisibility=hidden
-libexpatinternal_la_SOURCES = \
+libexpat_la_SOURCES = \
     xmlparse.c \
     xmltok.c \
     xmlrole.c
 
-libexpat_la_LIBADD = libexpatinternal.la
+if WITH_TESTS
+libtestpat_la_SOURCES = $(libexpat_la_SOURCES)
+endif
 
 doc_DATA = \
     ../AUTHORS \

--- a/expat/lib/internal.h
+++ b/expat/lib/internal.h
@@ -161,8 +161,14 @@ unsigned long long testingAccountingGetCountBytesIndirect(XML_Parser parser);
 const char *unsignedCharToPrintable(unsigned char c);
 #endif
 
-extern XML_Bool g_reparseDeferralEnabledDefault; // written ONLY in runtests.c
-extern unsigned int g_bytesScanned;              // used for testing only
+extern
+#if ! defined(XML_TESTING)
+    const
+#endif
+    XML_Bool g_reparseDeferralEnabledDefault; // written ONLY in runtests.c
+#if defined(XML_TESTING)
+extern unsigned int g_bytesScanned; // used for testing only
+#endif
 
 #ifdef __cplusplus
 }

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -629,8 +629,14 @@ static unsigned long getDebugLevel(const char *variableName,
        ? 0                                                                     \
        : ((*((pool)->ptr)++ = c), 1))
 
-XML_Bool g_reparseDeferralEnabledDefault = XML_TRUE; // write ONLY in runtests.c
-unsigned int g_bytesScanned = 0;                     // used for testing only
+#if ! defined(XML_TESTING)
+const
+#endif
+    XML_Bool g_reparseDeferralEnabledDefault
+    = XML_TRUE; // write ONLY in runtests.c
+#if defined(XML_TESTING)
+unsigned int g_bytesScanned = 0; // used for testing only
+#endif
 
 struct XML_ParserStruct {
   /* The first member must be m_userData so that the XML_GetUserData
@@ -1017,7 +1023,9 @@ callProcessor(XML_Parser parser, const char *start, const char *end,
       return XML_ERROR_NONE;
     }
   }
+#if defined(XML_TESTING)
   g_bytesScanned += (unsigned)have_now;
+#endif
   const enum XML_Error ret = parser->m_processor(parser, start, end, endPtr);
   if (ret == XML_ERROR_NONE) {
     // if we consumed nothing, remember what we had on this parse attempt.

--- a/expat/tests/Makefile.am
+++ b/expat/tests/Makefile.am
@@ -32,7 +32,7 @@
 
 SUBDIRS = . benchmark
 
-AM_CPPFLAGS = @AM_CPPFLAGS@ -I$(srcdir)/../lib
+AM_CPPFLAGS = @AM_CPPFLAGS@ -I$(srcdir)/../lib -DXML_TESTING
 
 check_PROGRAMS = runtests runtests_cxx
 TESTS = runtests runtests_cxx

--- a/expat/tests/Makefile.am
+++ b/expat/tests/Makefile.am
@@ -72,8 +72,8 @@ runtests_cxx_SOURCES = \
     runtests_cxx.cpp \
     structdata_cxx.cpp
 
-runtests_LDADD = ../lib/libexpatinternal.la
-runtests_cxx_LDADD = ../lib/libexpatinternal.la
+runtests_LDADD = ../lib/libtestpat.la
+runtests_cxx_LDADD = ../lib/libtestpat.la
 
 runtests_LDFLAGS = @AM_LDFLAGS@ @LIBM@
 runtests_cxx_LDFLAGS = @AM_LDFLAGS@ @LIBM@


### PR DESCRIPTION
Alternative to #826