### PR TITLE
fuzzers|cmake: Stop linking `xml_lpm_fuzzer` against Abseil, explicitly

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -63,7 +63,6 @@ jobs:
       run: |-
         set -x
         sudo apt-get install --yes --no-install-recommends -V \
-            libabsl-dev \
             liblzma-dev \
             libprotobuf-dev \
             protobuf-compiler

--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -761,7 +761,6 @@ if(EXPAT_BUILD_FUZZERS)
         endforeach()
     endforeach()
 
-    find_package(absl REQUIRED)
     find_package(Protobuf REQUIRED)
 
     # Only include libprotobuf-mutator here so we don't build it in non-fuzz
@@ -804,7 +803,6 @@ if(EXPAT_BUILD_FUZZERS)
     target_include_directories(xml_lpm_fuzzer PUBLIC ${ProtobufMutator_INCLUDE_DIR})
     target_link_libraries(xml_lpm_fuzzer
                           fuzzpat
-                          ${absl_LIBRARIES}
                           ${Protobuf_LIBRARIES}
                           ${ProtobufMutator_LIBRARIES})
     add_dependencies(xml_lpm_fuzzer ${ProtobufMutator_PREFIX})


### PR DESCRIPTION
Follow-up to #950

This reverts commit d7e41e2de81768122df9fab9fe8c57bf91652f77.