### PR TITLE
`configure.ac`: Fix condition for symbol versioning check (fixes #1146)

### DIFF
--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -152,7 +152,7 @@ AS_IF([test "x$enable_symbol_versioning" != xno],
    AC_SUBST([VSCRIPT_LDFLAGS])
   ])
 AM_CONDITIONAL([HAVE_VSCRIPT],
-  [test "$enable_symbol_versioning" != xno])
+  [test "x$enable_symbol_versioning" != xno])
 
 dnl patching ${archive_cmds} to affect generation of file "libtool" to fix linking with clang (issue #312)
 AS_CASE(["$LD"],[*clang*],


### PR DESCRIPTION
# Self-Diagnosis

- [x] This pull request fixes #1146.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,   and hence expect CI to be all-green for this pull request
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

This PR fixes #1146 . An incorrect check in configure.ac enables part of symbol versioning which should be disabled by default, resulting in the build failing with slibtool. See #1146 for more information.

@hartwork  @gordonmessmer 