### PR TITLE
lib: Remove cast that truncates a `size_t` to an `unsigned`

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -8145,7 +8145,7 @@ poolGrow(STRING_POOL *pool) {
     if (bytesToAllocate == 0)
       return XML_FALSE;
 
-    temp = REALLOC(pool->parser, pool->blocks, (unsigned)bytesToAllocate);
+    temp = REALLOC(pool->parser, pool->blocks, bytesToAllocate);
     if (temp == NULL)
       return XML_FALSE;
     pool->blocks = temp;


### PR DESCRIPTION
The source expression, `bytesToAllocate`, is a `size_t` and the type of the corresponding parameter in the function it is being passed to is also `size_t`. Thus this cast is redundant.

Note that this cast was not losing information. On platforms like x86-64, `sizeof(unsigned) < sizeof(size_t)`. But `bytesToAllocate` is the result of a call to `poolBytesToAllocateFor` here that can never return a value that would overflow an `unsigned`.

The source of this seems to have been an oversight in 810b74e4703dcfdd8f404e3cb177d44684775143.