### PR TITLE
`.gitignore`: Add missing example `element_declarations`

### DIFF
--- a/expat/examples/.gitignore
+++ b/expat/examples/.gitignore
@@ -1,4 +1,6 @@
 Makefile
+element_declarations
+element_declarations.plg
 elements
 elements.plg
 outline


### PR DESCRIPTION
Follow-up to #673