### PR TITLE
Drop support for CMake <3.13

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -35,7 +35,7 @@
 # Unlike most of Expat,
 # this file is copyrighted under the BSD-license for buildsystem files of KDE.
 
-cmake_minimum_required(VERSION 3.10.0)
+cmake_minimum_required(VERSION 3.13.0)
 
 project(expat
     VERSION


### PR DESCRIPTION
Because libprotobuf-mutator with tests enabled [already needs CMake >=3.13 in practice](https://github.com/google/libprotobuf-mutator/pull/276).

PS: Near-end-of-life Ubuntu "focal" 20.04 LTS has [CMake 3.16.3](https://packages.ubuntu.com/focal/cmake) and Debian "bullseye" old(!)stable has [CMake 3.18.4](https://packages.debian.org/bullseye/cmake).