### PR TITLE
Fix `libexpat.def.cmake` version comments (for CMake with Windows)

### DIFF
--- a/expat/lib/libexpat.def.cmake
+++ b/expat/lib/libexpat.def.cmake
@@ -1,6 +1,7 @@
 ; DEF file for MS VC++
 
 EXPORTS
+; added some time before version 1.95.4
   XML_DefaultCurrent @1
   XML_ErrorString @2
   XML_ExpatVersion @3
@@ -55,8 +56,8 @@ EXPORTS
   XML_SetUserData @52
   XML_SetXmlDeclHandler @53
   XML_UseParserAsHandlerArg @54
-; added with version 1.95.3
   XML_ParserReset @55
+; added with version 1.95.4
   XML_SetSkippedEntityHandler @56
 ; added with version 1.95.5
   XML_GetFeatureList @57
@@ -70,7 +71,7 @@ EXPORTS
   XML_StopParser @63
   XML_ResumeParser @64
   XML_GetParsingStatus @65
-; added with version 2.1.1
+; added with version 2.1.0
 @_EXPAT_COMMENT_ATTR_INFO@ XML_GetAttributeInfo @66
   XML_SetHashSalt @67
 ; internal @68 removed with version 2.3.1


### PR DESCRIPTION
In reaction to https://github.com/libexpat/libexpat/pull/1134#discussion_r2724536425 :

- `XML_GetAttributeInfo` and `XML_SetHashSalt` were introduced in 2.1.0 not 2.1.1.
- `XML_SetSkippedEntityHandler` appeared in 1.95.4 not 1.95.3.
- Release 1.95.3 also introduced `XML_ExpatVersionInfo` (further up), not just `XML_ParserReset`.

CC @gordonmessmer 