### PR TITLE
Improve determination of buffer size `bufSize` in function `doContent`

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -3502,6 +3502,8 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
             tag->name.strLen = convLen;
             break;
           }
+          if (SIZE_MAX / 2 < (size_t)(tag->bufEnd - tag->buf))
+            return XML_ERROR_NO_MEMORY;
           const size_t bufSize = (size_t)(tag->bufEnd - tag->buf) * 2;
           {
             char *temp = REALLOC(parser, tag->buf, bufSize);

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -3503,7 +3503,7 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
             tag->name.strLen = convLen;
             break;
           }
-          bufSize = (int)(tag->bufEnd - tag->buf) << 1;
+          bufSize = (int)(tag->bufEnd - tag->buf) * 2;
           {
             char *temp = REALLOC(parser, tag->buf, bufSize);
             if (temp == NULL)

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -3492,7 +3492,6 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
         const char *fromPtr = tag->rawName;
         toPtr = (XML_Char *)tag->buf;
         for (;;) {
-          int bufSize;
           int convLen;
           const enum XML_Convert_Result convert_res
               = XmlConvert(enc, &fromPtr, rawNameEnd, (ICHAR **)&toPtr,
@@ -3503,7 +3502,7 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
             tag->name.strLen = convLen;
             break;
           }
-          bufSize = (int)(tag->bufEnd - tag->buf) * 2;
+          const size_t bufSize = (size_t)(tag->bufEnd - tag->buf) * 2;
           {
             char *temp = REALLOC(parser, tag->buf, bufSize);
             if (temp == NULL)


### PR DESCRIPTION
Some tweaks spawned from the review of https://github.com/libexpat/libexpat/pull/1072.