### PR TITLE
[2.6.1] Fix DOCBOOK_TO_MAN variable use in doc Makefile

### DIFF
--- a/expat/doc/Makefile.am
+++ b/expat/doc/Makefile.am
@@ -37,7 +37,7 @@ dist_man_MANS = xmlwf.1
 
 xmlwf.1: xmlwf.xml
 	-rm -f $@
-	test x$(DOCBOOK_TO_MAN) != x && $(DOCBOOK_TO_MAN) $<
+	test "x$(DOCBOOK_TO_MAN)" != x && $(DOCBOOK_TO_MAN) $<
 	test -f $@ || mv XMLWF.1 $@
 endif
 


### PR DESCRIPTION
Not using quotes causes problems when DOCBOOK_TO_MAN contains command and argument