### PR TITLE
Fix warning: no `-Wno-pedantic-ms-format` (`-Wunknown-warning-option`) for LLVM MinGW

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -325,7 +325,7 @@ if(FLAG_VISIBILITY)
   endif()
   set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} -fvisibility=hidden")
 endif()
-if(MINGW)
+if(MINGW AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU"))
     # Without __USE_MINGW_ANSI_STDIO the compiler produces a false positive
     set(EXTRA_COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} -Wno-pedantic-ms-format")
 endif()


### PR DESCRIPTION
ONLY gcc has `-Wno-pedantic-ms-format`:

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-pedantic-ms-format

```logs
[root@wlbvm-deb 2025-02-07 15:44:40 +0800 nativepkgs]% CROSS_TOOLCHAIN_ROOT="$PWD/toolchain/llvm-mingw" ./build_win-mingw_aarch64.sh libexpat shared
cmake -S "/root/code/nativepkgs/deps/libexpat/expat" -B "/root/code/nativepkgs/tmp/libexpat/win-mingw/aarch64"   -D CMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON     -D CMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON   -D CMAKE_INSTALL_PREFIX="/root/code/nativepkgs/out/libexpat/win-mingw/aarch64"    -D CMAKE_INSTALL_LIBDIR:PATH=lib     -D EXPAT_WARNINGS_AS_ERRORS:BOOL=1   -D EXPAT_BUILD_TOOLS:BOOL=0      -D EXPAT_BUILD_EXAMPLES:BOOL=0   -D EXPAT_BUILD_TESTS:BOOL=0      -D EXPAT_BUILD_DOCS:BOOL=0       -D EXPAT_BUILD_FUZZERS:BOOL=0    -D EXPAT_OSSFUZZ_BUILD:BOOL=0    -D EXPAT_WITH_LIBBSD:BOOL=0      -D CMAKE_BUILD_TYPE=Release -D EXPAT_SHARED_LIBS:BOOL=1  -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache -D CMAKE_TOOLCHAIN_FILE=/root/code/nativepkgs/toolchain/llvm-mingw/toolchain-cmake-template.aarch64
-- The C compiler identification is Clang 19.1.7
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /root/code/nativepkgs/toolchain/llvm-mingw/bin/aarch64-w64-mingw32-clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for dlfcn.h
-- Looking for dlfcn.h - not found
-- Looking for fcntl.h
-- Looking for fcntl.h - found
-- Looking for inttypes.h
-- Looking for inttypes.h - found
-- Looking for memory.h
-- Looking for memory.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stdlib.h
-- Looking for stdlib.h - found
-- Looking for strings.h
-- Looking for strings.h - found
-- Looking for string.h
-- Looking for string.h - found
-- Looking for sys/stat.h
-- Looking for sys/stat.h - found
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Looking for getpagesize
-- Looking for getpagesize - not found
-- Looking for mmap
-- Looking for mmap - not found
-- Looking for getrandom
-- Looking for getrandom - not found
-- Looking for arc4random_buf
-- Looking for arc4random_buf - not found
-- Looking for arc4random
-- Looking for arc4random - not found
-- Looking for 4 include files stdlib.h, ..., float.h
-- Looking for 4 include files stdlib.h, ..., float.h - found
-- Performing Test HAVE_OFF_T
-- Performing Test HAVE_OFF_T - Success
-- Performing Test HAVE_SYSCALL_GETRANDOM
-- Performing Test HAVE_SYSCALL_GETRANDOM - Failed
-- Performing Test FLAG_NO_STRICT_ALIASING
-- Performing Test FLAG_NO_STRICT_ALIASING - Success
-- Performing Test FLAG_VISIBILITY
-- Performing Test FLAG_VISIBILITY - Success
-- Looking for cos in m
-- Looking for cos in m - found
-- ===========================================================================
-- 
-- Configuration
--   Generator .................. Unix Makefiles
--   Build type ................. Release
--   Prefix ..................... /root/code/nativepkgs/out/libexpat/win-mingw/aarch64
--   Shared libraries ........... 1
--   Character type ............. char (UTF-8)
--   Library name postfix ....... 
-- 
--   Build documentation ........ 0
--   Build examples ............. 0
--   Build fuzzers .............. 0
--   Build tests ................ 0
--   Build tools (xmlwf) ........ 0
--   Build pkg-config file ...... ON
--   Install files .............. ON
-- 
--   Features
--     // Advanced options, changes not advised
--     Attributes info .......... OFF
--     Context bytes ............ 1024
--     DTD support .............. ON
--     General entities ......... ON
--     Large size ............... OFF
--     Minimum size ............. OFF
--     Namespace support ........ ON
-- 
--   Entropy sources
--     rand_s ................... ON
-- 
-- Continue with
--   make
--   sudo make install
-- 
-- ===========================================================================
-- Configuring done (7.0s)
-- Generating done (0.0s)
-- Build files have been written to: /root/code/nativepkgs/tmp/libexpat/win-mingw/aarch64
[ 20%] Building C object CMakeFiles/expat.dir/lib/xmlparse.c.obj
[ 40%] Building RC object CMakeFiles/expat.dir/win32/version.rc.res
[ 60%] Building C object CMakeFiles/expat.dir/lib/xmltok.c.obj
[ 80%] Building C object CMakeFiles/expat.dir/lib/xmlrole.c.obj
error: unknown warning option '-Wno-pedantic-ms-format'; did you mean '-Wno-pedantic-macros'? [-Werror,-Wunknown-warning-option]
gmake[2]: *** [CMakeFiles/expat.dir/build.make:92: CMakeFiles/expat.dir/lib/xmlrole.c.obj] Error 1
gmake[2]: *** Waiting for unfinished jobs....
error: unknown warning option '-Wno-pedantic-ms-format'; did you mean '-Wno-pedantic-macros'? [-Werror,-Wunknown-warning-option]
gmake[2]: *** [CMakeFiles/expat.dir/build.make:77: CMakeFiles/expat.dir/lib/xmlparse.c.obj] Error 1
error: unknown warning option '-Wno-pedantic-ms-format'; did you mean '-Wno-pedantic-macros'? [-Werror,-Wunknown-warning-option]
gmake[2]: *** [CMakeFiles/expat.dir/build.make:107: CMakeFiles/expat.dir/lib/xmltok.c.obj] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/expat.dir/all] Error 2
gmake: *** [Makefile:156: all] Error 2
```