### PR TITLE
Avoid export vs config naming collision in the CMake package install

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -932,6 +932,8 @@ expat_install(
 expat_install(
     EXPORT
         expat
+    FILE
+        expat-targets.cmake
     DESTINATION
         ${CMAKE_INSTALL_LIBDIR}/cmake/expat-${PROJECT_VERSION}/
     NAMESPACE

--- a/expat/cmake/expat-config.cmake.in
+++ b/expat/cmake/expat-config.cmake.in
@@ -32,7 +32,7 @@ if(NOT _expat_config_included)
     set(_expat_config_included TRUE)
 
 
-include("${CMAKE_CURRENT_LIST_DIR}/expat.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/expat-targets.cmake")
 
 @PACKAGE_INIT@
 


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [ ] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

Avoid export vs config naming collision in the CMake package install. This violated the [CMake install(EXPORT) docs](https://cmake.org/cmake/help/latest/command/install.html#export) and lead in some cases to issues where the config file was wrongly globbed and then deleted in the install step.

I'm not familiar with Git(Hub), so I realized after pushing to my fork that the GitHub actions are disabled by default. I now enabled them in case of future pushes. Unless I can force to run GitHub Actions on an already existing commit, I'm afraid I didn't run the Actions CI yet...
