### PR TITLE
`solaris.yml`: Make Solaris CI use `pkg install` instead of `pkgutil -i`

### DIFF
--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -53,15 +53,20 @@ jobs:
 
         prepare: |
           set -e -x
-          pkgutil -U
-          pkgutil -y -i \
-              autoconf \
-              automake \
-              bash \
-              cmake \
-              gmake \
-              gsed \
-              libtool
+
+          # NOTE: Exit code 0 means "all now installed and all not before".
+          #       Exit code 3 means "all now installed and some not before".
+          #       Exit code 4 means "all now installed and all already before".
+          #       Command "pkg list -a" can show a list of packages available.
+          pkg install \
+            autoconf \
+            automake \
+            bash \
+            cmake \
+            gnu-make \
+            gnu-sed \
+            libtool \
+            || [ $? -eq 3 -o $? -eq 4 ]  # see comment block above
 
         run: |
           set -e -x

--- a/expat/Changes
+++ b/expat/Changes
@@ -60,6 +60,9 @@ Release 2.7.4 ??? ????????? ?? ????
                     instead
 
         Special thanks to:
+            Jakub Kulík
+            Neil Pang
+                 and
             Artiphishell Inc.
 
 Release 2.7.3 Wed September 24 2025


### PR DESCRIPTION
The dependencies installed by `pkgutil` were not actually used.

Related:
https://github.com/libexpat/libexpat/issues/830#issuecomment-3745190458
