### PR TITLE
Fix alignment of internal allocations for some non-amd64 architectures (e.g. sparc32) (fixes #1046)

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -42,6 +42,11 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Release 2.7.3 ??? ????????? ?? ????
+        Bug fixes:
+     #1046 #1047  Fix alignment of internal allocations for some non-amd64
+                    architectures (e.g. sparc32); fixes up on the fix to
+                    CVE-2025-59375 in release 2.7.2 from #1034
+
         Other changes:
            #1043  Prove and regression-proof absence of integer overflow
                     from function expat_realloc
@@ -49,7 +54,9 @@ Release 2.7.3 ??? ????????? ?? ????
 
         Special thanks to:
             Matthew Fernandez
+            Rolf Eike Beer
                  and
+            Clang/GCC UndefinedBehaviorSanitizer
             Z3 Theorem Prover
 
 Release 2.7.2 Tue September 16 2025

--- a/expat/lib/internal.h
+++ b/expat/lib/internal.h
@@ -108,6 +108,7 @@
 #endif
 
 #include <limits.h> // ULONG_MAX
+#include <stddef.h> // size_t
 
 #if defined(_WIN32)                                                            \
     && (! defined(__USE_MINGW_ANSI_STDIO)                                      \
@@ -152,6 +153,11 @@
 #define EXPAT_ALLOC_TRACKER_MAXIMUM_AMPLIFICATION_DEFAULT 100.0f
 #define EXPAT_ALLOC_TRACKER_ACTIVATION_THRESHOLD_DEFAULT                       \
   67108864 // 64 MiB, 2^26
+
+// NOTE: If function expat_alloc was user facing, EXPAT_MALLOC_ALIGNMENT would
+//       have to take sizeof(long double) into account
+#define EXPAT_MALLOC_ALIGNMENT sizeof(long long) // largest parser (sub)member
+#define EXPAT_MALLOC_PADDING ((EXPAT_MALLOC_ALIGNMENT) - sizeof(size_t))
 
 /* NOTE END */
 

--- a/expat/tests/alloc_tests.c
+++ b/expat/tests/alloc_tests.c
@@ -2362,14 +2362,12 @@ make_alloc_test_case(Suite *s) {
   tcase_add_test__ifdef_xml_dtd(
       tc_alloc, test_alloc_reset_after_external_entity_parser_create_fail);
 
-  tcase_add_test__ifdef_xml_dtd(tc_alloc, test_alloc_tracker_size_recorded);
-  tcase_add_test__ifdef_xml_dtd(tc_alloc,
-                                test_alloc_tracker_maximum_amplification);
-  tcase_add_test__ifdef_xml_dtd(tc_alloc, test_alloc_tracker_threshold);
-  tcase_add_test__ifdef_xml_dtd(tc_alloc,
-                                test_alloc_tracker_getbuffer_unlimited);
-  tcase_add_test__ifdef_xml_dtd(tc_alloc, test_alloc_tracker_api);
+  tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_size_recorded);
+  tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_maximum_amplification);
+  tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_threshold);
+  tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_getbuffer_unlimited);
+  tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_api);
 
   tcase_add_test(tc_alloc, test_mem_api_cycle);
-  tcase_add_test__ifdef_xml_dtd(tc_alloc, test_mem_api_unlimited);
+  tcase_add_test__if_xml_ge(tc_alloc, test_mem_api_unlimited);
 }

--- a/expat/tests/alloc_tests.c
+++ b/expat/tests/alloc_tests.c
@@ -2132,6 +2132,22 @@ START_TEST(test_alloc_tracker_size_recorded) {
 }
 END_TEST
 
+START_TEST(test_alloc_tracker_pointer_alignment) {
+  XML_Parser parser = XML_ParserCreate(NULL);
+#if XML_GE == 1
+  assert_true(sizeof(long long) >= sizeof(size_t)); // self-test
+  long long *const ptr
+      = (long long *)expat_malloc(parser, 4 * sizeof(long long), -1);
+  ptr[0] = 0LL;
+  ptr[1] = 1LL;
+  ptr[2] = 2LL;
+  ptr[3] = 3LL;
+  expat_free(parser, ptr, -1);
+#endif
+  XML_ParserFree(parser);
+}
+END_TEST
+
 START_TEST(test_alloc_tracker_maximum_amplification) {
   if (g_reparseDeferralEnabledDefault == XML_TRUE) {
     return;
@@ -2363,6 +2379,7 @@ make_alloc_test_case(Suite *s) {
       tc_alloc, test_alloc_reset_after_external_entity_parser_create_fail);
 
   tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_size_recorded);
+  tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_pointer_alignment);
   tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_maximum_amplification);
   tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_threshold);
   tcase_add_test__if_xml_ge(tc_alloc, test_alloc_tracker_getbuffer_unlimited);

--- a/expat/tests/alloc_tests.c
+++ b/expat/tests/alloc_tests.c
@@ -2091,6 +2091,13 @@ START_TEST(test_alloc_reset_after_external_entity_parser_create_fail) {
 }
 END_TEST
 
+#if XML_GE == 1
+static size_t
+sizeRecordedFor(void *ptr) {
+  return *(size_t *)((char *)ptr - EXPAT_MALLOC_PADDING - sizeof(size_t));
+}
+#endif // XML_GE == 1
+
 START_TEST(test_alloc_tracker_size_recorded) {
   XML_Memory_Handling_Suite memsuite = {malloc, realloc, free};
 
@@ -2106,16 +2113,16 @@ START_TEST(test_alloc_tracker_size_recorded) {
     void *ptr = expat_malloc(parser, 10, -1);
 
     assert_true(ptr != NULL);
-    assert_true(*((size_t *)ptr - 1) == 10);
+    assert_true(sizeRecordedFor(ptr) == 10);
 
     assert_true(expat_realloc(parser, ptr, SIZE_MAX / 2, -1) == NULL);
 
-    assert_true(*((size_t *)ptr - 1) == 10); // i.e. unchanged
+    assert_true(sizeRecordedFor(ptr) == 10); // i.e. unchanged
 
     ptr = expat_realloc(parser, ptr, 20, -1);
 
     assert_true(ptr != NULL);
-    assert_true(*((size_t *)ptr - 1) == 20);
+    assert_true(sizeRecordedFor(ptr) == 20);
 
     expat_free(parser, ptr, -1);
 #endif


### PR DESCRIPTION
Fixes #1046, follow-up to #1034

CC @DerDakon @Smattr