### PR TITLE
Fix CI / `autotools-cmake.yml`: Fix "brew install cmake" for macOS

### DIFF
--- a/.github/workflows/autotools-cmake.yml
+++ b/.github/workflows/autotools-cmake.yml
@@ -78,6 +78,7 @@ jobs:
     - name: (macOS) Install build dependencies
       if: "${{ runner.os == 'macOS' }}"
       run: |
+        brew uninstall cmake
         brew install \
             autoconf \
             automake \


### PR DESCRIPTION
The symptom was:

```
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.

To install this version, you must first uninstall the existing formula:
  brew uninstall cmake
Then you can install the desired version:
  brew install cmake
```