### PR TITLE
Address clang-tidy warning `misc-no-recursion`

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -41,7 +41,7 @@ Release 2.7.2 ??? ????? ?? ????
         Other changes:
             #994  docs: Drop AppVeyor badge
            #1000  tests: Fix portable_strndup
-            #999  Address more clang-tidy warnings
+      #999 #1001  Address more clang-tidy warnings
 
         Special thanks to:
             Alexander Bluhm

--- a/expat/apply-clang-tidy.sh
+++ b/expat/apply-clang-tidy.sh
@@ -35,6 +35,7 @@ cd "$(dirname "$(type -P "$0")")"
 checks_to_enable=(
     bugprone-narrowing-conversions
     bugprone-suspicious-string-compare
+    misc-no-recursion
     readability-avoid-const-params-in-decls
     readability-named-parameter
 )

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1015,9 +1015,10 @@ generate_hash_secret_salt(XML_Parser parser) {
 
 static unsigned long
 get_hash_secret_salt(XML_Parser parser) {
-  if (parser->m_parentParser != NULL)
-    return get_hash_secret_salt(parser->m_parentParser);
-  return parser->m_hash_secret_salt;
+  const XML_Parser rootParser = getRootParserOf(parser, NULL);
+  assert(! rootParser->m_parentParser);
+
+  return rootParser->m_hash_secret_salt;
 }
 
 static enum XML_Error
@@ -2017,12 +2018,14 @@ int XMLCALL
 XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
   if (parser == NULL)
     return 0;
-  if (parser->m_parentParser)
-    return XML_SetHashSalt(parser->m_parentParser, hash_salt);
+
+  const XML_Parser rootParser = getRootParserOf(parser, NULL);
+  assert(! rootParser->m_parentParser);
+
   /* block after XML_Parse()/XML_ParseBuffer() has been called */
-  if (parserBusy(parser))
+  if (parserBusy(rootParser))
     return 0;
-  parser->m_hash_secret_salt = hash_salt;
+  rootParser->m_hash_secret_salt = hash_salt;
   return 1;
 }
 

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -627,10 +627,10 @@ static void entityTrackingOnOpen(XML_Parser parser, ENTITY *entity,
                                  int sourceLine);
 static void entityTrackingOnClose(XML_Parser parser, ENTITY *entity,
                                   int sourceLine);
+#endif /* XML_GE == 1 */
 
 static XML_Parser getRootParserOf(XML_Parser parser,
                                   unsigned int *outLevelDiff);
-#endif /* XML_GE == 1 */
 
 static unsigned long getDebugLevel(const char *variableName,
                                    unsigned long defaultDebugLevel);
@@ -8288,6 +8288,8 @@ entityTrackingOnClose(XML_Parser originParser, ENTITY *entity, int sourceLine) {
   rootParser->m_entity_stats.currentDepth--;
 }
 
+#endif /* XML_GE == 1 */
+
 static XML_Parser
 getRootParserOf(XML_Parser parser, unsigned int *outLevelDiff) {
   XML_Parser rootParser = parser;
@@ -8302,6 +8304,8 @@ getRootParserOf(XML_Parser parser, unsigned int *outLevelDiff) {
   }
   return rootParser;
 }
+
+#if XML_GE == 1
 
 const char *
 unsignedCharToPrintable(unsigned char c) {


### PR DESCRIPTION
CC @jasonthorsness