### PR TITLE
replaced int by size_t where appropriate in libexpat API

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -1119,7 +1119,7 @@ with <code>isFinal</code> set to <code>XML_TRUE</code>.</p>
 enum XML_Status XMLCALL
 XML_Parse(XML_Parser p,
           const char *s,
-          int len,
+          size_t len,
           int isFinal);
 </pre>
 <pre class="signature">
@@ -1181,7 +1181,7 @@ then parse with <code><a href="#XML_ParseBuffer">XML_ParseBuffer</a></code>.
 <pre class="fcndec">
 enum XML_Status XMLCALL
 XML_ParseBuffer(XML_Parser p,
-                int len,
+                size_t len,
                 int isFinal);
 </pre>
 <div class="fcndef">
@@ -1202,7 +1202,7 @@ Negative values for <code>len</code> are rejected since Expat 2.6.3.
 <pre class="fcndec">
 void * XMLCALL
 XML_GetBuffer(XML_Parser p,
-              int len);
+              size_t len);
 </pre>
 <div class="fcndef">
 Obtain a buffer of size <code>len</code> to read a piece of the document
@@ -1214,7 +1214,7 @@ typical use would look like this:
 
 <pre class="eg">
 for (;;) {
-  int bytes_read;
+  ssize_t bytes_read;
   void *buff = XML_GetBuffer(p, BUFF_SIZE);
   if (buff == NULL) {
     /* handle error */

--- a/expat/examples/element_declarations.c
+++ b/expat/examples/element_declarations.c
@@ -217,7 +217,7 @@ main(void) {
 
     done = feof(stdin);
 
-    if (XML_ParseBuffer(parser, (int)len, done) == XML_STATUS_ERROR) {
+    if (XML_ParseBuffer(parser, len, done) == XML_STATUS_ERROR) {
       enum XML_Error errorCode = XML_GetErrorCode(parser);
       if (errorCode == XML_ERROR_ABORTED) {
         errorCode = XML_ERROR_NO_MEMORY;

--- a/expat/examples/elements.c
+++ b/expat/examples/elements.c
@@ -106,7 +106,7 @@ main(void) {
 
     done = feof(stdin);
 
-    if (XML_ParseBuffer(parser, (int)len, done) == XML_STATUS_ERROR) {
+    if (XML_ParseBuffer(parser, len, done) == XML_STATUS_ERROR) {
       fprintf(stderr,
               "Parse error at line %" XML_FMT_INT_MOD "u:\n%" XML_FMT_STR "\n",
               XML_GetCurrentLineNumber(parser),

--- a/expat/examples/outline.c
+++ b/expat/examples/outline.c
@@ -109,7 +109,7 @@ main(void) {
 
     done = feof(stdin);
 
-    if (XML_ParseBuffer(parser, (int)len, done) == XML_STATUS_ERROR) {
+    if (XML_ParseBuffer(parser, len, done) == XML_STATUS_ERROR) {
       fprintf(stderr,
               "Parse error at line %" XML_FMT_INT_MOD "u:\n%" XML_FMT_STR "\n",
               XML_GetCurrentLineNumber(parser),

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -785,13 +785,13 @@ XML_GetAttributeInfo(XML_Parser parser);
    values.
 */
 XMLPARSEAPI(enum XML_Status)
-XML_Parse(XML_Parser parser, const char *s, int len, int isFinal);
+XML_Parse(XML_Parser parser, const char *s, size_t len, int isFinal);
 
 XMLPARSEAPI(void *)
-XML_GetBuffer(XML_Parser parser, int len);
+XML_GetBuffer(XML_Parser parser, size_t len);
 
 XMLPARSEAPI(enum XML_Status)
-XML_ParseBuffer(XML_Parser parser, int len, int isFinal);
+XML_ParseBuffer(XML_Parser parser, size_t len, int isFinal);
 
 /* Stops parsing, causing XML_Parse() or XML_ParseBuffer() to return.
    Must be called from within a call-back handler, except when aborting

--- a/expat/lib/expat_external.h
+++ b/expat/lib/expat_external.h
@@ -154,8 +154,9 @@ typedef char XML_LChar;
 typedef long long XML_Index;
 typedef unsigned long long XML_Size;
 #else
-typedef long XML_Index;
-typedef unsigned long XML_Size;
+#include <stddef.h>
+typedef ptrdiff_t XML_Index;
+typedef size_t XML_Size;
 #endif /* XML_LARGE_SIZE */
 
 #ifdef __cplusplus

--- a/expat/tests/acc_tests.c
+++ b/expat/tests/acc_tests.c
@@ -259,7 +259,7 @@ START_TEST(test_accounting_precision) {
 
     enum XML_Status status
         = _XML_Parse_SINGLE_BYTES(parser, cases[u].primaryText,
-                                  (int)strlen(cases[u].primaryText), XML_TRUE);
+                                  strlen(cases[u].primaryText), XML_TRUE);
     if (status != XML_STATUS_OK) {
       _xml_failure(parser, __FILE__, __LINE__);
     }

--- a/expat/tests/alloc_tests.c
+++ b/expat/tests/alloc_tests.c
@@ -82,7 +82,7 @@ START_TEST(test_alloc_parse_xdecl) {
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
     XML_SetXmlDeclHandler(g_parser, dummy_xdecl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* Resetting the parser is insufficient, because some memory
@@ -132,7 +132,7 @@ START_TEST(test_alloc_parse_xdecl_2) {
     g_allocation_count = i;
     XML_SetXmlDeclHandler(g_parser, dummy_xdecl_handler);
     XML_SetUnknownEncodingHandler(g_parser, long_encoding_handler, NULL);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -159,7 +159,7 @@ START_TEST(test_alloc_parse_pi) {
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
     XML_SetProcessingInstructionHandler(g_parser, dummy_pi_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -185,7 +185,7 @@ START_TEST(test_alloc_parse_pi_2) {
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
     XML_SetProcessingInstructionHandler(g_parser, dummy_pi_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -226,7 +226,7 @@ START_TEST(test_alloc_parse_pi_3) {
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
     XML_SetProcessingInstructionHandler(g_parser, dummy_pi_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -250,7 +250,7 @@ START_TEST(test_alloc_parse_comment) {
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
     XML_SetCommentHandler(g_parser, dummy_comment_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -276,7 +276,7 @@ START_TEST(test_alloc_parse_comment_2) {
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
     XML_SetCommentHandler(g_parser, dummy_comment_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -302,7 +302,7 @@ START_TEST(test_alloc_create_external_parser) {
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetUserData(g_parser, foo_text);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_duff_loader);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR) {
     fail("External parser allocator returned success incorrectly");
   }
@@ -323,7 +323,7 @@ START_TEST(test_alloc_run_external_parser) {
     XML_SetUserData(g_parser, foo_text);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_null_loader);
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -353,7 +353,7 @@ START_TEST(test_alloc_dtd_copy_default_atts) {
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_dbl_handler);
   XML_SetUserData(g_parser, &callno);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -379,7 +379,7 @@ START_TEST(test_alloc_external_entity) {
     callno = 0;
     XML_SetUserData(g_parser, &callno);
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         == XML_STATUS_OK)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -407,7 +407,7 @@ START_TEST(test_alloc_ext_entity_set_encoding) {
     XML_SetExternalEntityRefHandler(g_parser,
                                     external_entity_alloc_set_encoding);
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         == XML_STATUS_OK)
       break;
     g_allocation_count = -1;
@@ -436,7 +436,7 @@ START_TEST(test_alloc_internal_entity) {
     g_allocation_count = i;
     XML_SetUnknownEncodingHandler(g_parser, unknown_released_encoding_handler,
                                   NULL);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -488,7 +488,7 @@ START_TEST(test_alloc_dtd_default_handling) {
     CharData_Init(&storage);
     XML_SetUserData(g_parser, &storage);
     XML_SetCharacterDataHandler(g_parser, accumulate_characters);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -561,7 +561,7 @@ START_TEST(test_alloc_realloc_buffer) {
       fail("1.5K buffer reallocation failed");
     assert(buffer != NULL);
     memcpy(buffer, text, strlen(text));
-    if (XML_ParseBuffer(g_parser, (int)strlen(text), XML_FALSE)
+    if (XML_ParseBuffer(g_parser, strlen(text), XML_FALSE)
         == XML_STATUS_OK)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -588,7 +588,7 @@ START_TEST(test_alloc_ext_entity_realloc_buffer) {
   for (i = 0; i < max_realloc_count; i++) {
     XML_SetExternalEntityRefHandler(g_parser, external_entity_reallocator);
     XML_SetUserData(g_parser, &i);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         == XML_STATUS_OK)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -633,7 +633,7 @@ START_TEST(test_alloc_realloc_many_attributes) {
 
   for (i = 0; i < max_realloc_count; i++) {
     g_reallocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -685,7 +685,7 @@ START_TEST(test_alloc_public_entity_value) {
     XML_SetExternalEntityRefHandler(g_parser, external_entity_public);
     /* Provoke a particular code path */
     XML_SetEntityDeclHandler(g_parser, dummy_entity_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -749,7 +749,7 @@ START_TEST(test_alloc_realloc_subst_public_entity_value) {
     XML_SetUserData(g_parser, dtd_text);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_public);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -794,7 +794,7 @@ START_TEST(test_alloc_parse_public_doctype) {
     init_dummy_handlers();
     XML_SetDoctypeDeclHandler(g_parser, dummy_start_doctype_decl_handler,
                               dummy_end_doctype_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -842,7 +842,7 @@ START_TEST(test_alloc_parse_public_doctype_long_name) {
     g_allocation_count = i;
     XML_SetDoctypeDeclHandler(g_parser, dummy_start_doctype_decl_handler,
                               dummy_end_doctype_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -871,7 +871,7 @@ START_TEST(test_alloc_set_foreign_dtd) {
     XML_SetExternalEntityRefHandler(g_parser, external_entity_alloc);
     if (XML_UseForeignDTD(g_parser, XML_TRUE) != XML_ERROR_NONE)
       fail("Could not set foreign DTD");
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text1, (int)strlen(text1), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text1, strlen(text1), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -903,7 +903,7 @@ START_TEST(test_alloc_attribute_enum_value) {
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     /* An attribute list handler provokes a different code path */
     XML_SetAttlistDeclHandler(g_parser, dummy_attlist_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -959,7 +959,7 @@ START_TEST(test_alloc_realloc_attribute_enum_value) {
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     /* An attribute list handler provokes a different code path */
     XML_SetAttlistDeclHandler(g_parser, dummy_attlist_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1009,7 +1009,7 @@ START_TEST(test_alloc_realloc_implied_attribute) {
   for (i = 0; i < max_realloc_count; i++) {
     g_reallocation_count = i;
     XML_SetAttlistDeclHandler(g_parser, dummy_attlist_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1059,7 +1059,7 @@ START_TEST(test_alloc_realloc_default_attribute) {
   for (i = 0; i < max_realloc_count; i++) {
     g_reallocation_count = i;
     XML_SetAttlistDeclHandler(g_parser, dummy_attlist_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1124,7 +1124,7 @@ START_TEST(test_alloc_notation) {
     init_dummy_handlers();
     XML_SetNotationDeclHandler(g_parser, dummy_notation_decl_handler);
     XML_SetEntityDeclHandler(g_parser, dummy_entity_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1174,7 +1174,7 @@ START_TEST(test_alloc_public_notation) {
     g_allocation_count = i;
     init_dummy_handlers();
     XML_SetNotationDeclHandler(g_parser, dummy_notation_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1223,7 +1223,7 @@ START_TEST(test_alloc_system_notation) {
     g_allocation_count = i;
     init_dummy_handlers();
     XML_SetNotationDeclHandler(g_parser, dummy_notation_decl_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1261,7 +1261,7 @@ START_TEST(test_alloc_nested_groups) {
     XML_SetStartElementHandler(g_parser, record_element_start_handler);
     XML_SetUserData(g_parser, &storage);
     init_dummy_handlers();
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1301,7 +1301,7 @@ START_TEST(test_alloc_realloc_nested_groups) {
     XML_SetStartElementHandler(g_parser, record_element_start_handler);
     XML_SetUserData(g_parser, &storage);
     init_dummy_handlers();
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1339,7 +1339,7 @@ START_TEST(test_alloc_large_group) {
     g_allocation_count = i;
     XML_SetElementDeclHandler(g_parser, dummy_element_decl_handler);
     init_dummy_handlers();
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1377,7 +1377,7 @@ START_TEST(test_alloc_realloc_group_choice) {
     g_reallocation_count = i;
     XML_SetElementDeclHandler(g_parser, dummy_element_decl_handler);
     init_dummy_handlers();
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1403,7 +1403,7 @@ START_TEST(test_alloc_pi_in_epilog) {
     g_allocation_count = i;
     XML_SetProcessingInstructionHandler(g_parser, dummy_pi_handler);
     init_dummy_handlers();
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1429,7 +1429,7 @@ START_TEST(test_alloc_comment_in_epilog) {
     g_allocation_count = i;
     XML_SetCommentHandler(g_parser, dummy_comment_handler);
     init_dummy_handlers();
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1472,7 +1472,7 @@ START_TEST(test_alloc_realloc_long_attribute_value) {
 
   for (i = 0; i < max_realloc_count; i++) {
     g_reallocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1493,7 +1493,7 @@ START_TEST(test_alloc_attribute_whitespace) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1514,7 +1514,7 @@ START_TEST(test_alloc_attribute_predefined_entity) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1559,7 +1559,7 @@ START_TEST(test_alloc_long_attr_default_with_char_ref) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1603,7 +1603,7 @@ START_TEST(test_alloc_long_attr_value) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1691,7 +1691,7 @@ START_TEST(test_alloc_realloc_param_entity_newline) {
     XML_SetUserData(g_parser, dtd_text);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_alloc);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1737,7 +1737,7 @@ START_TEST(test_alloc_realloc_ce_extends_pe) {
     XML_SetUserData(g_parser, dtd_text);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_alloc);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1771,7 +1771,7 @@ START_TEST(test_alloc_realloc_attributes) {
 
   for (i = 0; i < max_realloc_count; i++) {
     g_reallocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1811,7 +1811,7 @@ START_TEST(test_alloc_long_doc_name) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1863,7 +1863,7 @@ START_TEST(test_alloc_long_base) {
       XML_ParserReset(g_parser, NULL);
       continue;
     }
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1910,7 +1910,7 @@ START_TEST(test_alloc_long_public_id) {
     XML_SetUserData(g_parser, entity_text);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_alloc);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -1958,7 +1958,7 @@ START_TEST(test_alloc_long_entity_value) {
     XML_SetUserData(g_parser, entity_text);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_alloc);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_alloc_parse_xdecl() */
@@ -2026,7 +2026,7 @@ START_TEST(test_alloc_long_notation) {
     XML_SetUserData(g_parser, options);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_optioner);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
 
@@ -2048,7 +2048,7 @@ START_TEST(test_alloc_reset_after_external_entity_parser_create_fail) {
       g_parser, external_entity_parser_create_alloc_fail_handler);
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Call to parse was expected to fail");
 

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -136,7 +136,7 @@ START_TEST(test_bom_utf8) {
   /* This test is really just making sure we don't core on a UTF-8 BOM. */
   const char *text = "\357\273\277<e/>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -196,7 +196,7 @@ START_TEST(test_hash_collision) {
         "</doc>\n";
 
   XML_SetHashSalt(g_parser, COLLIDING_HASH_SALT);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -297,7 +297,7 @@ START_TEST(test_illegal_utf8) {
 
   for (i = 128; i <= 255; ++i) {
     snprintf(text, sizeof(text), "<e>%ccd</e>", i);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         == XML_STATUS_OK) {
       snprintf(text, sizeof(text),
                "expected token error for '%c' (ordinal %d) in UTF-8 text", i,
@@ -603,7 +603,7 @@ START_TEST(test_line_number_after_parse) {
                      "\n</tag>";
   XML_Size lineno;
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   lineno = XML_GetCurrentLineNumber(g_parser);
@@ -621,7 +621,7 @@ START_TEST(test_column_number_after_parse) {
   const char *text = "<tag></tag>";
   XML_Size colno;
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   colno = XML_GetCurrentColumnNumber(g_parser);
@@ -657,7 +657,7 @@ START_TEST(test_line_and_column_numbers_inside_handlers) {
   XML_SetUserData(g_parser, &storage);
   XML_SetStartElementHandler(g_parser, start_element_event_handler2);
   XML_SetEndElementHandler(g_parser, end_element_event_handler2);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 
@@ -672,7 +672,7 @@ START_TEST(test_line_number_after_error) {
                      "  <b>\n"
                      "  </a>"; /* missing </b> */
   XML_Size lineno;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Expected a parse error");
 
@@ -692,7 +692,7 @@ START_TEST(test_column_number_after_error) {
                      "  <b>\n"
                      "  </a>"; /* missing </b> */
   XML_Size colno;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Expected a parse error");
 
@@ -735,7 +735,7 @@ START_TEST(test_really_long_lines) {
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+"
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+"
         "</e>";
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -771,7 +771,7 @@ START_TEST(test_really_long_encoded_lines) {
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+"
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+"
         "</e>";
-  int parse_len = (int)strlen(text);
+  size_t parse_len = strlen(text);
 
   /* Need a cdata handler to provoke the code path we want to test */
   XML_SetCharacterDataHandler(g_parser, dummy_cdata_handler);
@@ -797,7 +797,7 @@ START_TEST(test_end_element_events) {
   CharData_Init(&storage);
   XML_SetUserData(g_parser, &storage);
   XML_SetEndElementHandler(g_parser, end_element_event_handler);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -908,7 +908,7 @@ START_TEST(test_attr_whitespace_normalization) {
 
   XML_SetStartElementHandler(g_parser,
                              check_attr_contains_normalized_whitespace);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -954,7 +954,7 @@ START_TEST(test_unknown_encoding_internal_entity) {
                      "<test a='&foo;'/>";
 
   XML_SetUnknownEncodingHandler(g_parser, UnknownEncodingHandler, NULL);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -967,7 +967,7 @@ START_TEST(test_unrecognised_encoding_internal_entity) {
                      "<test a='&foo;'/>";
 
   XML_SetUnknownEncodingHandler(g_parser, UnrecognisedEncodingHandler, NULL);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Unrecognised encoding not rejected");
 }
@@ -1069,7 +1069,7 @@ START_TEST(test_wfc_undeclared_entity_unread_external_subset) {
   const char *text = "<!DOCTYPE doc SYSTEM 'foo'>\n"
                      "<doc>&entity;</doc>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -1231,7 +1231,7 @@ START_TEST(test_recursive_external_parameter_entity_2) {
     assert_true(ext_parser != NULL);
 
     const enum XML_Status actualStatus
-        = _XML_Parse_SINGLE_BYTES(ext_parser, doc, (int)strlen(doc), XML_TRUE);
+        = _XML_Parse_SINGLE_BYTES(ext_parser, doc, strlen(doc), XML_TRUE);
 
     assert_true(actualStatus == expectedStatus);
     if (actualStatus != XML_STATUS_OK) {
@@ -1336,12 +1336,12 @@ START_TEST(test_dtd_attr_handling) {
     set_subtest("%s", test->definition);
     XML_SetAttlistDeclHandler(g_parser, verify_attlist_decl_handler);
     XML_SetUserData(g_parser, test);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, prolog, (int)strlen(prolog),
+    if (_XML_Parse_SINGLE_BYTES(g_parser, prolog, strlen(prolog),
                                 XML_FALSE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
     if (_XML_Parse_SINGLE_BYTES(g_parser, test->definition,
-                                (int)strlen(test->definition), XML_TRUE)
+                                strlen(test->definition), XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
     XML_ParserReset(g_parser, NULL);
@@ -1360,7 +1360,7 @@ START_TEST(test_empty_ns_without_namespaces) {
                      "  <e xmlns:prefix=''/>\n"
                      "</doc>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -1377,7 +1377,7 @@ START_TEST(test_ns_in_attribute_default_without_namespaces) {
                      "      ]>\n"
                      "<e:element/>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -1396,7 +1396,7 @@ START_TEST(test_stop_parser_between_char_data_calls) {
 
   XML_SetCharacterDataHandler(g_parser, clearing_aborting_character_handler);
   g_resumable = XML_FALSE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (XML_GetErrorCode(g_parser) != XML_ERROR_ABORTED)
@@ -1417,13 +1417,13 @@ START_TEST(test_suspend_parser_between_char_data_calls) {
 
   XML_SetCharacterDataHandler(g_parser, clearing_aborting_character_handler);
   g_resumable = XML_TRUE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)
     xml_failure(g_parser);
   if (XML_GetErrorCode(g_parser) != XML_ERROR_NONE)
     xml_failure(g_parser);
   /* Try parsing directly */
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Attempt to continue parse while suspended not faulted");
   if (XML_GetErrorCode(g_parser) != XML_ERROR_SUSPENDED)
@@ -1438,7 +1438,7 @@ START_TEST(test_repeated_stop_parser_between_char_data_calls) {
   XML_SetCharacterDataHandler(g_parser, parser_stop_character_handler);
   g_resumable = XML_FALSE;
   g_abortable = XML_FALSE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Failed to double-stop parser");
 
@@ -1446,7 +1446,7 @@ START_TEST(test_repeated_stop_parser_between_char_data_calls) {
   XML_SetCharacterDataHandler(g_parser, parser_stop_character_handler);
   g_resumable = XML_TRUE;
   g_abortable = XML_FALSE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)
     fail("Failed to double-suspend parser");
 
@@ -1454,7 +1454,7 @@ START_TEST(test_repeated_stop_parser_between_char_data_calls) {
   XML_SetCharacterDataHandler(g_parser, parser_stop_character_handler);
   g_resumable = XML_TRUE;
   g_abortable = XML_TRUE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Failed to suspend-abort parser");
 }
@@ -1472,7 +1472,7 @@ START_TEST(test_good_cdata_ascii) {
   XML_SetStartCdataSectionHandler(g_parser, dummy_start_cdata_handler);
   XML_SetEndCdataSectionHandler(g_parser, dummy_end_cdata_handler);
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -1484,7 +1484,7 @@ START_TEST(test_good_cdata_ascii) {
   XML_SetCharacterDataHandler(g_parser, accumulate_characters);
   XML_SetDefaultHandler(g_parser, dummy_default_handler);
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -1724,7 +1724,7 @@ START_TEST(test_bad_cdata) {
   for (; i < sizeof(cases) / sizeof(struct CaseData); i++) {
     set_subtest("%s", cases[i].text);
     const enum XML_Status actualStatus = _XML_Parse_SINGLE_BYTES(
-        g_parser, cases[i].text, (int)strlen(cases[i].text), XML_TRUE);
+        g_parser, cases[i].text, strlen(cases[i].text), XML_TRUE);
     const enum XML_Error actualError = XML_GetErrorCode(g_parser);
 
     assert(actualStatus == XML_STATUS_ERROR);
@@ -1835,7 +1835,7 @@ START_TEST(test_suspend_parser_between_cdata_calls) {
 
   XML_SetCharacterDataHandler(g_parser, clearing_aborting_character_handler);
   g_resumable = XML_TRUE;
-  result = _XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE);
+  result = _XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE);
   if (result != XML_STATUS_SUSPENDED) {
     if (result == XML_STATUS_ERROR)
       xml_failure(g_parser);
@@ -1895,7 +1895,7 @@ START_TEST(test_default_current) {
     XML_SetDefaultHandler(g_parser, record_default_handler);
     XML_SetCharacterDataHandler(g_parser, record_cdata_handler);
     XML_SetUserData(g_parser, &storage);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
     int i = 0;
@@ -1926,7 +1926,7 @@ START_TEST(test_default_current) {
     XML_SetDefaultHandler(g_parser, record_default_handler);
     XML_SetCharacterDataHandler(g_parser, record_cdata_nodefault_handler);
     XML_SetUserData(g_parser, &storage);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
     int i = 0;
@@ -1954,7 +1954,7 @@ START_TEST(test_default_current) {
     XML_SetDefaultHandler(g_parser, record_default_handler);
     XML_SetCharacterDataHandler(g_parser, record_cdata_handler);
     XML_SetUserData(g_parser, &storage);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, entity_text, (int)strlen(entity_text),
+    if (_XML_Parse_SINGLE_BYTES(g_parser, entity_text, strlen(entity_text),
                                 XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
@@ -1991,7 +1991,7 @@ START_TEST(test_default_current) {
     XML_SetCharacterDataHandler(g_parser, record_cdata_handler);
     XML_SetSkippedEntityHandler(g_parser, record_skip_handler);
     XML_SetUserData(g_parser, &storage);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, entity_text, (int)strlen(entity_text),
+    if (_XML_Parse_SINGLE_BYTES(g_parser, entity_text, strlen(entity_text),
                                 XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
@@ -2027,7 +2027,7 @@ START_TEST(test_default_current) {
     XML_SetDefaultHandlerExpand(g_parser, record_default_handler);
     XML_SetCharacterDataHandler(g_parser, record_cdata_handler);
     XML_SetUserData(g_parser, &storage);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, entity_text, (int)strlen(entity_text),
+    if (_XML_Parse_SINGLE_BYTES(g_parser, entity_text, strlen(entity_text),
                                 XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
@@ -2063,7 +2063,7 @@ START_TEST(test_default_current) {
     XML_SetDefaultHandlerExpand(g_parser, record_default_handler);
     XML_SetCharacterDataHandler(g_parser, record_cdata_nodefault_handler);
     XML_SetUserData(g_parser, &storage);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, entity_text, (int)strlen(entity_text),
+    if (_XML_Parse_SINGLE_BYTES(g_parser, entity_text, strlen(entity_text),
                                 XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
@@ -2101,7 +2101,7 @@ START_TEST(test_dtd_elements) {
                      "<doc><chapter>Wombats are go</chapter></doc>";
 
   XML_SetElementDeclHandler(g_parser, dummy_element_decl_handler);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2177,7 +2177,7 @@ START_TEST(test_dtd_elements_nesting) {
   XML_SetUserData(g_parser, (void *)(uintptr_t)-1);
 
   XML_SetElementDeclHandler(g_parser, element_decl_check_model);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 
@@ -2201,7 +2201,7 @@ START_TEST(test_set_foreign_dtd) {
   XML_SetDefaultHandler(g_parser, dummy_default_handler);
   if (XML_UseForeignDTD(g_parser, XML_TRUE) != XML_ERROR_NONE)
     fail("Could not set foreign DTD");
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text1, (int)strlen(text1), XML_FALSE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text1, strlen(text1), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 
@@ -2216,7 +2216,7 @@ START_TEST(test_set_foreign_dtd) {
     fail("Failed to reject late hash salt change");
 
   /* Now finish the parse */
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, (int)strlen(text2), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, strlen(text2), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2271,7 +2271,7 @@ START_TEST(test_foreign_dtd_with_doctype) {
   XML_SetDefaultHandler(g_parser, dummy_default_handler);
   if (XML_UseForeignDTD(g_parser, XML_TRUE) != XML_ERROR_NONE)
     fail("Could not set foreign DTD");
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text1, (int)strlen(text1), XML_FALSE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text1, strlen(text1), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 
@@ -2286,7 +2286,7 @@ START_TEST(test_foreign_dtd_with_doctype) {
     fail("Failed to reject late hash salt change");
 
   /* Now finish the parse */
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, (int)strlen(text2), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, strlen(text2), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2301,7 +2301,7 @@ START_TEST(test_foreign_dtd_without_external_subset) {
   XML_SetUserData(g_parser, NULL);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_null_loader);
   XML_UseForeignDTD(g_parser, XML_TRUE);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2366,7 +2366,7 @@ START_TEST(test_attributes) {
 
   XML_SetStartElementHandler(parser, counting_start_element_handler);
   XML_SetUserData(parser, &parserAndElementInfos);
-  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(parser);
 
@@ -2387,7 +2387,7 @@ START_TEST(test_reset_in_entity) {
 
   g_resumable = XML_TRUE;
   XML_SetCharacterDataHandler(g_parser, clearing_aborting_character_handler);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   XML_GetParsingStatus(g_parser, &status);
@@ -2406,7 +2406,7 @@ START_TEST(test_resume_invalid_parse) {
 
   g_resumable = XML_TRUE;
   XML_SetCharacterDataHandler(g_parser, clearing_aborting_character_handler);
-  if (XML_Parse(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (XML_Parse(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (XML_ResumeParser(g_parser) == XML_STATUS_OK)
@@ -2422,7 +2422,7 @@ START_TEST(test_resume_resuspended) {
 
   g_resumable = XML_TRUE;
   XML_SetCharacterDataHandler(g_parser, clearing_aborting_character_handler);
-  if (XML_Parse(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (XML_Parse(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   g_resumable = XML_TRUE;
@@ -2445,7 +2445,7 @@ START_TEST(test_cdata_default) {
   XML_SetUserData(g_parser, &storage);
   XML_SetDefaultHandler(g_parser, accumulate_characters);
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -2460,7 +2460,7 @@ START_TEST(test_subordinate_reset) {
 
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_resetter);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2474,7 +2474,7 @@ START_TEST(test_subordinate_suspend) {
 
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_suspender);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2493,7 +2493,7 @@ START_TEST(test_subordinate_xdecl_suspend) {
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_suspend_xmldecl);
   g_resumable = XML_TRUE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2509,7 +2509,7 @@ START_TEST(test_subordinate_xdecl_abort) {
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_suspend_xmldecl);
   g_resumable = XML_FALSE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2555,13 +2555,13 @@ START_TEST(test_explicit_encoding) {
   /* Say we are UTF-8 */
   if (XML_SetEncoding(g_parser, XCS("utf-8")) != XML_STATUS_OK)
     fail("Failed to set explicit encoding");
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text1, (int)strlen(text1), XML_FALSE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text1, strlen(text1), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   /* Try to switch encodings mid-parse */
   if (XML_SetEncoding(g_parser, XCS("us-ascii")) != XML_STATUS_ERROR)
     fail("Allowed encoding change");
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, (int)strlen(text2), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, strlen(text2), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   /* Try now the parse is over */
@@ -2579,7 +2579,7 @@ START_TEST(test_trailing_cr) {
   XML_SetCharacterDataHandler(g_parser, cr_cdata_handler);
   XML_SetUserData(g_parser, &found_cr);
   found_cr = 0;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_OK)
     fail("Failed to fault unclosed doc");
   if (found_cr == 0)
@@ -2590,7 +2590,7 @@ START_TEST(test_trailing_cr) {
   XML_SetDefaultHandler(g_parser, cr_cdata_handler);
   XML_SetUserData(g_parser, &found_cr);
   found_cr = 0;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_OK)
     fail("Failed to fault unclosed doc");
   if (found_cr == 0)
@@ -2610,7 +2610,7 @@ START_TEST(test_ext_entity_trailing_cr) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_cr_catcher);
   XML_SetUserData(g_parser, &found_cr);
   found_cr = 0;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_OK)
     xml_failure(g_parser);
   if (found_cr == 0)
@@ -2622,7 +2622,7 @@ START_TEST(test_ext_entity_trailing_cr) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_bad_cr_catcher);
   XML_SetUserData(g_parser, &found_cr);
   found_cr = 0;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_OK)
     xml_failure(g_parser);
   if (found_cr == 0)
@@ -2635,12 +2635,11 @@ START_TEST(test_trailing_rsqb) {
   const char *text8 = "<doc>]";
   const char text16[] = "\xFF\xFE<\000d\000o\000c\000>\000]\000";
   int found_rsqb;
-  int text8_len = (int)strlen(text8);
 
   XML_SetCharacterDataHandler(g_parser, rsqb_handler);
   XML_SetUserData(g_parser, &found_rsqb);
   found_rsqb = 0;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text8, text8_len, XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text8, strlen(text8), XML_TRUE)
       == XML_STATUS_OK)
     fail("Failed to fault unclosed doc");
   if (found_rsqb == 0)
@@ -2684,7 +2683,7 @@ START_TEST(test_ext_entity_trailing_rsqb) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_rsqb_catcher);
   XML_SetUserData(g_parser, &found_rsqb);
   found_rsqb = 0;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_OK)
     xml_failure(g_parser);
   if (found_rsqb == 0)
@@ -2701,7 +2700,7 @@ START_TEST(test_ext_entity_good_cdata) {
 
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_good_cdata_ascii);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_OK)
     xml_failure(g_parser);
 }
@@ -2727,13 +2726,13 @@ START_TEST(test_user_parameters) {
   XML_UseParserAsHandlerArg(g_parser);
   XML_SetUserData(g_parser, (void *)1);
   g_handler_data = g_parser;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_FALSE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   /* Ensure we can't change policy mid-parse */
   if (XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_NEVER))
     fail("Changed param entity parsing policy while parsing");
-  if (_XML_Parse_SINGLE_BYTES(g_parser, epilog, (int)strlen(epilog), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, epilog, strlen(epilog), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (g_comment_count != 3)
@@ -2766,7 +2765,7 @@ START_TEST(test_ext_entity_ref_parameter) {
    */
   XML_SetExternalEntityRefHandlerArg(g_parser, (void *)text);
   g_handler_data = text;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 
@@ -2776,7 +2775,7 @@ START_TEST(test_ext_entity_ref_parameter) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_ref_param_checker);
   XML_SetExternalEntityRefHandlerArg(g_parser, NULL);
   g_handler_data = g_parser;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -2796,7 +2795,7 @@ START_TEST(test_empty_parse) {
 
   /* Now try with valid text before the empty end */
   XML_ParserReset(g_parser, NULL);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_FALSE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (XML_Parse(g_parser, NULL, 0, XML_TRUE) == XML_STATUS_ERROR)
@@ -2804,7 +2803,7 @@ START_TEST(test_empty_parse) {
 
   /* Now try with invalid text before the empty end */
   XML_ParserReset(g_parser, NULL);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, partial, (int)strlen(partial),
+  if (_XML_Parse_SINGLE_BYTES(g_parser, partial, strlen(partial),
                               XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
@@ -2848,8 +2847,6 @@ START_TEST(test_get_buffer_1) {
   if (XML_ParseBuffer(g_parser, strlen(text), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
-  if (XML_GetBuffer(g_parser, SIZE_T_MAX) != NULL)
-    fail("SIZE_T_MAX buffer not failed");
 
   /* Now try extending it a more reasonable but still too large
    * amount.  The allocator in XML_GetBuffer() doubles the buffer
@@ -2863,7 +2860,7 @@ START_TEST(test_get_buffer_1) {
    */
   if (get_feature(XML_FEATURE_CONTEXT_BYTES, &context_bytes) != XML_STATUS_OK)
     context_bytes = 0;
-  if (XML_GetBuffer(g_parser, INT_MAX - (context_bytes + 1025)) != NULL)
+  if (XML_GetBuffer(g_parser, SIZE_T_MAX - (context_bytes + 1025)) != NULL)
     fail("INT_MAX- buffer not failed");
 
   /* Now try extending it a carefully crafted amount */
@@ -2883,7 +2880,7 @@ START_TEST(test_get_buffer_2) {
     fail("1.5K buffer failed");
   assert(buffer != NULL);
   memcpy(buffer, text, strlen(text));
-  if (XML_ParseBuffer(g_parser, (int)strlen(text), XML_FALSE)
+  if (XML_ParseBuffer(g_parser, strlen(text), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 
@@ -2900,11 +2897,11 @@ START_TEST(test_get_buffer_3_overflow) {
   assert(parser != NULL);
 
   const char *const text = "\n";
-  const int expectedKeepValue = (int)strlen(text);
+  const int expectedKeepValue = strlen(text);
 
   // After this call, variable "keep" in XML_GetBuffer will
   // have value expectedKeepValue
-  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text),
+  if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text),
                               XML_FALSE /* isFinal */)
       == XML_STATUS_ERROR)
     xml_failure(parser);
@@ -2931,7 +2928,7 @@ START_TEST(test_buffer_can_grow_to_max) {
       "herebutipromisethatididntheybtwhowgreatarespacesandpunctuationforhelping"
       "withreadabilityprettygreatithinkanywaysthisisprobablylongenoughbye><x a='"};
   const int num_prefixes = sizeof(prefixes) / sizeof(prefixes[0]);
-  size_t maxbuf = SIZE_T_MAX / 2 + (SIZE_T_MAX & 1); // round up without overflow
+  size_t maxbuf = SIZE_T_MAX; // round up without overflow
 #if defined(__MINGW32__) && ! defined(__MINGW64__)
   // workaround for mingw/wine32 on GitHub CI not being able to reach 1GiB
   // Can we make a big allocation?
@@ -2946,7 +2943,7 @@ START_TEST(test_buffer_can_grow_to_max) {
   for (int i = 0; i < num_prefixes; ++i) {
     set_subtest("\"%s\"", prefixes[i]);
     XML_Parser parser = XML_ParserCreate(NULL);
-    const int prefix_len = (int)strlen(prefixes[i]);
+    const size_t prefix_len = strlen(prefixes[i]);
     const enum XML_Status s
         = _XML_Parse_SINGLE_BYTES(parser, prefixes[i], prefix_len, XML_FALSE);
     if (s != XML_STATUS_OK)
@@ -2954,6 +2951,7 @@ START_TEST(test_buffer_can_grow_to_max) {
 
     // XML_CONTEXT_BYTES of the prefix may remain in the buffer;
     // subtracting the whole prefix is easiest, and close enough.
+    printf("%zu %zu\n",maxbuf, prefix_len);
     assert_true(XML_GetBuffer(parser, maxbuf - prefix_len) != NULL);
     // The limit should be consistent; no prefix should allow us to
     // reach above the max buffer size.
@@ -2984,7 +2982,7 @@ START_TEST(test_byte_info_at_end) {
   if (XML_GetCurrentByteIndex(g_parser) != -1
       || XML_GetCurrentByteCount(g_parser) != 0)
     fail("Byte index/count incorrect at start of parse");
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   /* At end, the count will be zero and the index the end of string */
@@ -3001,7 +2999,7 @@ END_TEST
 START_TEST(test_byte_info_at_error) {
   const char *text = PRE_ERROR_STR POST_ERROR_STR;
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_OK)
     fail("Syntax error not faulted");
   if (XML_GetCurrentByteCount(g_parser) != 0)
@@ -3026,12 +3024,12 @@ START_TEST(test_byte_info_at_cdata) {
   if (XML_GetInputContext(g_parser, &offset, &size) != NULL)
     fail("Unexpected context at start of parse");
 
-  data.start_element_len = (int)strlen(START_ELEMENT);
-  data.cdata_len = (int)strlen(CDATA_TEXT);
-  data.total_string_len = (int)strlen(text);
+  data.start_element_len = strlen(START_ELEMENT);
+  data.cdata_len = strlen(CDATA_TEXT);
+  data.total_string_len = strlen(text);
   XML_SetCharacterDataHandler(g_parser, byte_character_handler);
   XML_SetUserData(g_parser, &data);
-  if (XML_Parse(g_parser, text, (int)strlen(text), XML_TRUE) != XML_STATUS_OK)
+  if (XML_Parse(g_parser, text, strlen(text), XML_TRUE) != XML_STATUS_OK)
     xml_failure(g_parser);
 }
 END_TEST
@@ -3052,7 +3050,7 @@ START_TEST(test_predefined_entities) {
    */
   CharData_Init(&storage);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   /* The default handler doesn't translate the entities */
@@ -3116,7 +3114,7 @@ START_TEST(test_ignore_section) {
   XML_SetElementDeclHandler(g_parser, dummy_element_decl_handler);
   XML_SetStartElementHandler(g_parser, dummy_start_element);
   XML_SetEndElementHandler(g_parser, dummy_end_element);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -3207,7 +3205,7 @@ END_TEST
 
 struct bom_testdata {
   const char *external;
-  int split;
+  size_t split;
   XML_Bool nested_callback_happened;
 };
 
@@ -3228,7 +3226,7 @@ external_bom_checker(XML_Parser parser, const XML_Char *context,
     struct bom_testdata *const testdata
         = (struct bom_testdata *)XML_GetUserData(parser);
     const char *const external = testdata->external;
-    const int split = testdata->split;
+    const size_t split = testdata->split;
     testdata->nested_callback_happened = XML_TRUE;
 
     if (_XML_Parse_SINGLE_BYTES(ext_parser, external, split, XML_FALSE)
@@ -3244,7 +3242,7 @@ external_bom_checker(XML_Parser parser, const XML_Char *context,
     fail("unknown systemId");
   }
 
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_OK)
     xml_failure(ext_parser);
 
@@ -3257,9 +3255,9 @@ START_TEST(test_external_bom_consumed) {
   const char *const text = "<!DOCTYPE doc SYSTEM '004-1.ent'>\n"
                            "<doc></doc>\n";
   const char *const external = "\xEF\xBB\xBF<!ATTLIST doc a1 CDATA 'value'>";
-  const int len = (int)strlen(external);
-  for (int split = 0; split <= len; ++split) {
-    set_subtest("split at byte %d", split);
+  const size_t len = strlen(external);
+  for (size_t split = 0; split <= len; ++split) {
+    set_subtest("split at byte %zu", split);
 
     struct bom_testdata testdata;
     testdata.external = external;
@@ -3273,7 +3271,7 @@ START_TEST(test_external_bom_consumed) {
     XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(parser, external_bom_checker);
     XML_SetUserData(parser, &testdata);
-    if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text), XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(parser);
     if (! testdata.nested_callback_happened) {
@@ -3321,7 +3319,7 @@ START_TEST(test_external_entity_values) {
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_valuer);
     XML_SetUserData(g_parser, &data_004_2[i]);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(g_parser);
     XML_ParserReset(g_parser, NULL);
@@ -3348,7 +3346,7 @@ START_TEST(test_ext_entity_value_abort) {
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_value_aborter);
   g_resumable = XML_FALSE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -3412,7 +3410,7 @@ START_TEST(test_dtd_stop_processing) {
 
   XML_SetEntityDeclHandler(g_parser, dummy_entity_decl_handler);
   init_dummy_handlers();
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (get_dummy_handler_flags() != 0)
@@ -3429,7 +3427,7 @@ START_TEST(test_public_notation_no_sysid) {
 
   init_dummy_handlers();
   XML_SetNotationDeclHandler(g_parser, dummy_notation_decl_handler);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (get_dummy_handler_flags() != DUMMY_NOTATION_DECL_HANDLER_FLAG)
@@ -3455,7 +3453,7 @@ START_TEST(test_nested_groups) {
   XML_SetStartElementHandler(g_parser, record_element_start_handler);
   XML_SetUserData(g_parser, &storage);
   init_dummy_handlers();
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, XCS("doce"));
@@ -3479,7 +3477,7 @@ START_TEST(test_group_choice) {
 
   XML_SetElementDeclHandler(g_parser, dummy_element_decl_handler);
   init_dummy_handlers();
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (get_dummy_handler_flags() != DUMMY_ELEMENT_DECL_HANDLER_FLAG)
@@ -3499,7 +3497,7 @@ START_TEST(test_standalone_parameter_entity) {
   XML_SetUserData(g_parser, dtd_data);
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_public);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -3520,7 +3518,7 @@ START_TEST(test_skipped_parameter_entity) {
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetSkippedEntityHandler(g_parser, dummy_skip_handler);
   init_dummy_handlers();
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (get_dummy_handler_flags() != DUMMY_SKIP_HANDLER_FLAG)
@@ -3555,7 +3553,7 @@ START_TEST(test_undefined_ext_entity_in_external_dtd) {
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_devaluer);
   XML_SetUserData(g_parser, NULL);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 
@@ -3566,7 +3564,7 @@ START_TEST(test_undefined_ext_entity_in_external_dtd) {
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_devaluer);
   XML_SetUserData(g_parser, g_parser); /* Any non-NULL value will do */
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -3579,13 +3577,13 @@ START_TEST(test_suspend_xdecl) {
   XML_SetXmlDeclHandler(g_parser, entity_suspending_xdecl_handler);
   XML_SetUserData(g_parser, g_parser);
   g_resumable = XML_TRUE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)
     xml_failure(g_parser);
   if (XML_GetErrorCode(g_parser) != XML_ERROR_NONE)
     xml_failure(g_parser);
   /* Attempt to start a new parse while suspended */
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Attempt to parse while suspended not faulted");
   if (XML_GetErrorCode(g_parser) != XML_ERROR_SUSPENDED)
@@ -3601,7 +3599,7 @@ START_TEST(test_abort_epilog) {
   XML_SetDefaultHandler(g_parser, selective_aborting_default_handler);
   XML_SetUserData(g_parser, &trigger_char);
   g_resumable = XML_FALSE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Abort not triggered");
   if (XML_GetErrorCode(g_parser) != XML_ERROR_ABORTED)
@@ -3629,7 +3627,7 @@ START_TEST(test_suspend_epilog) {
   XML_SetDefaultHandler(g_parser, selective_aborting_default_handler);
   XML_SetUserData(g_parser, &trigger_char);
   g_resumable = XML_TRUE;
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)
     xml_failure(g_parser);
 }
@@ -3641,7 +3639,7 @@ START_TEST(test_suspend_in_sole_empty_tag) {
 
   XML_SetEndElementHandler(g_parser, suspending_end_handler);
   XML_SetUserData(g_parser, g_parser);
-  rc = _XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE);
+  rc = _XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE);
   if (rc == XML_STATUS_ERROR)
     xml_failure(g_parser);
   else if (rc != XML_STATUS_SUSPENDED)
@@ -3666,7 +3664,7 @@ START_TEST(test_partial_char_in_epilog) {
   const char *text = "<doc></doc>\xe2\x82";
 
   /* First check that no fault is raised if the parse is not finished */
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_FALSE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   /* Now check that it is faulted once we finish */
@@ -3694,7 +3692,7 @@ START_TEST(test_suspend_resume_internal_entity) {
   XML_SetUserData(g_parser, &storage);
   // can't use SINGLE_BYTES here, because it'll return early on suspension, and
   // we won't know exactly how much input we actually managed to give Expat.
-  if (XML_Parse(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (XML_Parse(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, XCS(""));
@@ -3781,7 +3779,7 @@ START_TEST(test_resume_entity_with_syntax_error) {
                      "<doc>&foo;</doc>\n";
 
   XML_SetStartElementHandler(g_parser, start_element_suspender);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)
     xml_failure(g_parser);
   if (XML_ResumeParser(g_parser) != XML_STATUS_ERROR)
@@ -3806,7 +3804,7 @@ START_TEST(test_suspend_resume_parameter_entity) {
   XML_SetElementDeclHandler(g_parser, element_decl_suspender);
   XML_SetCharacterDataHandler(g_parser, accumulate_characters);
   XML_SetUserData(g_parser, &storage);
-  if (XML_Parse(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (XML_Parse(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, XCS(""));
@@ -3820,7 +3818,7 @@ END_TEST
 START_TEST(test_restart_on_error) {
   const char *text = "<$doc><doc></doc>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Invalid tag name not faulted");
   if (XML_GetErrorCode(g_parser) != XML_ERROR_INVALID_TOKEN)
@@ -3854,7 +3852,7 @@ END_TEST
 START_TEST(test_trailing_cr_in_att_value) {
   const char *text = "<doc a='value\r'/>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -3874,7 +3872,7 @@ START_TEST(test_standalone_internal_entity) {
                      "<doc att2='any'/>";
 
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -3891,7 +3889,7 @@ START_TEST(test_skipped_external_entity) {
   XML_SetUserData(g_parser, &test_data);
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -3910,7 +3908,7 @@ START_TEST(test_skipped_null_loaded_ext_entity) {
   XML_SetUserData(g_parser, &test_data);
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_oneshot_loader);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -3928,7 +3926,7 @@ START_TEST(test_skipped_unloaded_ext_entity) {
   XML_SetUserData(g_parser, &test_data);
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_oneshot_loader);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -3953,7 +3951,7 @@ START_TEST(test_param_entity_with_trailing_cr) {
   XML_SetEntityDeclHandler(g_parser, param_entity_match_handler);
   param_entity_match_init(XCS(PARAM_ENTITY_NAME),
                           XCS(PARAM_ENTITY_CORE_VALUE) XCS("\n"));
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   int entity_match_flag = get_param_entity_match_flag();
@@ -4030,7 +4028,7 @@ START_TEST(test_pi_handled_in_default) {
   CharData_Init(&storage);
   XML_SetDefaultHandler(g_parser, accumulate_characters);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4046,7 +4044,7 @@ START_TEST(test_comment_handled_in_default) {
   CharData_Init(&storage);
   XML_SetDefaultHandler(g_parser, accumulate_characters);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4062,7 +4060,7 @@ START_TEST(test_pi_yml) {
   CharData_Init(&storage);
   XML_SetProcessingInstructionHandler(g_parser, accumulate_pi_characters);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4077,7 +4075,7 @@ START_TEST(test_pi_xnl) {
   CharData_Init(&storage);
   XML_SetProcessingInstructionHandler(g_parser, accumulate_pi_characters);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4092,7 +4090,7 @@ START_TEST(test_pi_xmm) {
   CharData_Init(&storage);
   XML_SetProcessingInstructionHandler(g_parser, accumulate_pi_characters);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4272,7 +4270,7 @@ START_TEST(test_unknown_encoding_long_name_1) {
   XML_SetUnknownEncodingHandler(g_parser, MiscEncodingHandler, NULL);
   XML_SetStartElementHandler(g_parser, record_element_start_handler);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4294,7 +4292,7 @@ START_TEST(test_unknown_encoding_long_name_2) {
   XML_SetUnknownEncodingHandler(g_parser, MiscEncodingHandler, NULL);
   XML_SetStartElementHandler(g_parser, record_element_start_handler);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4408,7 +4406,7 @@ START_TEST(test_ext_entity_latin1_utf16le_bom) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader2);
   XML_SetUserData(g_parser, &test_data);
   XML_SetCharacterDataHandler(g_parser, ext2_accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4439,7 +4437,7 @@ START_TEST(test_ext_entity_latin1_utf16be_bom) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader2);
   XML_SetUserData(g_parser, &test_data);
   XML_SetCharacterDataHandler(g_parser, ext2_accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4474,7 +4472,7 @@ START_TEST(test_ext_entity_latin1_utf16le_bom2) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader2);
   XML_SetUserData(g_parser, &test_data);
   XML_SetCharacterDataHandler(g_parser, ext2_accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4505,7 +4503,7 @@ START_TEST(test_ext_entity_latin1_utf16be_bom2) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader2);
   XML_SetUserData(g_parser, &test_data);
   XML_SetCharacterDataHandler(g_parser, ext2_accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4534,7 +4532,7 @@ START_TEST(test_ext_entity_utf16_be) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader2);
   XML_SetUserData(g_parser, &test_data);
   XML_SetCharacterDataHandler(g_parser, ext2_accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4563,7 +4561,7 @@ START_TEST(test_ext_entity_utf16_le) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader2);
   XML_SetUserData(g_parser, &test_data);
   XML_SetCharacterDataHandler(g_parser, ext2_accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4614,7 +4612,7 @@ START_TEST(test_ext_entity_utf8_non_bom) {
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader2);
   XML_SetUserData(g_parser, &test_data);
   XML_SetCharacterDataHandler(g_parser, ext2_accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -4723,7 +4721,7 @@ START_TEST(test_utf8_in_start_tags) {
       XML_Parser parser = XML_ParserCreate(NULL);
 
       const enum XML_Status status = _XML_Parse_SINGLE_BYTES(
-          parser, doc, (int)strlen(doc), /*isFinal=*/XML_FALSE);
+          parser, doc, strlen(doc), /*isFinal=*/XML_FALSE);
 
       bool success = true;
       if ((status == XML_STATUS_OK) != expectedSuccess) {
@@ -4763,7 +4761,7 @@ START_TEST(test_trailing_spaces_in_elements) {
   XML_SetElementHandler(g_parser, record_element_start_handler,
                         record_element_end_handler);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -5177,7 +5175,7 @@ START_TEST(test_default_doctype_handler) {
   XML_SetUserData(g_parser, &test_data);
   XML_SetDefaultHandler(g_parser, checking_default_handler);
   XML_SetEntityDeclHandler(g_parser, dummy_entity_decl_handler);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   for (i = 0; test_data[i].expected != NULL; i++)
@@ -5190,7 +5188,7 @@ START_TEST(test_empty_element_abort) {
   const char *text = "<abort/>";
 
   XML_SetStartElementHandler(g_parser, start_element_suspender);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Expected to error on abort");
 }
@@ -5216,7 +5214,7 @@ START_TEST(test_pool_integrity_with_unfinished_attr) {
   XML_SetAttlistDeclHandler(g_parser, dummy_attlist_decl_handler);
   XML_SetCommentHandler(g_parser, accumulate_comment);
   XML_SetUserData(g_parser, &storage);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -5241,7 +5239,7 @@ START_TEST(test_nested_entity_suspend) {
   XML_SetCommentHandler(parser, accumulate_and_suspend_comment_handler);
   XML_SetUserData(parser, &parserPlusStorage);
 
-  enum XML_Status status = XML_Parse(parser, text, (int)strlen(text), XML_TRUE);
+  enum XML_Status status = XML_Parse(parser, text, strlen(text), XML_TRUE);
   while (status == XML_STATUS_SUSPENDED) {
     status = XML_ResumeParser(parser);
   }
@@ -5267,11 +5265,11 @@ START_TEST(test_big_tokens_scale_linearly) {
   };
   const int num_cases = sizeof(text) / sizeof(text[0]);
   char aaaaaa[4096];
-  const int fillsize = (int)sizeof(aaaaaa);
-  const int fillcount = 100;
-  const unsigned approx_bytes = fillsize * fillcount; // ignore pre/post.
+  const size_t fillsize = sizeof(aaaaaa);
+  const size_t fillcount = 100;
+  const size_t approx_bytes = fillsize * fillcount; // ignore pre/post.
   const unsigned max_factor = 4;
-  const unsigned max_scanned = max_factor * approx_bytes;
+  const size_t max_scanned = max_factor * approx_bytes;
 
   memset(aaaaaa, 'a', fillsize);
 
@@ -5288,7 +5286,7 @@ START_TEST(test_big_tokens_scale_linearly) {
     // parse the start text
     g_bytesScanned = 0;
     status = _XML_Parse_SINGLE_BYTES(parser, text[i].pre,
-                                     (int)strlen(text[i].pre), XML_FALSE);
+                                     strlen(text[i].pre), XML_FALSE);
     if (status != XML_STATUS_OK) {
       xml_failure(parser);
     }
@@ -5303,11 +5301,11 @@ START_TEST(test_big_tokens_scale_linearly) {
       if (g_bytesScanned > max_scanned) {
         // We're not done, and have already passed the limit -- the test will
         // definitely fail. This block allows us to save time by failing early.
-        const unsigned pushed
-            = (unsigned)strlen(text[i].pre) + (f + 1) * fillsize;
+        const size_t pushed
+            = strlen(text[i].pre) + (f + 1) * fillsize;
         fprintf(
             stderr,
-            "after %d/%d loops: pushed=%u scanned=%u (factor ~%.2f) max_scanned: %u (factor ~%u)\n",
+            "after %d/%zu loops: pushed=%zu scanned=%u (factor ~%.2f) max_scanned: %zu (factor ~%u)\n",
             f + 1, fillcount, pushed, g_bytesScanned,
             g_bytesScanned / (double)pushed, max_scanned, max_factor);
         past_max_count++;
@@ -5319,7 +5317,7 @@ START_TEST(test_big_tokens_scale_linearly) {
 
     // parse the end text
     status = _XML_Parse_SINGLE_BYTES(parser, text[i].post,
-                                     (int)strlen(text[i].post), XML_TRUE);
+                                     strlen(text[i].post), XML_TRUE);
     if (status != XML_STATUS_OK) {
       xml_failure(parser);
     }
@@ -5328,7 +5326,7 @@ START_TEST(test_big_tokens_scale_linearly) {
     if (g_bytesScanned > max_scanned) {
       fprintf(
           stderr,
-          "after all input: scanned=%u (factor ~%.2f) max_scanned: %u (factor ~%u)\n",
+          "after all input: scanned=%u (factor ~%.2f) max_scanned: %zu (factor ~%u)\n",
           g_bytesScanned, g_bytesScanned / (double)approx_bytes, max_scanned,
           max_factor);
       fail("scanned too many bytes");
@@ -5363,14 +5361,14 @@ START_TEST(test_set_reparse_deferral) {
 
     enum XML_Status status;
     // parse the start text
-    status = XML_Parse(parser, pre, (int)strlen(pre), XML_FALSE);
+    status = XML_Parse(parser, pre, strlen(pre), XML_FALSE);
     if (status != XML_STATUS_OK) {
       xml_failure(parser);
     }
     CharData_CheckXMLChars(&storage, XCS("d")); // first element should be done
 
     // ..and the start of the token
-    status = XML_Parse(parser, start, (int)strlen(start), XML_FALSE);
+    status = XML_Parse(parser, start, strlen(start), XML_FALSE);
     if (status != XML_STATUS_OK) {
       xml_failure(parser);
     }
@@ -5386,7 +5384,7 @@ START_TEST(test_set_reparse_deferral) {
     CharData_CheckXMLChars(&storage, XCS("d")); // *still* just the first one
 
     // end the <x> token.
-    status = XML_Parse(parser, end, (int)strlen(end), XML_FALSE);
+    status = XML_Parse(parser, end, strlen(end), XML_FALSE);
     if (status != XML_STATUS_OK) {
       xml_failure(parser);
     }
@@ -5455,14 +5453,14 @@ external_inherited_parser(XML_Parser p, const XML_Char *context,
 
   enum XML_Status status;
   // parse the initial text
-  status = XML_Parse(parser, pre, (int)strlen(pre), XML_FALSE);
+  status = XML_Parse(parser, pre, strlen(pre), XML_FALSE);
   if (status != XML_STATUS_OK) {
     xml_failure(parser);
   }
   assert_true(testdata.count == 1); // first element should be done
 
   // ..and the start of the big token
-  status = XML_Parse(parser, start, (int)strlen(start), XML_FALSE);
+  status = XML_Parse(parser, start, strlen(start), XML_FALSE);
   if (status != XML_STATUS_OK) {
     xml_failure(parser);
   }
@@ -5478,7 +5476,7 @@ external_inherited_parser(XML_Parser p, const XML_Char *context,
   assert_true(testdata.count == 1); // *still* just the first one
 
   // end the big token.
-  status = XML_Parse(parser, end, (int)strlen(end), XML_FALSE);
+  status = XML_Parse(parser, end, strlen(end), XML_FALSE);
   if (status != XML_STATUS_OK) {
     xml_failure(parser);
   }
@@ -5498,7 +5496,7 @@ external_inherited_parser(XML_Parser p, const XML_Char *context,
   assert_true(testdata.count == 2); // the big token should be done
 
   // parse the final text
-  status = XML_Parse(parser, post, (int)strlen(post), XML_TRUE);
+  status = XML_Parse(parser, post, strlen(post), XML_TRUE);
   if (status != XML_STATUS_OK) {
     xml_failure(parser);
   }
@@ -5522,7 +5520,7 @@ START_TEST(test_reparse_deferral_is_inherited) {
     // is what we expected, based on the value of `enabled` (in userdata).
     XML_SetExternalEntityRefHandler(parser, external_inherited_parser);
     assert_true(XML_SetReparseDeferralEnabled(parser, enabled));
-    if (XML_Parse(parser, text, (int)strlen(text), XML_TRUE) != XML_STATUS_OK)
+    if (XML_Parse(parser, text, strlen(text), XML_TRUE) != XML_STATUS_OK)
       xml_failure(parser);
 
     XML_ParserFree(parser);
@@ -5560,7 +5558,7 @@ START_TEST(test_set_reparse_deferral_on_the_fly) {
 
   enum XML_Status status;
   // parse the start text
-  status = XML_Parse(parser, pre, (int)strlen(pre), XML_FALSE);
+  status = XML_Parse(parser, pre, strlen(pre), XML_FALSE);
   if (status != XML_STATUS_OK) {
     xml_failure(parser);
   }
@@ -5574,7 +5572,7 @@ START_TEST(test_set_reparse_deferral_on_the_fly) {
   CharData_CheckXMLChars(&storage, XCS("d")); // *still* just the first one
 
   // end the <x> token.
-  status = XML_Parse(parser, end, (int)strlen(end), XML_FALSE);
+  status = XML_Parse(parser, end, strlen(end), XML_FALSE);
   if (status != XML_STATUS_OK) {
     xml_failure(parser);
   }
@@ -5964,7 +5962,6 @@ make_basic_test_case(Suite *s) {
   tcase_add_test__ifdef_xml_dtd(tc_basic, test_user_parameters);
   tcase_add_test__ifdef_xml_dtd(tc_basic, test_ext_entity_ref_parameter);
   tcase_add_test(tc_basic, test_empty_parse);
-  tcase_add_test(tc_basic, test_negative_len_parse);
   tcase_add_test(tc_basic, test_get_buffer_1);
   tcase_add_test(tc_basic, test_get_buffer_2);
 #if XML_CONTEXT_BYTES > 0

--- a/expat/tests/common.c
+++ b/expat/tests/common.c
@@ -141,7 +141,7 @@ XML_Bool g_resumable = XML_FALSE;
 XML_Bool g_abortable = XML_FALSE;
 
 /* Used to control _XML_Parse_SINGLE_BYTES() chunk size */
-int g_chunkSize = 1;
+size_t g_chunkSize = 1;
 
 /* Common test functions */
 
@@ -190,13 +190,13 @@ _xml_failure(XML_Parser parser, const char *file, int line) {
 }
 
 enum XML_Status
-_XML_Parse_SINGLE_BYTES(XML_Parser parser, const char *s, int len,
+_XML_Parse_SINGLE_BYTES(XML_Parser parser, const char *s, size_t len,
                         int isFinal) {
   // This ensures that tests have to run pathological parse cases
   // (e.g. when `s` is NULL) against plain XML_Parse rather than
   // chunking _XML_Parse_SINGLE_BYTES.
-  assert((parser != NULL) && (s != NULL) && (len >= 0));
-  const int chunksize = g_chunkSize;
+  assert((parser != NULL) && (s != NULL));
+  const size_t chunksize = g_chunkSize;
   if (chunksize > 0) {
     // parse in chunks of `chunksize` bytes as long as not exhausting
     for (; len > chunksize; len -= chunksize, s += chunksize) {

--- a/expat/tests/common.c
+++ b/expat/tests/common.c
@@ -213,7 +213,7 @@ _XML_Parse_SINGLE_BYTES(XML_Parser parser, const char *s, size_t len,
 void
 _expect_failure(const char *text, enum XML_Error errorCode,
                 const char *errorMessage, const char *file, int lineno) {
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_OK)
     /* Hackish use of _fail() macro, but lets us report
        the right filename and line number. */
@@ -230,7 +230,7 @@ _run_character_check(const char *text, const XML_Char *expected,
   CharData_Init(&storage);
   XML_SetUserData(g_parser, &storage);
   XML_SetCharacterDataHandler(g_parser, accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     _xml_failure(g_parser, file, line);
   CharData_CheckXMLChars(&storage, expected);
@@ -244,7 +244,7 @@ _run_attribute_check(const char *text, const XML_Char *expected,
   CharData_Init(&storage);
   XML_SetUserData(g_parser, &storage);
   XML_SetStartElementHandler(g_parser, accumulate_attribute);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     _xml_failure(g_parser, file, line);
   CharData_CheckXMLChars(&storage, expected);
@@ -259,7 +259,7 @@ _run_ext_character_check(const char *text, ExtTest *test_data,
   test_data->storage = storage;
   XML_SetUserData(g_parser, test_data);
   XML_SetCharacterDataHandler(g_parser, ext_accumulate_characters);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     _xml_failure(g_parser, file, line);
   CharData_CheckXMLChars(storage, expected);

--- a/expat/tests/common.h
+++ b/expat/tests/common.h
@@ -83,7 +83,7 @@ extern XML_Parser g_parser;
 extern XML_Bool g_resumable;
 extern XML_Bool g_abortable;
 
-extern int g_chunkSize;
+extern size_t g_chunkSize;
 
 extern const char *long_character_data_text;
 extern const char *long_cdata_text;
@@ -99,7 +99,7 @@ extern void _xml_failure(XML_Parser parser, const char *file, int line);
 #  define xml_failure(parser) _xml_failure((parser), __FILE__, __LINE__)
 
 extern enum XML_Status _XML_Parse_SINGLE_BYTES(XML_Parser parser, const char *s,
-                                               int len, int isFinal);
+                                               size_t len, int isFinal);
 
 extern void _expect_failure(const char *text, enum XML_Error errorCode,
                             const char *errorMessage, const char *file,

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -425,7 +425,7 @@ external_entity_optioner(XML_Parser parser, const XML_Char *context,
       if (ext_parser == NULL)
         return XML_STATUS_ERROR;
       rc = _XML_Parse_SINGLE_BYTES(ext_parser, options->parse_text,
-                                   (int)strlen(options->parse_text), XML_TRUE);
+                                   strlen(options->parse_text), XML_TRUE);
       XML_ParserFree(ext_parser);
       return rc;
     }
@@ -453,7 +453,7 @@ external_entity_loader(XML_Parser parser, const XML_Char *context,
       fail("XML_SetEncoding() ignored for external entity");
   }
   if (_XML_Parse_SINGLE_BYTES(extparser, test_data->parse_text,
-                              (int)strlen(test_data->parse_text), XML_TRUE)
+                              strlen(test_data->parse_text), XML_TRUE)
       == XML_STATUS_ERROR) {
     xml_failure(extparser);
     return XML_STATUS_ERROR;
@@ -480,7 +480,7 @@ external_entity_faulter(XML_Parser parser, const XML_Char *context,
       fail("XML_SetEncoding failed");
   }
   if (_XML_Parse_SINGLE_BYTES(ext_parser, fault->parse_text,
-                              (int)strlen(fault->parse_text), XML_TRUE)
+                              strlen(fault->parse_text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail(fault->fail_text);
   if (XML_GetErrorCode(ext_parser) != fault->error)
@@ -521,7 +521,7 @@ external_entity_resetter(XML_Parser parser, const XML_Char *context,
     fail("Parsing status is not INITIALIZED");
     return XML_STATUS_ERROR;
   }
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR) {
     xml_failure(parser);
     return XML_STATUS_ERROR;
@@ -532,7 +532,7 @@ external_entity_resetter(XML_Parser parser, const XML_Char *context,
     return XML_STATUS_ERROR;
   }
   /* Check we can't parse here */
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Parsing when finished not faulted");
   if (XML_GetErrorCode(ext_parser) != XML_ERROR_FINISHED)
@@ -576,7 +576,7 @@ external_entity_suspender(XML_Parser parser, const XML_Char *context,
     fail("Could not create external entity parser");
   XML_SetElementDeclHandler(ext_parser, entity_suspending_decl_handler);
   XML_SetUserData(ext_parser, ext_parser);
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR) {
     xml_failure(ext_parser);
     return XML_STATUS_ERROR;
@@ -614,7 +614,7 @@ external_entity_suspend_xmldecl(XML_Parser parser, const XML_Char *context,
     fail("Could not create external entity parser");
   XML_SetXmlDeclHandler(ext_parser, entity_suspending_xdecl_handler);
   XML_SetUserData(ext_parser, ext_parser);
-  rc = _XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE);
+  rc = _XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE);
   XML_GetParsingStatus(ext_parser, &status);
   if (g_resumable) {
     if (rc == XML_STATUS_ERROR)
@@ -642,7 +642,7 @@ external_entity_suspending_faulter(XML_Parser parser, const XML_Char *context,
   XML_Parser ext_parser;
   ExtFaults *fault = (ExtFaults *)XML_GetUserData(parser);
   void *buffer;
-  int parse_len = (int)strlen(fault->parse_text);
+  int parse_len = strlen(fault->parse_text);
 
   UNUSED_P(base);
   UNUSED_P(systemId);
@@ -703,7 +703,7 @@ external_entity_cr_catcher(XML_Parser parser, const XML_Char *context,
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
   XML_SetCharacterDataHandler(ext_parser, cr_cdata_handler);
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(ext_parser);
   XML_ParserFree(ext_parser);
@@ -724,7 +724,7 @@ external_entity_bad_cr_catcher(XML_Parser parser, const XML_Char *context,
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
   XML_SetCharacterDataHandler(ext_parser, cr_cdata_handler);
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_OK)
     fail("Async entity error not caught");
   if (XML_GetErrorCode(ext_parser) != XML_ERROR_ASYNC_ENTITY)
@@ -747,7 +747,7 @@ external_entity_rsqb_catcher(XML_Parser parser, const XML_Char *context,
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
   XML_SetCharacterDataHandler(ext_parser, rsqb_handler);
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Async entity error not caught");
   if (XML_GetErrorCode(ext_parser) != XML_ERROR_ASYNC_ENTITY)
@@ -775,7 +775,7 @@ external_entity_good_cdata_ascii(XML_Parser parser, const XML_Char *context,
   XML_SetUserData(ext_parser, &storage);
   XML_SetCharacterDataHandler(ext_parser, accumulate_characters);
 
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(ext_parser);
   CharData_CheckXMLChars(&storage, expected);
@@ -799,7 +799,7 @@ external_entity_param_checker(XML_Parser parser, const XML_Char *context,
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
   g_handler_data = ext_parser;
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR) {
     xml_failure(parser);
     return XML_STATUS_ERROR;
@@ -827,7 +827,7 @@ external_entity_ref_param_checker(XML_Parser parameter, const XML_Char *context,
   ext_parser = XML_ExternalEntityParserCreate(g_parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(ext_parser);
 
@@ -857,13 +857,13 @@ external_entity_param(XML_Parser parser, const XML_Char *context,
     fail("Could not create external entity parser");
 
   if (! xcstrcmp(systemId, XCS("004-1.ent"))) {
-    if (_XML_Parse_SINGLE_BYTES(ext_parser, text1, (int)strlen(text1), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(ext_parser, text1, strlen(text1), XML_TRUE)
         != XML_STATUS_ERROR)
       fail("Inner DTD with invalid tag not rejected");
     if (XML_GetErrorCode(ext_parser) != XML_ERROR_EXTERNAL_ENTITY_HANDLING)
       xml_failure(ext_parser);
   } else if (! xcstrcmp(systemId, XCS("004-2.ent"))) {
-    if (_XML_Parse_SINGLE_BYTES(ext_parser, text2, (int)strlen(text2), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(ext_parser, text2, strlen(text2), XML_TRUE)
         != XML_STATUS_ERROR)
       fail("Invalid tag in external param not rejected");
     if (XML_GetErrorCode(ext_parser) != XML_ERROR_SYNTAX)
@@ -889,7 +889,7 @@ external_entity_load_ignore(XML_Parser parser, const XML_Char *context,
   ext_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(parser);
 
@@ -967,7 +967,7 @@ external_entity_valuer(XML_Parser parser, const XML_Char *context,
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
   if (! xcstrcmp(systemId, XCS("004-1.ent"))) {
-    if (_XML_Parse_SINGLE_BYTES(ext_parser, text1, (int)strlen(text1), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(ext_parser, text1, strlen(text1), XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(ext_parser);
   } else if (! xcstrcmp(systemId, XCS("004-2.ent"))) {
@@ -976,7 +976,7 @@ external_entity_valuer(XML_Parser parser, const XML_Char *context,
     enum XML_Error error;
 
     status = _XML_Parse_SINGLE_BYTES(ext_parser, fault->parse_text,
-                                     (int)strlen(fault->parse_text), XML_TRUE);
+                                     strlen(fault->parse_text), XML_TRUE);
     if (fault->error == XML_ERROR_NONE) {
       if (status == XML_STATUS_ERROR)
         xml_failure(ext_parser);
@@ -1014,7 +1014,7 @@ external_entity_not_standalone(XML_Parser parser, const XML_Char *context,
     fail("Could not create external entity parser");
   if (! xcstrcmp(systemId, XCS("foo"))) {
     XML_SetNotStandaloneHandler(ext_parser, reject_not_standalone_handler);
-    if (_XML_Parse_SINGLE_BYTES(ext_parser, text1, (int)strlen(text1), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(ext_parser, text1, strlen(text1), XML_TRUE)
         != XML_STATUS_ERROR)
       fail("Expected not standalone rejection");
     if (XML_GetErrorCode(ext_parser) != XML_ERROR_NOT_STANDALONE)
@@ -1023,7 +1023,7 @@ external_entity_not_standalone(XML_Parser parser, const XML_Char *context,
     XML_ParserFree(ext_parser);
     return XML_STATUS_ERROR;
   } else if (! xcstrcmp(systemId, XCS("bar"))) {
-    if (_XML_Parse_SINGLE_BYTES(ext_parser, text2, (int)strlen(text2), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(ext_parser, text2, strlen(text2), XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(ext_parser);
   }
@@ -1051,14 +1051,14 @@ external_entity_value_aborter(XML_Parser parser, const XML_Char *context,
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
   if (! xcstrcmp(systemId, XCS("004-1.ent"))) {
-    if (_XML_Parse_SINGLE_BYTES(ext_parser, text1, (int)strlen(text1), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(ext_parser, text1, strlen(text1), XML_TRUE)
         == XML_STATUS_ERROR)
       xml_failure(ext_parser);
   }
   if (! xcstrcmp(systemId, XCS("004-2.ent"))) {
     XML_SetXmlDeclHandler(ext_parser, entity_suspending_xdecl_handler);
     XML_SetUserData(ext_parser, ext_parser);
-    if (_XML_Parse_SINGLE_BYTES(ext_parser, text2, (int)strlen(text2), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(ext_parser, text2, strlen(text2), XML_TRUE)
         != XML_STATUS_ERROR)
       fail("Aborted parse not faulted");
     if (XML_GetErrorCode(ext_parser) != XML_ERROR_ABORTED)
@@ -1091,7 +1091,7 @@ external_entity_public(XML_Parser parser, const XML_Char *context,
     fail("Unexpected parameters to external entity parser");
   assert(text != NULL);
   parse_res
-      = _XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE);
+      = _XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE);
   XML_ParserFree(ext_parser);
   return parse_res;
 }
@@ -1117,7 +1117,7 @@ external_entity_devaluer(XML_Parser parser, const XML_Char *context,
     fail("Could note create external entity parser");
   if (clear_handler_flag)
     XML_SetExternalEntityRefHandler(ext_parser, NULL);
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(ext_parser);
 
@@ -1141,7 +1141,7 @@ external_entity_oneshot_loader(XML_Parser parser, const XML_Char *context,
   /* Use the requested entity parser for further externals */
   XML_SetExternalEntityRefHandler(ext_parser, test_data->handler);
   if (_XML_Parse_SINGLE_BYTES(ext_parser, test_data->parse_text,
-                              (int)strlen(test_data->parse_text), XML_TRUE)
+                              strlen(test_data->parse_text), XML_TRUE)
       == XML_STATUS_ERROR) {
     xml_failure(ext_parser);
   }
@@ -1224,7 +1224,7 @@ external_entity_unfinished_attlist(XML_Parser parser, const XML_Char *context,
   if (ext_parser == NULL)
     fail("Could not create external entity parser");
 
-  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(ext_parser);
 
@@ -1254,7 +1254,7 @@ external_entity_handler(XML_Parser parser, const XML_Char *context,
   /* Set user data to any non-NULL value */
   XML_SetUserData(parser, parser);
   p2 = XML_ExternalEntityParserCreate(parser, context, NULL);
-  if (_XML_Parse_SINGLE_BYTES(p2, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(p2, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR) {
     xml_failure(p2);
     return XML_STATUS_ERROR;
@@ -1343,7 +1343,7 @@ external_entity_dbl_handler(XML_Parser parser, const XML_Char *context,
   }
 
   g_allocation_count = ALLOC_ALWAYS_SUCCEED;
-  if (_XML_Parse_SINGLE_BYTES(new_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(new_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR) {
     xml_failure(new_parser);
     return XML_STATUS_ERROR;
@@ -1374,7 +1374,7 @@ external_entity_dbl_handler_2(XML_Parser parser, const XML_Char *context,
     new_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
     if (new_parser == NULL)
       return XML_STATUS_ERROR;
-    rv = _XML_Parse_SINGLE_BYTES(new_parser, text, (int)strlen(text), XML_TRUE);
+    rv = _XML_Parse_SINGLE_BYTES(new_parser, text, strlen(text), XML_TRUE);
   } else {
     /* Just run through once */
     text = ("<?xml version='1.0' encoding='us-ascii'?>"
@@ -1382,7 +1382,7 @@ external_entity_dbl_handler_2(XML_Parser parser, const XML_Char *context,
     new_parser = XML_ExternalEntityParserCreate(parser, context, NULL);
     if (new_parser == NULL)
       return XML_STATUS_ERROR;
-    rv = _XML_Parse_SINGLE_BYTES(new_parser, text, (int)strlen(text), XML_TRUE);
+    rv = _XML_Parse_SINGLE_BYTES(new_parser, text, strlen(text), XML_TRUE);
   }
   XML_ParserFree(new_parser);
   if (rv == XML_STATUS_ERROR)
@@ -1412,7 +1412,7 @@ external_entity_alloc_set_encoding(XML_Parser parser, const XML_Char *context,
     return XML_STATUS_ERROR;
   }
   status
-      = _XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE);
+      = _XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE);
   XML_ParserFree(ext_parser);
   if (status == XML_STATUS_ERROR)
     return XML_STATUS_ERROR;
@@ -1441,7 +1441,7 @@ external_entity_reallocator(XML_Parser parser, const XML_Char *context,
     fail("Buffer allocation failed");
   assert(buffer != NULL);
   memcpy(buffer, text, strlen(text));
-  status = XML_ParseBuffer(ext_parser, (int)strlen(text), XML_FALSE);
+  status = XML_ParseBuffer(ext_parser, strlen(text), XML_FALSE);
   g_reallocation_count = -1;
   XML_ParserFree(ext_parser);
   return (status == XML_STATUS_OK) ? XML_STATUS_OK : XML_STATUS_ERROR;
@@ -1462,7 +1462,7 @@ external_entity_alloc(XML_Parser parser, const XML_Char *context,
   if (ext_parser == NULL)
     return XML_STATUS_ERROR;
   parse_res
-      = _XML_Parse_SINGLE_BYTES(ext_parser, text, (int)strlen(text), XML_TRUE);
+      = _XML_Parse_SINGLE_BYTES(ext_parser, text, strlen(text), XML_TRUE);
   XML_ParserFree(ext_parser);
   return parse_res;
 }
@@ -1523,7 +1523,7 @@ accounting_external_entity_ref_handler(XML_Parser parser,
   assert(entParser);
 
   const enum XML_Status status = _XML_Parse_SINGLE_BYTES(
-      entParser, externalText, (int)strlen(externalText), XML_TRUE);
+      entParser, externalText, strlen(externalText), XML_TRUE);
 
   XML_ParserFree(entParser);
   return status;

--- a/expat/tests/misc_tests.c
+++ b/expat/tests/misc_tests.c
@@ -298,7 +298,7 @@ START_TEST(test_misc_stop_during_end_handler_issue_240_1) {
   mydata->deep = 0;
   XML_SetUserData(parser, mydata);
 
-  result = _XML_Parse_SINGLE_BYTES(parser, doc1, (int)strlen(doc1), 1);
+  result = _XML_Parse_SINGLE_BYTES(parser, doc1, strlen(doc1), 1);
   XML_ParserFree(parser);
   free(mydata);
   if (result != XML_STATUS_ERROR)
@@ -319,7 +319,7 @@ START_TEST(test_misc_stop_during_end_handler_issue_240_2) {
   mydata->deep = 0;
   XML_SetUserData(parser, mydata);
 
-  result = _XML_Parse_SINGLE_BYTES(parser, doc2, (int)strlen(doc2), 1);
+  result = _XML_Parse_SINGLE_BYTES(parser, doc2, strlen(doc2), 1);
   XML_ParserFree(parser);
   free(mydata);
   if (result != XML_STATUS_ERROR)
@@ -366,7 +366,7 @@ START_TEST(test_misc_deny_internal_entity_closing_doctype_issue_317) {
     if (setParamEntityResult != 1)
       fail("Failed to set XML_PARAM_ENTITY_PARSING_ALWAYS.");
 
-    parseResult = _XML_Parse_SINGLE_BYTES(parser, input, (int)strlen(input), 0);
+    parseResult = _XML_Parse_SINGLE_BYTES(parser, input, strlen(input), 0);
     if (parseResult != XML_STATUS_ERROR) {
       parseResult = _XML_Parse_SINGLE_BYTES(parser, "", 0, 1);
       if (parseResult != XML_STATUS_ERROR) {
@@ -395,7 +395,7 @@ START_TEST(test_misc_tag_mismatch_reset_leak) {
   const char *const text = "<open xmlns='https://namespace1.test'></close>";
   XML_Parser parser = XML_ParserCreateNS(NULL, XCS('\n'));
 
-  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Call to parse was expected to fail");
   if (XML_GetErrorCode(parser) != XML_ERROR_TAG_MISMATCH)
@@ -403,7 +403,7 @@ START_TEST(test_misc_tag_mismatch_reset_leak) {
 
   XML_ParserReset(parser, NULL);
 
-  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Call to parse was expected to fail");
   if (XML_GetErrorCode(parser) != XML_ERROR_TAG_MISMATCH)
@@ -450,7 +450,7 @@ START_TEST(test_misc_general_entities_support) {
   XML_SetEntityDeclHandler(parser, accumulate_entity_decl);
   XML_SetCharacterDataHandler(parser, accumulate_characters);
 
-  if (_XML_Parse_SINGLE_BYTES(parser, doc, (int)strlen(doc), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(parser, doc, strlen(doc), XML_TRUE)
       != XML_STATUS_OK) {
     xml_failure(parser);
   }
@@ -492,7 +492,7 @@ START_TEST(test_misc_char_handler_stop_without_leak) {
   assert_true(parser != NULL);
   XML_SetUserData(parser, parser);
   XML_SetCharacterDataHandler(parser, resumable_stopping_character_handler);
-  _XML_Parse_SINGLE_BYTES(parser, data, (int)strlen(data), XML_FALSE);
+  _XML_Parse_SINGLE_BYTES(parser, data, strlen(data), XML_FALSE);
   XML_ParserFree(parser);
 }
 END_TEST

--- a/expat/tests/ns_tests.c
+++ b/expat/tests/ns_tests.c
@@ -79,12 +79,12 @@ START_TEST(test_return_ns_triplet) {
   g_triplet_start_flag = XML_FALSE;
   g_triplet_end_flag = XML_FALSE;
   init_dummy_handlers();
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_FALSE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   /* Check that unsetting "return triplets" fails while still parsing */
   XML_SetReturnNSTriplet(g_parser, XML_FALSE);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, epilog, (int)strlen(epilog), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, epilog, strlen(epilog), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   if (! g_triplet_start_flag)
@@ -125,7 +125,7 @@ run_ns_tagname_overwrite_test(const char *text, const XML_Char *result) {
   XML_SetUserData(g_parser, &storage);
   XML_SetElementHandler(g_parser, overwrite_start_checker,
                         overwrite_end_checker);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
   CharData_CheckXMLChars(&storage, result);
@@ -180,7 +180,7 @@ START_TEST(test_start_ns_clears_start_element) {
   XML_SetStartNamespaceDeclHandler(g_parser, start_ns_clearing_start_element);
   XML_SetEndNamespaceDeclHandler(g_parser, dummy_end_namespace_decl_handler);
   XML_UseParserAsHandlerArg(g_parser);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -201,7 +201,7 @@ START_TEST(test_default_ns_from_ext_subset_and_ext_ge) {
   /* We actually need to set this handler to tickle this bug. */
   XML_SetStartElementHandler(g_parser, dummy_start_element);
   XML_SetUserData(g_parser, NULL);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -258,7 +258,7 @@ START_TEST(test_ns_prefix_with_empty_uri_4) {
   XML_SetReturnNSTriplet(g_parser, XML_TRUE);
   XML_SetUserData(g_parser, (void *)elemstr);
   XML_SetEndElementHandler(g_parser, triplet_end_checker);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -273,7 +273,7 @@ START_TEST(test_ns_unbound_prefix) {
                      "]>\n"
                      "<prefix:doc/>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Unbound prefix incorrectly passed");
   if (XML_GetErrorCode(g_parser) != XML_ERROR_UNBOUND_PREFIX)
@@ -289,7 +289,7 @@ START_TEST(test_ns_default_with_empty_uri) {
   XML_SetStartNamespaceDeclHandler(g_parser,
                                    dummy_start_namespace_decl_handler);
   XML_SetEndNamespaceDeclHandler(g_parser, dummy_end_namespace_decl_handler);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -324,7 +324,7 @@ START_TEST(test_ns_duplicate_hashes) {
    */
   const char *text = "<doc xmlns:a='http://example.org/a'\n"
                      "     a:a='v' a:i='w' />";
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -361,7 +361,7 @@ START_TEST(test_ns_long_element) {
   XML_SetReturnNSTriplet(g_parser, XML_TRUE);
   XML_SetUserData(g_parser, (void *)elemstr);
   XML_SetElementHandler(g_parser, triplet_start_checker, triplet_end_checker);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -373,7 +373,7 @@ START_TEST(test_ns_mixed_prefix_atts) {
                      " xmlns:bar='http://example.org/'>"
                      "</e>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -388,7 +388,7 @@ START_TEST(test_ns_extend_uri_buffer) {
                      " <foo:thisisalongenoughnametotriggerallocationaction"
                      "   foo:a='12' />"
                      "</foo:e>";
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -405,7 +405,7 @@ START_TEST(test_ns_reserved_attributes) {
   expect_failure(text1, XML_ERROR_RESERVED_PREFIX_XMLNS,
                  "xmlns not rejected as an attribute");
   XML_ParserReset(g_parser, NULL);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, (int)strlen(text2), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, strlen(text2), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -511,10 +511,10 @@ START_TEST(test_ns_extremely_long_prefix) {
         "='foo'\n>"
         "</doc>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text1, (int)strlen(text1), XML_FALSE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text1, strlen(text1), XML_FALSE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, (int)strlen(text2), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text2, strlen(text2), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 }
@@ -534,7 +534,7 @@ END_TEST
 START_TEST(test_ns_double_colon) {
   const char *text = "<foo:e xmlns:foo='http://example.org/' foo:a:b='bar' />";
   const enum XML_Status status
-      = _XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE);
+      = _XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE);
 #ifdef XML_NS
   if ((status == XML_STATUS_OK)
       || (XML_GetErrorCode(g_parser) != XML_ERROR_INVALID_TOKEN)) {
@@ -553,7 +553,7 @@ END_TEST
 START_TEST(test_ns_double_colon_element) {
   const char *text = "<foo:bar:e xmlns:foo='http://example.org/' />";
   const enum XML_Status status
-      = _XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE);
+      = _XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE);
 #ifdef XML_NS
   if ((status == XML_STATUS_OK)
       || (XML_GetErrorCode(g_parser) != XML_ERROR_INVALID_TOKEN)) {
@@ -697,7 +697,7 @@ START_TEST(test_ns_separator_in_uri) {
     set_subtest("%s", cases[i].doc);
     XML_Parser parser = XML_ParserCreateNS(NULL, cases[i].namesep);
     XML_SetElementHandler(parser, dummy_start_element, dummy_end_element);
-    if (_XML_Parse_SINGLE_BYTES(parser, cases[i].doc, (int)strlen(cases[i].doc),
+    if (_XML_Parse_SINGLE_BYTES(parser, cases[i].doc, strlen(cases[i].doc),
                                 /*isFinal*/ XML_TRUE)
         != cases[i].expectedStatus) {
       failCount++;

--- a/expat/tests/nsalloc_tests.c
+++ b/expat/tests/nsalloc_tests.c
@@ -86,7 +86,7 @@ START_TEST(test_nsalloc_xmlns) {
     g_allocation_count = i;
     /* Exercise more code paths with a default handler */
     XML_SetDefaultHandler(g_parser, dummy_default_handler);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* Resetting the parser is insufficient, because some memory
@@ -140,34 +140,34 @@ START_TEST(test_nsalloc_parse_buffer) {
   /* Get the parser into suspended state */
   XML_SetCharacterDataHandler(g_parser, clearing_aborting_character_handler);
   g_resumable = XML_TRUE;
-  buffer = XML_GetBuffer(g_parser, (int)strlen(text));
+  buffer = XML_GetBuffer(g_parser, strlen(text));
   if (buffer == NULL)
     fail("Could not acquire parse buffer");
   assert(buffer != NULL);
   memcpy(buffer, text, strlen(text));
-  if (XML_ParseBuffer(g_parser, (int)strlen(text), XML_TRUE)
+  if (XML_ParseBuffer(g_parser, strlen(text), XML_TRUE)
       != XML_STATUS_SUSPENDED)
     xml_failure(g_parser);
   if (XML_GetErrorCode(g_parser) != XML_ERROR_NONE)
     xml_failure(g_parser);
-  if (XML_ParseBuffer(g_parser, (int)strlen(text), XML_TRUE)
+  if (XML_ParseBuffer(g_parser, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Suspended XML_ParseBuffer not faulted");
   if (XML_GetErrorCode(g_parser) != XML_ERROR_SUSPENDED)
     xml_failure(g_parser);
-  if (XML_GetBuffer(g_parser, (int)strlen(text)) != NULL)
+  if (XML_GetBuffer(g_parser, strlen(text)) != NULL)
     fail("Suspended XML_GetBuffer not faulted");
 
   /* Get it going again and complete the world */
   XML_SetCharacterDataHandler(g_parser, NULL);
   if (XML_ResumeParser(g_parser) != XML_STATUS_OK)
     xml_failure(g_parser);
-  if (XML_ParseBuffer(g_parser, (int)strlen(text), XML_TRUE)
+  if (XML_ParseBuffer(g_parser, strlen(text), XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Post-finishing XML_ParseBuffer not faulted");
   if (XML_GetErrorCode(g_parser) != XML_ERROR_FINISHED)
     xml_failure(g_parser);
-  if (XML_GetBuffer(g_parser, (int)strlen(text)) != NULL)
+  if (XML_GetBuffer(g_parser, strlen(text)) != NULL)
     fail("Post-finishing XML_GetBuffer not faulted");
 }
 END_TEST
@@ -234,7 +234,7 @@ START_TEST(test_nsalloc_long_prefix) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -294,7 +294,7 @@ START_TEST(test_nsalloc_long_uri) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -337,7 +337,7 @@ START_TEST(test_nsalloc_long_attr) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -423,7 +423,7 @@ START_TEST(test_nsalloc_long_attr_prefix) {
     XML_SetReturnNSTriplet(g_parser, XML_TRUE);
     XML_SetUserData(g_parser, (void *)elemstr);
     XML_SetElementHandler(g_parser, triplet_start_checker, triplet_end_checker);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -447,7 +447,7 @@ START_TEST(test_nsalloc_realloc_attributes) {
 
   for (i = 0; i < max_realloc_count; i++) {
     g_reallocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -480,7 +480,7 @@ START_TEST(test_nsalloc_long_element) {
     XML_SetReturnNSTriplet(g_parser, XML_TRUE);
     XML_SetUserData(g_parser, (void *)elemstr);
     XML_SetElementHandler(g_parser, triplet_start_checker, triplet_end_checker);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -516,7 +516,7 @@ START_TEST(test_nsalloc_realloc_binding_uri) {
   const unsigned max_realloc_count = 10;
 
   /* First, do a full parse that will leave bindings around */
-  if (_XML_Parse_SINGLE_BYTES(g_parser, first, (int)strlen(first), XML_TRUE)
+  if (_XML_Parse_SINGLE_BYTES(g_parser, first, strlen(first), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
 
@@ -524,7 +524,7 @@ START_TEST(test_nsalloc_realloc_binding_uri) {
   for (i = 0; i < max_realloc_count; i++) {
     XML_ParserReset(g_parser, NULL);
     g_reallocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, second, (int)strlen(second), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, second, strlen(second), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
   }
@@ -597,7 +597,7 @@ START_TEST(test_nsalloc_realloc_long_prefix) {
 
   for (i = 0; i < max_realloc_count; i++) {
     g_reallocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -673,7 +673,7 @@ START_TEST(test_nsalloc_realloc_longer_prefix) {
 
   for (i = 0; i < max_realloc_count; i++) {
     g_reallocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -784,9 +784,9 @@ START_TEST(test_nsalloc_long_namespace) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text1, (int)strlen(text1), XML_FALSE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text1, strlen(text1), XML_FALSE)
             != XML_STATUS_ERROR
-        && _XML_Parse_SINGLE_BYTES(g_parser, text2, (int)strlen(text2),
+        && _XML_Parse_SINGLE_BYTES(g_parser, text2, strlen(text2),
                                    XML_TRUE)
                != XML_STATUS_ERROR)
       break;
@@ -860,7 +860,7 @@ START_TEST(test_nsalloc_less_long_namespace) {
 
   for (i = 0; i < max_alloc_count; i++) {
     g_allocation_count = i;
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -911,7 +911,7 @@ START_TEST(test_nsalloc_long_context) {
     XML_SetUserData(g_parser, options);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_optioner);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
 
@@ -941,7 +941,7 @@ context_realloc_test(const char *text) {
     XML_SetUserData(g_parser, options);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_optioner);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -1224,7 +1224,7 @@ START_TEST(test_nsalloc_realloc_long_ge_name) {
     XML_SetUserData(g_parser, options);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_optioner);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
     /* See comment in test_nsalloc_xmlns() */
@@ -1329,9 +1329,9 @@ START_TEST(test_nsalloc_realloc_long_context_in_dtd) {
     XML_SetUserData(g_parser, options);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_optioner);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text1, (int)strlen(text1), XML_FALSE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text1, strlen(text1), XML_FALSE)
             != XML_STATUS_ERROR
-        && _XML_Parse_SINGLE_BYTES(g_parser, text2, (int)strlen(text2),
+        && _XML_Parse_SINGLE_BYTES(g_parser, text2, strlen(text2),
                                    XML_TRUE)
                != XML_STATUS_ERROR)
       break;
@@ -1380,7 +1380,7 @@ START_TEST(test_nsalloc_long_default_in_ext) {
     XML_SetUserData(g_parser, options);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_optioner);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
 
@@ -1449,7 +1449,7 @@ START_TEST(test_nsalloc_long_systemid_in_ext) {
     XML_SetUserData(g_parser, options);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_optioner);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
 
@@ -1485,7 +1485,7 @@ START_TEST(test_nsalloc_prefixed_element) {
     XML_SetUserData(g_parser, options);
     XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
     XML_SetExternalEntityRefHandler(g_parser, external_entity_optioner);
-    if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
+    if (_XML_Parse_SINGLE_BYTES(g_parser, text, strlen(text), XML_TRUE)
         != XML_STATUS_ERROR)
       break;
 

--- a/expat/tests/runtests.c
+++ b/expat/tests/runtests.c
@@ -102,7 +102,7 @@ main(int argc, char *argv[]) {
     for (int enabled = 0; enabled <= 1; ++enabled) {
       char context[100];
       g_reparseDeferralEnabledDefault = enabled;
-      snprintf(context, sizeof(context), "chunksize=%d deferral=%d",
+      snprintf(context, sizeof(context), "chunksize=%zu deferral=%d",
                g_chunkSize, enabled);
       context[sizeof(context) - 1] = '\0';
       srunner_run_all(sr, context, verbosity);

--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -72,7 +72,7 @@
 #  endif
 #endif
 
-int g_read_size_bytes = 1024 * 8;
+size_t g_read_size_bytes = 1024 * 8;
 
 typedef struct {
   XML_Parser parser;

--- a/expat/xmlwf/xmlfile.h
+++ b/expat/xmlwf/xmlfile.h
@@ -42,7 +42,7 @@
 #  define XML_FMT_INT_MOD "l"
 #endif
 
-extern int g_read_size_bytes;
+extern size_t g_read_size_bytes;
 
 extern int XML_ProcessFile(XML_Parser parser, const XML_Char *filename,
                            unsigned flags);

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -304,8 +304,8 @@ processingInstruction(void *userData, const XML_Char *target,
 static XML_Char *
 xcsdup(const XML_Char *s) {
   XML_Char *result;
-  int count = 0;
-  int numBytes;
+  size_t count = 0;
+  size_t numBytes;
 
   /* Get the length of the string, including terminator */
   while (s[count++] != 0) {


### PR DESCRIPTION
In the expat API calls the int len parameter will be replaced by size_t let.
Code, documentation and tests adapted.