### PR TITLE
Remove `XML_DTD` guards before `is_param` accesses

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -5846,18 +5846,17 @@ processInternalEntity(XML_Parser parser, ENTITY *entity, XML_Bool betweenDecl) {
   /* Set a safe default value in case 'next' does not get set */
   next = textStart;
 
-#ifdef XML_DTD
   if (entity->is_param) {
     int tok
         = XmlPrologTok(parser->m_internalEncoding, textStart, textEnd, &next);
     result = doProlog(parser, parser->m_internalEncoding, textStart, textEnd,
                       tok, next, &next, XML_FALSE, XML_FALSE,
                       XML_ACCOUNT_ENTITY_EXPANSION);
-  } else
-#endif /* XML_DTD */
+  } else {
     result = doContent(parser, parser->m_tagLevel, parser->m_internalEncoding,
                        textStart, textEnd, &next, XML_FALSE,
                        XML_ACCOUNT_ENTITY_EXPANSION);
+  }
 
   if (result == XML_ERROR_NONE) {
     if (textEnd != next && parser->m_parsingStatus.parsing == XML_SUSPENDED) {
@@ -5894,18 +5893,17 @@ internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
   /* Set a safe default value in case 'next' does not get set */
   next = textStart;
 
-#ifdef XML_DTD
   if (entity->is_param) {
     int tok
         = XmlPrologTok(parser->m_internalEncoding, textStart, textEnd, &next);
     result = doProlog(parser, parser->m_internalEncoding, textStart, textEnd,
                       tok, next, &next, XML_FALSE, XML_TRUE,
                       XML_ACCOUNT_ENTITY_EXPANSION);
-  } else
-#endif /* XML_DTD */
+  } else {
     result = doContent(parser, openEntity->startTagLevel,
                        parser->m_internalEncoding, textStart, textEnd, &next,
                        XML_FALSE, XML_ACCOUNT_ENTITY_EXPANSION);
+  }
 
   if (result != XML_ERROR_NONE)
     return result;
@@ -5932,7 +5930,6 @@ internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
     return XML_ERROR_NONE;
   }
 
-#ifdef XML_DTD
   if (entity->is_param) {
     int tok;
     parser->m_processor = prologProcessor;
@@ -5940,9 +5937,7 @@ internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
     return doProlog(parser, parser->m_encoding, s, end, tok, next, nextPtr,
                     (XML_Bool)! parser->m_parsingStatus.finalBuffer, XML_TRUE,
                     XML_ACCOUNT_DIRECT);
-  } else
-#endif /* XML_DTD */
-  {
+  } else {
     parser->m_processor = contentProcessor;
     /* see externalEntityContentProcessor vs contentProcessor */
     result = doContent(parser, parser->m_parentParser ? 1 : 0,


### PR DESCRIPTION
As a part of the `ENTITY` struct, `is_param` is correctly initialized even when `XML_DTD` is not defined. This can be seen in the `lookup` function, which sets all the `ENTITY` memory, including the `is_param` flag, to zero during the `ENTITY` creation. Additionally, `is_param` can only be assigned `XML_TRUE` when `XML_DTD` is defined, which makes `XML_DTD` checks before `is_param` accesses not necessary.

Currently, some of the `is_param` accesses are guarded by the `XML_DTD` and some not. This commit removes all `XML_DTD` guards that are meant for `is_param` accesses.