### PR TITLE
Update links in code comments to HTTPS

### DIFF
--- a/expat/fuzz/xml_parse_fuzzer.c
+++ b/expat/fuzz/xml_parse_fuzzer.c
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/expat/fuzz/xml_parsebuffer_fuzzer.c
+++ b/expat/fuzz/xml_parsebuffer_fuzzer.c
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/expat/qa.sh
+++ b/expat/qa.sh
@@ -83,7 +83,7 @@ populate_environment() {
     if [[ ${QA_COMPILER} = clang ]]; then
         case "${QA_SANITIZER}" in
             address)
-                # http://clang.llvm.org/docs/AddressSanitizer.html
+                # https://clang.llvm.org/docs/AddressSanitizer.html
                 BASE_COMPILE_FLAGS+=" -g -fsanitize=address -fno-omit-frame-pointer -fno-common"
                 BASE_LINK_FLAGS+=" -g -fsanitize=address"
                 # macOS's XCode does not support LeakSanitizer and reports error:
@@ -97,11 +97,11 @@ populate_environment() {
                 BASE_LINK_FLAGS+=' -fuse-ld=gold'
                 ;;
             memory)
-                # http://clang.llvm.org/docs/MemorySanitizer.html
+                # https://clang.llvm.org/docs/MemorySanitizer.html
                 BASE_COMPILE_FLAGS+=" -fsanitize=memory -fno-omit-frame-pointer -g -O2 -fsanitize-memory-track-origins -fsanitize-blacklist=$PWD/memory-sanitizer-blacklist.txt"
                 ;;
             undefined)
-                # http://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+                # https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
                 BASE_COMPILE_FLAGS+=" -fsanitize=undefined"
                 BASE_LINK_FLAGS+=" -fsanitize=undefined"
                 export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:abort_on_error=1"

--- a/expat/tests/xmltest.sh
+++ b/expat/tests/xmltest.sh
@@ -2,8 +2,8 @@
 # EXPAT TEST SCRIPT FOR W3C XML TEST SUITE
 #
 # This script can be used to exercise Expat against the
-# w3c.org xml test suite, available from
-# http://www.w3.org/XML/Test/xmlts20020606.zip.
+# w3c.org xml test suite, available from:
+# https://www.w3.org/XML/Test/xmlts20020606.zip
 #
 # To run this script, first set XMLWF below so that xmlwf can be
 # found, then set the output directory with OUTPUT.


### PR DESCRIPTION
This updates a few http links to their https version.

In one case, I made an additional change. In xmltest.sh, the URL ended with a dot, which was part of the sentence. I found that not ideal and changed it so there's a : before and the url itself is no longer part of the sentence.
