### PR TITLE
Incorrect value passed to `XML_AttlistDeclHandler` for `NotationType` production

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -5211,8 +5211,8 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
       = {ASCII_N, ASCII_M, ASCII_T, ASCII_O, ASCII_K,
          ASCII_E, ASCII_N, ASCII_S, '\0'};
   static const XML_Char notationPrefix[]
-      = {ASCII_N, ASCII_O, ASCII_T, ASCII_A,      ASCII_T,
-         ASCII_I, ASCII_O, ASCII_N, ASCII_LPAREN, '\0'};
+      = {ASCII_N, ASCII_O, ASCII_T,     ASCII_A,      ASCII_T, ASCII_I,
+         ASCII_O, ASCII_N, ASCII_SPACE, ASCII_LPAREN, '\0'};
   static const XML_Char enumValueSep[] = {ASCII_PIPE, '\0'};
   static const XML_Char enumValueStart[] = {ASCII_LPAREN, '\0'};
 

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -1418,11 +1418,11 @@ START_TEST(test_dtd_attr_handling) {
           "<!ATTLIST doc a NOTATION (foo) #IMPLIED>\n"
           "]>"
           "<doc/>",
-          XCS("doc"), XCS("a"), XCS("NOTATION(foo)"), NULL, XML_FALSE},
+          XCS("doc"), XCS("a"), XCS("NOTATION (foo)"), NULL, XML_FALSE},
          {"<!ATTLIST doc a NOTATION (foo) 'bar'>\n"
           "]>"
           "<doc/>",
-          XCS("doc"), XCS("a"), XCS("NOTATION(foo)"), XCS("bar"), XML_FALSE},
+          XCS("doc"), XCS("a"), XCS("NOTATION (foo)"), XCS("bar"), XML_FALSE},
          {"<!ATTLIST doc a CDATA '\xdb\xb2'>\n"
           "]>"
           "<doc/>",


### PR DESCRIPTION
The production for NotationType in both XML 1.0 [^1] & XML 1.1 [^2] specifies that the `NOTATION` literal must be followed by whitespace before the `(` literal.

Make sure this is the case for types derived from this production rule when calling `XML_AttlistDeclHandler`.

[^1]: https://www.w3.org/TR/xml/#NT-NotationType

[^2]: https://www.w3.org/TR/xml11/#NT-NotationType