### PR TITLE
Add alias expat::expat

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -425,6 +425,7 @@ else()
 endif()
 
 add_library(expat ${_SHARED} ${_EXPAT_C_SOURCES} ${_EXPAT_EXTRA_SOURCES})
+add_library(expat::expat ALIAS expat)
 if(_EXPAT_LIBM_FOUND)
     target_link_libraries(expat m)
 endif()


### PR DESCRIPTION
As the find module and the config create the expat::expat alias for expat, the build-process should do this also to make it easier to include this in a chainbuild