### PR TITLE
`xmlwf`: Resolve use of functions `XML_GetErrorLineNumber` and `XML_GetErrorColumnNumber`

### DIFF
--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -96,8 +96,8 @@ reportError(XML_Parser parser, const XML_Char *filename) {
     ftprintf(stdout,
              T("%s") T(":%") T(XML_FMT_INT_MOD) T("u") T(":%")
                  T(XML_FMT_INT_MOD) T("u") T(": %s\n"),
-             filename, XML_GetErrorLineNumber(parser),
-             XML_GetErrorColumnNumber(parser), message);
+             filename, XML_GetCurrentLineNumber(parser),
+             XML_GetCurrentColumnNumber(parser), message);
   else
     ftprintf(stderr, T("%s: (unknown message %u)\n"), filename,
              (unsigned int)code);


### PR DESCRIPTION
In reaction to https://github.com/python/cpython/pull/139234#discussion_r2369500837

These functions no longer exist and calling them only worked because of these alias macros:

```console
$ git grep XML_GetError | grep -v XML_GetErrorCode
lib/expat.h:#  define XML_GetErrorLineNumber XML_GetCurrentLineNumber
lib/expat.h:#  define XML_GetErrorColumnNumber XML_GetCurrentColumnNumber
lib/expat.h:#  define XML_GetErrorByteIndex XML_GetCurrentByteIndex
```

CC @picnixz