### PR TITLE
`block` struct should have a Flexible Array Member as last part of its struct

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -349,7 +349,7 @@ typedef struct {
 typedef struct block {
   struct block *next;
   int size;
-  XML_Char s[1];
+  XML_Char s[];
 } BLOCK;
 
 typedef struct {


### PR DESCRIPTION
Since this is a C99 feature, it works better than a one-member block.

Since this makes it clear that blocks can vary in length, a flexible array member works here.
It also makes it clear that this is not undefined behavior.

Also, yes, this does affect the underlying assembly for the better, by 10 instructions total.

In addition, there is no risk, because:
1. Size of this struct is not used.
2. It is not Undefined 
3. offsetof gets the same value anyway. 