### PR TITLE
CMake: Specify MSVCRT flag explicitly

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -360,6 +360,7 @@ if (MSVC)
                 )
             string(REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
         endforeach()
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     endif()
 endif()
 


### PR DESCRIPTION
Newer versions of CMake (3.15 and up) have an explicit flag that chooses the msvc runtime library: [CMAKE_MSVC_RUNTIME_LIBRARY](https://cmake.org/cmake/help/v4.0/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html). This PR solves the issue, where iff `EXPAT_MSVC_STATIC_CRT` is set to ON, then the file generated could still be created with the shared runtime. 

By ensuring the cmake flag is set to the static flag in case expat_msvc_static is ON, everything works as intended