### PR TITLE
Replace unneeded entities with UTF-8 characters

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -2324,10 +2324,10 @@ XML_SetAllocTrackerMaximumAmplification(XML_Parser p,
       <code><a href="#XML_MemMalloc">XML_MemMalloc</a></code>
       and
       <code><a href="#XML_MemRealloc">XML_MemRealloc</a></code>
-      &mdash;
+      —
       <em>healthy</em> use of these two functions continues to be a responsibility
       of the application using Expat
-      &mdash;,
+      —,
     </li>
     <li>
       the main character buffer used by functions


### PR DESCRIPTION
While there is no formal deprecation of named entities, they are unnecessary, unusual in modern HTML, and it is often recommended to avoid any entities besides the basic HTML characters (like &amp;, &lt; ...).

See, e.g.:
https://google.github.io/styleguide/htmlcssguide.html#Entity_References