### PR TITLE
CI: Stop using about-to-be-removed image "macos-13"

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
     name: Perform checks
     strategy:
       matrix:
-        os: [macos-13, macos-15]
+        os: [macos-14, macos-15]
         include:
           - MODE: cmake-oos
           - MODE: distcheck


### PR DESCRIPTION
> The macOS 13 runner image will be retired by December 4th, 2025.