### PR TITLE
WASI: Stop using `getpid`

### DIFF
--- a/.github/workflows/wasi_sdk.yml
+++ b/.github/workflows/wasi_sdk.yml
@@ -56,9 +56,8 @@ jobs:
       run: |
         cmake_args=(
           -DCMAKE_TOOLCHAIN_FILE=/opt/wasi-sdk/share/cmake/wasi-sdk.cmake
-          -DCMAKE_C_FLAGS='-O1 -pipe -Wall -Wextra -pedantic -Wno-overlength-strings -D_WASI_EMULATED_GETPID -DXML_POOR_ENTROPY'
+          -DCMAKE_C_FLAGS='-O1 -pipe -Wall -Wextra -pedantic -Wno-overlength-strings -DXML_POOR_ENTROPY'
           -DCMAKE_CXX_FLAGS='-O2 -pipe -Wall -Wextra -pedantic -Wno-overlength-strings'
-          -DCMAKE_{EXE,SHARED,MODULE}_LINKER_FLAGS='-lwasi-emulated-getpid'
           -DEXPAT_BUILD_DOCS=OFF
           -DEXPAT_BUILD_TESTS=OFF
           -DEXPAT_SHARED_LIBS=OFF

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1230,8 +1230,11 @@ generate_hash_secret_salt(XML_Parser parser) {
 #  endif /* ! defined(_WIN32) && defined(XML_DEV_URANDOM) */
   /* .. and self-made low quality for backup: */
 
+  entropy = gather_time_entropy();
+#  if ! defined(__wasi__)
   /* Process ID is 0 bits entropy if attacker has local access */
-  entropy = gather_time_entropy() ^ getpid();
+  entropy ^= getpid();
+#  endif
 
   /* Factors are 2^31-1 and 2^61-1 (Mersenne primes M31 and M61) */
   if (sizeof(unsigned long) == 4) {


### PR DESCRIPTION
Resolves https://github.com/libexpat/libexpat/issues/1102

## Alternative 1:
Add a static function named getpid that would simply return 0.
It is somehow similar to `#  define getpid GetCurrentProcessId` for Windows.

## Alternative 2:
Modify configure/build scripts to add -lwasi-emulated-getpid flag. 
Not a good solution in my opinion