### PR TITLE
Make Autotools-generated CMake files look for `libexpat.@SO_MAJOR@.dylib` (fixes #935)

### DIFF
--- a/.github/workflows/autotools-cmake.yml
+++ b/.github/workflows/autotools-cmake.yml
@@ -125,6 +125,20 @@ jobs:
         cd expat/expat-*.*.*/
 
         if [[ "${{ runner.os }}" == macOS ]]; then
+          # There is a known difference between Autotools and CMake for macOS:
+          #   Autotools:
+          #   - /usr/local/lib123/libexpat.<major>.dylib
+          #   - /usr/local/lib123/libexpat.dylib
+          #   CMake:
+          #   - /usr/local/lib123/libexpat.<major>.<minor>.<patch>.dylib
+          #   - /usr/local/lib123/libexpat.<major>.dylib
+          #   - /usr/local/lib123/libexpat.dylib
+          # We patch the CMake side in line here to get the differ below to empty.
+          ( cd build_cmake/ROOT/usr/local/lib*/cmake/expat-*/ \
+              && sed -E 's,(libexpat\.[0-9]+)\.[0-9]+\.[0-9]+(\.dylib),\1\2,' expat-noconfig.cmake > expat-noconfig-patched.cmake \
+              && ! diff -u0 expat-noconfig{,-patched}.cmake \
+              && mv expat-noconfig{-patched,}.cmake )
+
           # Autotools' LT_LIB_M has a hardcoded exclude for "*-*-darwin*" hosts,
           # while macOS does have libm and is successfully found by CMake.
           # We patch the CMake side in line here to get the differ below to empty.

--- a/expat/cmake/autotools/expat-noconfig__macos.cmake.in
+++ b/expat/cmake/autotools/expat-noconfig__macos.cmake.in
@@ -8,12 +8,12 @@ set(CMAKE_IMPORT_FILE_VERSION 1)
 # Import target "expat::expat" for configuration "NoConfig"
 set_property(TARGET expat::expat APPEND PROPERTY IMPORTED_CONFIGURATIONS NOCONFIG)
 set_target_properties(expat::expat PROPERTIES
-  IMPORTED_LOCATION_NOCONFIG "${_IMPORT_PREFIX}/@LIBDIR_BASENAME@/libexpat.@SO_MAJOR@.@SO_MINOR@.@SO_PATCH@.dylib"
+  IMPORTED_LOCATION_NOCONFIG "${_IMPORT_PREFIX}/@LIBDIR_BASENAME@/libexpat.@SO_MAJOR@.dylib"
   IMPORTED_SONAME_NOCONFIG "@rpath/libexpat.@SO_MAJOR@.dylib"
   )
 
 list(APPEND _cmake_import_check_targets expat::expat )
-list(APPEND _cmake_import_check_files_for_expat::expat "${_IMPORT_PREFIX}/@LIBDIR_BASENAME@/libexpat.@SO_MAJOR@.@SO_MINOR@.@SO_PATCH@.dylib" )
+list(APPEND _cmake_import_check_files_for_expat::expat "${_IMPORT_PREFIX}/@LIBDIR_BASENAME@/libexpat.@SO_MAJOR@.dylib" )
 
 # Commands beyond this point should not need to know the version.
 set(CMAKE_IMPORT_FILE_VERSION)


### PR DESCRIPTION
.. to match what Autotools is producing in reality at build time. Unlike CMake, Autotools does not produce file `libexpat.@SO_MAJOR@.@SO_MINOR@.@SO_PATCH@.dylib` when compiling on macOS.

What the commit does on the CI side is closely mimicking a similar thing with MinGW that existed until 7731dd5b90621a9e4696d1c467bca2b6ece6e3e6^ .

Fixes #935