### PR TITLE
Remove unneeded `type="text/css"` from `style` tag

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -44,8 +44,8 @@
 -->
   <title>Expat XML Parser</title>
   <meta name="author" content="Clark Cooper, coopercc@netheaven.com" />
-  <link href="ok.min.css" rel="stylesheet" type="text/css" />
-  <link href="style.css" rel="stylesheet" type="text/css" />
+  <link href="ok.min.css" rel="stylesheet" />
+  <link href="style.css" rel="stylesheet" />
 </head>
 <body>
   <div>


### PR DESCRIPTION
This attribute has no effect and is discouraged in modern HTML. Same issue as https://github.com/libexpat/libexpat.github.io/pull/34