### PR TITLE
`freebsd.yml`: Downgrade to FreeBSD 14.3 to fix CI for the moment

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -48,7 +48,7 @@ jobs:
 
     - uses: vmactions/freebsd-vm@966989c456d41351f095a421f60e71342d3bce41  # v1.2.1
       with:
-        release: "15.0"
+        release: "14.3"
         usesh: true
 
         prepare: |


### PR DESCRIPTION
Related: https://github.com/vmactions/freebsd-vm/issues/108