### PR TITLE
[DRAFT] Add public formatting macros

### DIFF
--- a/expat/examples/element_declarations.c
+++ b/expat/examples/element_declarations.c
@@ -43,12 +43,6 @@
 #include <stdlib.h>
 #include <expat.h>
 
-#ifdef XML_LARGE_SIZE
-#  define XML_FMT_INT_MOD "ll"
-#else
-#  define XML_FMT_INT_MOD "l"
-#endif
-
 #ifdef XML_UNICODE_WCHAR_T
 #  define XML_FMT_STR "ls"
 #else
@@ -223,7 +217,7 @@ main(void) {
         errorCode = XML_ERROR_NO_MEMORY;
       }
       fprintf(stderr,
-              "Parse error at line %" XML_FMT_INT_MOD "u:\n%" XML_FMT_STR "\n",
+              "Parse error at line " XML_FMT_XML_SIZE() ":\n%" XML_FMT_STR "\n",
               XML_GetCurrentLineNumber(parser), XML_ErrorString(errorCode));
       XML_ParserFree(parser);
       return 1;

--- a/expat/examples/elements.c
+++ b/expat/examples/elements.c
@@ -42,12 +42,6 @@
 #include <stdio.h>
 #include <expat.h>
 
-#ifdef XML_LARGE_SIZE
-#  define XML_FMT_INT_MOD "ll"
-#else
-#  define XML_FMT_INT_MOD "l"
-#endif
-
 #ifdef XML_UNICODE_WCHAR_T
 #  define XML_FMT_STR "ls"
 #else
@@ -108,7 +102,7 @@ main(void) {
 
     if (XML_ParseBuffer(parser, (int)len, done) == XML_STATUS_ERROR) {
       fprintf(stderr,
-              "Parse error at line %" XML_FMT_INT_MOD "u:\n%" XML_FMT_STR "\n",
+              "Parse error at line " XML_FMT_XML_SIZE() ":\n%" XML_FMT_STR "\n",
               XML_GetCurrentLineNumber(parser),
               XML_ErrorString(XML_GetErrorCode(parser)));
       XML_ParserFree(parser);

--- a/expat/examples/outline.c
+++ b/expat/examples/outline.c
@@ -39,12 +39,6 @@
 #include <stdio.h>
 #include <expat.h>
 
-#ifdef XML_LARGE_SIZE
-#  define XML_FMT_INT_MOD "ll"
-#else
-#  define XML_FMT_INT_MOD "l"
-#endif
-
 #ifdef XML_UNICODE_WCHAR_T
 #  define XML_FMT_STR "ls"
 #else
@@ -111,7 +105,7 @@ main(void) {
 
     if (XML_ParseBuffer(parser, (int)len, done) == XML_STATUS_ERROR) {
       fprintf(stderr,
-              "Parse error at line %" XML_FMT_INT_MOD "u:\n%" XML_FMT_STR "\n",
+              "Parse error at line " XML_FMT_XML_SIZE() ":\n%" XML_FMT_STR "\n",
               XML_GetCurrentLineNumber(parser),
               XML_ErrorString(XML_GetErrorCode(parser)));
       XML_ParserFree(parser);

--- a/expat/lib/expat_external.h
+++ b/expat/lib/expat_external.h
@@ -159,6 +159,30 @@ typedef long XML_Index;
 typedef unsigned long XML_Size;
 #  endif /* XML_LARGE_SIZE */
 
+// Define macros to aid use of XML_Size and XML_Index in calls to printf
+// e.g. fprintf(stderr, "Error at line " XML_FMT_XML_SIZE() " line, "
+//                      "column " XML_FMT_XML_SIZE() ".\n", line, column);
+// Added in Expat 2.7.3.
+#  if defined(_WIN32)                                                          \
+      && (! defined(__USE_MINGW_ANSI_STDIO)                                    \
+          || (1 - __USE_MINGW_ANSI_STDIO - 1 == 0))
+#    ifdef XML_LARGE_SIZE // Use large integers for file/stream positions.
+#      define XML_FMT_XML_INDEX(midpart) "%" midpart "I64d"
+#      define XML_FMT_XML_SIZE(midpart) "%" midpart "I64u"
+#    else
+#      define XML_FMT_XML_INDEX(midpart) "%" midpart "I32d"
+#      define XML_FMT_XML_SIZE(midpart) "%" midpart "I32u"
+#    endif
+#  else
+#    ifdef XML_LARGE_SIZE // Use large integers for file/stream positions.
+#      define XML_FMT_XML_INDEX(midpart) "%" midpart "lld"
+#      define XML_FMT_XML_SIZE(midpart) "%" midpart "llu"
+#    else
+#      define XML_FMT_XML_INDEX(midpart) "%" midpart "ld"
+#      define XML_FMT_XML_SIZE(midpart) "%" midpart "lu"
+#    endif
+#  endif
+
 #  ifdef __cplusplus
 }
 #  endif

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -611,7 +611,7 @@ START_TEST(test_line_number_after_parse) {
   if (lineno != 4) {
     char buffer[100];
     snprintf(buffer, sizeof(buffer),
-             "expected 4 lines, saw %" XML_FMT_INT_MOD "u", lineno);
+             "expected 4 lines, saw " XML_FMT_XML_SIZE(), lineno);
     fail(buffer);
   }
 }
@@ -629,7 +629,7 @@ START_TEST(test_column_number_after_parse) {
   if (colno != 11) {
     char buffer[100];
     snprintf(buffer, sizeof(buffer),
-             "expected 11 columns, saw %" XML_FMT_INT_MOD "u", colno);
+             "expected 11 columns, saw " XML_FMT_XML_SIZE(), colno);
     fail(buffer);
   }
 }
@@ -681,7 +681,7 @@ START_TEST(test_line_number_after_error) {
   if (lineno != 3) {
     char buffer[100];
     snprintf(buffer, sizeof(buffer),
-             "expected 3 lines, saw %" XML_FMT_INT_MOD "u", lineno);
+             "expected 3 lines, saw " XML_FMT_XML_SIZE(), lineno);
     fail(buffer);
   }
 }
@@ -701,7 +701,7 @@ START_TEST(test_column_number_after_error) {
   if (colno != 4) {
     char buffer[100];
     snprintf(buffer, sizeof(buffer),
-             "expected 4 columns, saw %" XML_FMT_INT_MOD "u", colno);
+             "expected 4 columns, saw " XML_FMT_XML_SIZE(), colno);
     fail(buffer);
   }
 }

--- a/expat/tests/benchmark/benchmark.c
+++ b/expat/tests/benchmark/benchmark.c
@@ -48,12 +48,6 @@
 #include <time.h>
 #include "expat.h"
 
-#ifdef XML_LARGE_SIZE
-#  define XML_FMT_INT_MOD "ll"
-#else
-#  define XML_FMT_INT_MOD "l"
-#endif
-
 #ifdef XML_UNICODE_WCHAR_T
 #  define XML_FMT_STR "ls"
 #else
@@ -147,12 +141,13 @@ main(int argc, char *argv[]) {
         parseBufferSize = bufferSize;
       assert(parseBufferSize <= (ptrdiff_t)bufferSize);
       if (! XML_Parse(parser, XMLBufPtr, (int)parseBufferSize, isFinal)) {
-        fprintf(stderr,
-                "error '%" XML_FMT_STR "' at line %" XML_FMT_INT_MOD
-                "u character %" XML_FMT_INT_MOD "u\n",
-                XML_ErrorString(XML_GetErrorCode(parser)),
-                XML_GetCurrentLineNumber(parser),
-                XML_GetCurrentColumnNumber(parser));
+        fprintf(
+            stderr,
+            "error '%" XML_FMT_STR
+            "' at line " XML_FMT_XML_SIZE() " character " XML_FMT_XML_SIZE() "\n",
+            XML_ErrorString(XML_GetErrorCode(parser)),
+            XML_GetCurrentLineNumber(parser),
+            XML_GetCurrentColumnNumber(parser));
         free(XMLBuf);
         XML_ParserFree(parser);
         return 4;

--- a/expat/tests/common.c
+++ b/expat/tests/common.c
@@ -183,11 +183,12 @@ void
 _xml_failure(XML_Parser parser, const char *file, int line) {
   char buffer[1024];
   enum XML_Error err = XML_GetErrorCode(parser);
-  snprintf(buffer, sizeof(buffer),
-           "    %d: %" XML_FMT_STR " (line %" XML_FMT_INT_MOD
-           "u, offset %" XML_FMT_INT_MOD "u)\n    reported from %s, line %d\n",
-           err, XML_ErrorString(err), XML_GetCurrentLineNumber(parser),
-           XML_GetCurrentColumnNumber(parser), file, line);
+  snprintf(
+      buffer, sizeof(buffer),
+      "    %d: %" XML_FMT_STR
+      " (line " XML_FMT_XML_SIZE() ", offset " XML_FMT_XML_SIZE() ")\n    reported from %s, line %d\n",
+      err, XML_ErrorString(err), XML_GetCurrentLineNumber(parser),
+      XML_GetCurrentColumnNumber(parser), file, line);
   _fail(file, line, buffer);
 }
 

--- a/expat/tests/common.h
+++ b/expat/tests/common.h
@@ -52,12 +52,6 @@ extern "C" {
 #  include "minicheck.h"
 #  include "chardata.h"
 
-#  ifdef XML_LARGE_SIZE
-#    define XML_FMT_INT_MOD "ll"
-#  else
-#    define XML_FMT_INT_MOD "l"
-#  endif
-
 #  ifdef XML_UNICODE_WCHAR_T
 #    define XML_FMT_STR "ls"
 #    include <wchar.h>

--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -94,8 +94,8 @@ reportError(XML_Parser parser, const XML_Char *filename) {
   const XML_Char *message = XML_ErrorString(code);
   if (message)
     ftprintf(stdout,
-             T("%s") T(":%") T(XML_FMT_INT_MOD) T("u") T(":%")
-                 T(XML_FMT_INT_MOD) T("u") T(": %s\n"),
+             T("%s") T(":") T(XML_FMT_XML_SIZE()) T(":") T(XML_FMT_XML_SIZE())
+                 T(": %s\n"),
              filename, XML_GetCurrentLineNumber(parser),
              XML_GetCurrentColumnNumber(parser), message);
   else

--- a/expat/xmlwf/xmlfile.h
+++ b/expat/xmlwf/xmlfile.h
@@ -36,12 +36,6 @@
 #define XML_MAP_FILE 01
 #define XML_EXTERNAL_ENTITIES 02
 
-#ifdef XML_LARGE_SIZE
-#  define XML_FMT_INT_MOD "ll"
-#else
-#  define XML_FMT_INT_MOD "l"
-#endif
-
 extern int g_read_size_bytes;
 
 extern int XML_ProcessFile(XML_Parser parser, const XML_Char *filename,

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -563,9 +563,9 @@ metaLocation(XML_Parser parser) {
   if (uri)
     ftprintf(fp, T(" uri=\"%s\""), uri);
   ftprintf(fp,
-           T(" byte=\"%") T(XML_FMT_INT_MOD) T("d\"") T(" nbytes=\"%d\"")
-               T(" line=\"%") T(XML_FMT_INT_MOD) T("u\"") T(" col=\"%")
-                   T(XML_FMT_INT_MOD) T("u\""),
+           T(" byte=\"") T(XML_FMT_XML_INDEX()) T("\"") T(" nbytes=\"%d\"")
+               T(" line=\"") T(XML_FMT_XML_SIZE()) T("\"") T(" col=\"")
+                   T(XML_FMT_XML_SIZE()) T("\""),
            XML_GetCurrentByteIndex(parser), XML_GetCurrentByteCount(parser),
            XML_GetCurrentLineNumber(parser),
            XML_GetCurrentColumnNumber(parser));


### PR DESCRIPTION
In reaction to https://github.com/libexpat/libexpat/pull/1053#pullrequestreview-3254775106

This is a draft at the moment because:
- It is not clear yet if this is the right direction and worth completing
- The new macros would only be of use to projects where Expat >=2.7.3 is an acceptable dependency
- It needs tests
- Existing macro `XML_FMT_STR` would arguably need a similar approach to fully solve the duplication
- Emscripten support is still missing
- Last but not least: CI is red :smiley: 

Technically, this is inspired heavily by the existing internal…

https://github.com/libexpat/libexpat/blob/2e2c866437ab3f67eee67057afa9108cf9545730/expat/lib/internal.h#L113-L138

…that addresses `size_t`, `ptrdiff_t` and `unsigned long long`.

CC @picnixz