### PR TITLE
Fix `check_c_source_compiles` of `HAVE_SYSCALL_GETRANDOM`

### DIFF
--- a/expat/ConfigureChecks.cmake
+++ b/expat/ConfigureChecks.cmake
@@ -60,6 +60,7 @@ if(NOT HAVE_OFF_T)
 endif()
 
 check_c_source_compiles("
+        #define _GNU_SOURCE
         #include <stdlib.h>  /* for NULL */
         #include <unistd.h>  /* for syscall */
         #include <sys/syscall.h>  /* for SYS_getrandom */

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -274,6 +274,7 @@ AS_HELP_STRING([--without-sys-getrandom],
 AS_IF([test "x$with_sys_getrandom" != xno],
   [AC_MSG_CHECKING([for syscall SYS_getrandom (Linux 3.17+)])
    AC_LINK_IFELSE([AC_LANG_SOURCE([
+       #define _GNU_SOURCE
        #include <stdlib.h>  /* for NULL */
        #include <unistd.h>  /* for syscall */
        #include <sys/syscall.h>  /* for SYS_getrandom */


### PR DESCRIPTION
As the [manual](https://linux.die.net/man/2/syscall) states, if you want to make a syscall then you need `#define _GNU_SOURCE`

Without that the `check_c_source_compiles` fails on a Fedora 40 system with
````
src.c:6:13: error: implicit declaration of function ‘syscall’ [-Wimplicit-function-declaration]
    6 |             syscall(SYS_getrandom, NULL, 0, 0);
      |             ^~~~~~~
````
when this check should pass, as `SYS_getrandom` is available, only the declaration of `syscall` is behind a chain of defines `_GNU_SOURCE` -> `_DEFAULT_SOURCE` -> `__USE_MISC`