### PR TITLE
[draft] Fix CI / autotools: Sync CMake templates with CMake 3.31 (for Linux and Windows)

### DIFF
--- a/.github/workflows/autotools-cmake.yml
+++ b/.github/workflows/autotools-cmake.yml
@@ -51,10 +51,10 @@ jobs:
           - os: macos-14
             configure_args:
             cmake_args:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             configure_args:
             cmake_args:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             configure_args: --host=i686-w64-mingw32
             cmake_args: -DCMAKE_TOOLCHAIN_FILE=cmake/mingw-toolchain.cmake
     defaults:

--- a/expat/Changes
+++ b/expat/Changes
@@ -43,8 +43,13 @@
 
 Release 2.7.4 ??? ????????? ?? ????
         Other changes:
+           #1040  Autotools: Sync CMake templates with CMake 3.31 for Linux
+                    and Windows
            #1066  docs: Be explicit that parent parsers need to outlive
                     subparsers
+
+        Infrastructure:
+           #1040  CI: Adapt to breaking changes in GitHub Actions
 
 Release 2.7.3 Wed September 24 2025
         Security fixes:

--- a/expat/cmake/autotools/expat__linux.cmake.in
+++ b/expat/cmake/autotools/expat__linux.cmake.in
@@ -7,7 +7,7 @@ if(CMAKE_VERSION VERSION_LESS "2.8.12")
    message(FATAL_ERROR "CMake >= 2.8.12 required")
 endif()
 cmake_policy(PUSH)
-cmake_policy(VERSION 2.8.12...3.29)
+cmake_policy(VERSION 2.8.12...3.31)
 #----------------------------------------------------------------
 # Generated CMake target import file.
 #----------------------------------------------------------------

--- a/expat/cmake/autotools/expat__windows.cmake.in
+++ b/expat/cmake/autotools/expat__windows.cmake.in
@@ -7,7 +7,7 @@ if(CMAKE_VERSION VERSION_LESS "2.8.12")
    message(FATAL_ERROR "CMake >= 2.8.12 required")
 endif()
 cmake_policy(PUSH)
-cmake_policy(VERSION 2.8.12...3.29)
+cmake_policy(VERSION 2.8.12...3.31)
 #----------------------------------------------------------------
 # Generated CMake target import file.
 #----------------------------------------------------------------


### PR DESCRIPTION
It should be noted that GitHub Actions is transitioning related image `ubuntu-22.04` at the moment and so a CI run does roulette on these two images:
- Version: 202509**07.50**.1 — CMake 3.**29**
- Version: 202509**15.62**.1 — CMake 3.**31**
