### PR TITLE
doc: Make it explicit that `XML_GetCurrentColumnNumber` starts at 0

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -2137,8 +2137,8 @@ XML_Size XMLCALL
 XML_GetCurrentColumnNumber(XML_Parser p);
 </pre>
 <div class="fcndef">
-Return the offset, from the beginning of the current line, of
-the position.
+Return the <em>offset</em>, from the beginning of the current line, of
+the position.  The first column is reported as <code>0</code>.
 </div>
 
 <h4 id="XML_GetCurrentByteCount">XML_GetCurrentByteCount</h4>


### PR DESCRIPTION
CC @picnixz