### PR TITLE
Remove obsolete `Content-Style-Type`

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -44,7 +44,6 @@
 -->
   <title>Expat XML Parser</title>
   <meta name="author" content="Clark Cooper, coopercc@netheaven.com" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
   <link href="ok.min.css" rel="stylesheet" type="text/css" />
   <link href="style.css" rel="stylesheet" type="text/css" />
 </head>


### PR DESCRIPTION
`Content-Style-Type` was part of old versions of HTML, but it has no effect. It is not part of modern HTML standards, and also not of XHTML 1.0 (which this document uses).