### PR TITLE
`coverage.yml`: Fix for image `ubuntu-22.04` of `20240514.2.0`

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,11 +66,9 @@ jobs:
             lcov \
             libbsd-dev \
             lzip \
-            moreutils \
-            ppa-purge
+            moreutils
 
         # Install 32bit Wine
-        sudo ppa-purge -y ppa:ubuntu-toolchain-r/test  # to unblock
         sudo apt-get install --yes --no-install-recommends -V \
             mingw-w64 \
             wine-stable \


### PR DESCRIPTION
Was broken by https://github.com/actions/runner-images/issues/9679 .