### PR TITLE
Always provide path to find(1) for portability

### DIFF
--- a/expat/Makefile.am
+++ b/expat/Makefile.am
@@ -114,7 +114,7 @@ buildlib:
 	@echo 'ERROR: is no longer supported.  INSTEAD please:' >&2
 	@echo 'ERROR:' >&2
 	@echo 'ERROR:  * Mass-patch Makefile.am, e.g.' >&2
-	@echo 'ERROR:    # find -name Makefile.am -exec sed \' >&2
+	@echo 'ERROR:    # find . -name Makefile.am -exec sed \' >&2
 	@echo 'ERROR:          -e "s,libexpat\.la,libexpatw.la," \' >&2
 	@echo 'ERROR:          -e "s,libexpat_la,libexpatw_la," \' >&2
 	@echo 'ERROR:          -i {} +' >&2

--- a/expat/README.md
+++ b/expat/README.md
@@ -158,7 +158,7 @@ support this mode of compilation (yet):
 
 1. Mass-patch `Makefile.am` files to use `libexpatw.la` for a library name:
    <br/>
-   `find -name Makefile.am -exec sed
+   `find . -name Makefile.am -exec sed
        -e 's,libexpat\.la,libexpatw.la,'
        -e 's,libexpat_la,libexpatw_la,'
        -i {} +`

--- a/expat/qa.sh
+++ b/expat/qa.sh
@@ -192,7 +192,7 @@ run_processor() {
         local DOT_FORMAT="${DOT_FORMAT:-svg}"
         local o="callgraph.${DOT_FORMAT}"
         ANNOUNCE "egypt ...... | dot ...... > ${o}"
-        find -name '*.expand' \
+        find . -name '*.expand' \
                 | sort \
                 | xargs -r egypt \
                 | unflatten -c 20 \
@@ -209,7 +209,7 @@ run_processor() {
         )
         done
 
-        RUN find -name '*.gcov' | sort
+        RUN find . -name '*.gcov' | sort
         ;;
     esac
 }


### PR DESCRIPTION
Running find without path is a GNU extension.  GNU find uses current directory as starting-point in this case.  Better always use an explicit . in build scripts to support find on other systems.