### PR TITLE
Fix CI / `solaris.yml`: Update package database before trying to install

### DIFF
--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -53,6 +53,7 @@ jobs:
 
         prepare: |
           set -e -x
+          pkgutil -U
           pkgutil -y -i \
               autoconf \
               automake \


### PR DESCRIPTION
[The symptom](https://github.com/libexpat/libexpat/actions/runs/21298385036/job/61310382196) was:

```console
# pkgutil -y -i autoconf automake bash cmake gmake gsed libtool
[..]
=> Fetching CSWlibidn2-0-2.0.4,REV=2018.01.16 (38/47) ...
--2026-01-23 19:32:29--  http://mirror.opencsw.org/opencsw/testing/i386/5.11/libidn2_0-2.0.4,REV=2018.01.16-SunOS5.10-i386-CSW.pkg.gz
Resolving mirror.opencsw.org (mirror.opencsw.org)... 131.188.40.82, 2001:638:a000:4140::ffff:82
Connecting to mirror.opencsw.org (mirror.opencsw.org)|131.188.40.82|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2026-01-23 19:32:29 ERROR 404: Not Found.
```

