### PR TITLE
Expose billion laughs API with `XML_DTD` without `XML_GE` (fixes #828)

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -356,10 +356,7 @@ library and header would get installed in
 <h3>Configuring Expat Using the Pre-Processor</h3>
 
 <p>Expat's feature set can be configured using a small number of
-pre-processor definitions.  The definition of this symbols does not
-affect the set of entry points for Expat, only the behavior of the API
-and the definition of character types in the case of
-<code>XML_UNICODE_WCHAR_T</code>.  The symbols are:</p>
+pre-processor definitions.  The symbols are:</p>
 
 <dl class="cpp-symbols">
 <dt><a name="XML_GE">XML_GE</a></dt>

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -1042,7 +1042,7 @@ typedef struct {
 XMLPARSEAPI(const XML_Feature *)
 XML_GetFeatureList(void);
 
-#if defined(XML_GE) && XML_GE == 1
+#if defined(XML_DTD) || (defined(XML_GE) && XML_GE == 1)
 /* Added in Expat 2.4.0 for XML_DTD defined and
  * added in Expat 2.6.0 for XML_GE == 1. */
 XMLPARSEAPI(XML_Bool)


### PR DESCRIPTION
Fixes #828

Regression from 2.6.0 commit caa27198637683b15d810737bb8a6a81af19bfa5.