### PR TITLE
autotools: Modernize `conftools/expat.m4`

### DIFF
--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -63,7 +63,7 @@ m4_define([expat_version],
   m4_ifdef([__gnu__],
            [esyscmd(conftools/get-version.sh lib/expat.h)],
            [2.2.x]))
-AC_INIT([expat], expat_version, [https://github.com/libexpat/libexpat/issues])
+AC_INIT([expat], [expat_version], [https://github.com/libexpat/libexpat/issues])
 m4_undefine([expat_version])
 
 AC_CONFIG_SRCDIR([Makefile.in])
@@ -106,11 +106,7 @@ AC_SUBST(LIBREVISION)
 AC_SUBST(LIBAGE)
 
 AC_LANG([C])
-AC_PROG_CC_C99
-
-AS_IF([test "${ac_cv_prog_cc_c99}" = no],
-  [AC_MSG_ERROR([Expat requires a C99 compiler.])])
-
+AC_PROG_CC
 AS_IF([test "$GCC" = yes],
   [AX_APPEND_COMPILE_FLAGS([-Wall -Wextra], [AM_CFLAGS])
    dnl Be careful about adding the -fexceptions option; some versions of

--- a/expat/conftools/expat.m4
+++ b/expat/conftools/expat.m4
@@ -8,11 +8,11 @@ dnl In addition, an Automake conditional EXPAT_INSTALLED is set accordingly.
 dnl This is necessary to adapt a whole lot of packages that have expat
 dnl bundled as a static library.
 AC_DEFUN([AM_WITH_EXPAT],
-[ AC_ARG_WITH(expat,
-	      [  --with-expat=PREFIX     Use system Expat library],
-	      , with_expat=no)
+[ AC_ARG_WITH([expat],
+	      [AS_HELP_STRING([--with-expat=PREFIX], [Use system Expat library])],
+	      , [with_expat=no])
 
-  AM_CONDITIONAL(EXPAT_INSTALLED, test $with_expat != no)
+  AM_CONDITIONAL([EXPAT_INSTALLED], [test $with_expat != no])
 
   EXPAT_CFLAGS=
   EXPAT_LIBS=
@@ -21,23 +21,23 @@ AC_DEFUN([AM_WITH_EXPAT],
 		EXPAT_CFLAGS="-I$with_expat/include"
 		EXPAT_LIBS="-L$with_expat/lib"
 	fi
-	AC_CHECK_LIB(expat, XML_ParserCreate,
+	AC_CHECK_LIB([expat], [XML_ParserCreate],
 		     [ EXPAT_LIBS="$EXPAT_LIBS -lexpat"
 		       expat_found=yes ],
 		     [ expat_found=no ],
-		     "$EXPAT_LIBS")
+		     ["$EXPAT_LIBS"])
 	if test $expat_found = no; then
 		AC_MSG_ERROR([Could not find the Expat library])
 	fi
 	expat_save_CFLAGS="$CFLAGS"
 	CFLAGS="$CFLAGS $EXPAT_CFLAGS"
-	AC_CHECK_HEADERS(expat.h, , expat_found=no)
+	AC_CHECK_HEADERS([expat.h], , [expat_found=no])
 	if test $expat_found = no; then
 		AC_MSG_ERROR([Could not find expat.h])
 	fi
 	CFLAGS="$expat_save_CFLAGS"
   fi
 
-  AC_SUBST(EXPAT_CFLAGS)
-  AC_SUBST(EXPAT_LIBS)
+  AC_SUBST([EXPAT_CFLAGS])
+  AC_SUBST([EXPAT_LIBS])
 ])


### PR DESCRIPTION
This replaces old style in m4 and the obsolete macro in configure.ac