### PR TITLE
Allow triggering GitHub Actions workflows manually

### DIFF
--- a/.github/workflows/autotools-cmake.yml
+++ b/.github/workflows/autotools-cmake.yml
@@ -35,6 +35,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/cmake-required-version.yml
+++ b/.github/workflows/cmake-required-version.yml
@@ -35,6 +35,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -35,6 +35,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,6 +35,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -35,6 +35,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/expat_config_h.yml
+++ b/.github/workflows/expat_config_h.yml
@@ -35,6 +35,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,6 +36,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,6 +35,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/valid-xml.yml
+++ b/.github/workflows/valid-xml.yml
@@ -35,6 +35,7 @@ on:
   push:
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Some already had `workflow_dispatch` enabled.