### PR TITLE
doc: Add missing documentation of error `XML_ERROR_NOT_STARTED` (follow-up to #915)

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -1267,6 +1267,11 @@ call-backs, except when parsing an external parameter entity and
 <code>XML_STATUS_ERROR</code> otherwise.  The possible error codes
 are:</p>
 <dl>
+  <dt><code>XML_ERROR_NOT_STARTED</code></dt>
+  <dd>
+    when stopping or suspending a parser before it has started,
+    added in Expat 2.6.4.
+  </dd>
   <dt><code>XML_ERROR_SUSPENDED</code></dt>
   <dd>when suspending an already suspended parser.</dd>
   <dt><code>XML_ERROR_FINISHED</code></dt>


### PR DESCRIPTION
Follow-up to #915