### PR TITLE
[2.6.4] `expat.h`: minor compat fix

### DIFF
--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -132,7 +132,7 @@ enum XML_Error {
   /* Added in 2.4.0. */
   XML_ERROR_AMPLIFICATION_LIMIT_BREACH,
   /* Added in 2.6.4. */
-  XML_ERROR_NOT_STARTED,
+  XML_ERROR_NOT_STARTED
 };
 
 enum XML_Content_Type {


### PR DESCRIPTION
Fix the header, which currently breaks building some dependents:
```
cd /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/build/src/kml/base && /usr/bin/g++-4.2 -Dkmlbase_EXPORTS -I/opt/local/include -I/opt/local/libexec/boost/1.76/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src -pipe -I/opt/local/libexec/boost/1.76/include -Os -DNDEBUG -I/opt/local/libexec/boost/1.76/include -I/opt/local/include -Wall -Wextra -Wno-unused-parameter -pedantic -fno-rtti -arch ppc -mmacosx-version-min=10.6 -fPIC -MD -MT src/kml/base/CMakeFiles/kmlbase.dir/date_time.cc.o -MF CMakeFiles/kmlbase.dir/date_time.cc.o.d -o CMakeFiles/kmlbase.dir/date_time.cc.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/date_time.cc
[  5%] Building CXX object src/kml/base/CMakeFiles/kmlbase.dir/expat_parser.cc.o
cd /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/build/src/kml/base && /usr/bin/g++-4.2 -Dkmlbase_EXPORTS -I/opt/local/include -I/opt/local/libexec/boost/1.76/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src -pipe -I/opt/local/libexec/boost/1.76/include -Os -DNDEBUG -I/opt/local/libexec/boost/1.76/include -I/opt/local/include -Wall -Wextra -Wno-unused-parameter -pedantic -fno-rtti -arch ppc -mmacosx-version-min=10.6 -fPIC -MD -MT src/kml/base/CMakeFiles/kmlbase.dir/expat_parser.cc.o -MF CMakeFiles/kmlbase.dir/expat_parser.cc.o.d -o CMakeFiles/kmlbase.dir/expat_parser.cc.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/expat_parser.cc
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/expat_handler.h:31,
                 from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/expat_handler_ns.h:31,
                 from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/expat_handler_ns.cc:26:
/opt/local/include/expat.h:135: error: comma at end of enumerator list
In file included from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/expat_parser.h:37,
                 from /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/expat_parser.cc:28:
/opt/local/include/expat.h:135: error: comma at end of enumerator list
[  6%] Building CXX object src/kml/base/CMakeFiles/kmlbase.dir/file.cc.o
cd /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/build/src/kml/base && /usr/bin/g++-4.2 -Dkmlbase_EXPORTS -I/opt/local/include -I/opt/local/libexec/boost/1.76/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src -pipe -I/opt/local/libexec/boost/1.76/include -Os -DNDEBUG -I/opt/local/libexec/boost/1.76/include -I/opt/local/include -Wall -Wextra -Wno-unused-parameter -pedantic -fno-rtti -arch ppc -mmacosx-version-min=10.6 -fPIC -MD -MT src/kml/base/CMakeFiles/kmlbase.dir/file.cc.o -MF CMakeFiles/kmlbase.dir/file.cc.o.d -o CMakeFiles/kmlbase.dir/file.cc.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/file.cc
[  7%] Building CXX object src/kml/base/CMakeFiles/kmlbase.dir/file_posix.cc.o
cd /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/build/src/kml/base && /usr/bin/g++-4.2 -Dkmlbase_EXPORTS -I/opt/local/include -I/opt/local/libexec/boost/1.76/include -I/opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src -pipe -I/opt/local/libexec/boost/1.76/include -Os -DNDEBUG -I/opt/local/libexec/boost/1.76/include -I/opt/local/include -Wall -Wextra -Wno-unused-parameter -pedantic -fno-rtti -arch ppc -mmacosx-version-min=10.6 -fPIC -MD -MT src/kml/base/CMakeFiles/kmlbase.dir/file_posix.cc.o -MF CMakeFiles/kmlbase.dir/file_posix.cc.o.d -o CMakeFiles/kmlbase.dir/file_posix.cc.o -c /opt/local/var/macports/build/_opt_local_var_macports_sources_rsync.macports.org_macports_release_tarballs_ports_gis_libkml/libkml/work/libkml-1.3.0/src/kml/base/file_posix.cc
[  8%] Building CXX object src/kml/base/CMakeFiles/kmlbase.dir/math_util.cc.o
make[2]: *** [src/kml/base/CMakeFiles/kmlbase.dir/expat_handler_ns.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```