### PR TITLE
Re-enable clang-tidy warning `clang-analyzer-valist.Uninitialized`

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -46,6 +46,8 @@ Release 2.7.1 ??? ????? ?? ????
 
         Infrastructure:
             #987  CI: Enforce Clang Static Analyzer clean code
+            #991  CI: Re-enable warning clang-analyzer-valist.Uninitialized
+                    for clang-tidy
             #981  CI: Cover compilation with musl
        #983 #984  CI: Cover compilation with 32bit Emscripten
        #976 #977  CI: Protect against fuzzer files missing from future

--- a/expat/apply-clang-tidy.sh
+++ b/expat/apply-clang-tidy.sh
@@ -44,9 +44,6 @@ checks_to_disable=(
 
     # Used only in xmlwf, manually checked to be good enough for now
     clang-analyzer-security.insecureAPI.strcpy
-
-    # Disabling because buggy, see https://github.com/llvm/llvm-project/issues/40656
-    clang-analyzer-valist.Uninitialized
 )
 checks_to_disable_flat="${checks_to_disable[*]}"  # i.e. flat string separated by spaces
 


### PR DESCRIPTION
In reaction to https://github.com/llvm/llvm-project/issues/40656#issuecomment-2561999174

Thanks to @vszakats