### PR TITLE
Fix encoding of API documentation

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                       "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>


### PR DESCRIPTION
The XML encoding was declared as ISO-8859-1, but the comment contains a UTF-8 character (in my name).