### PR TITLE
`lib/xmlparse.c`: Avoid propagating `/dev/urandom` file descriptor to child processes

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1095,7 +1095,7 @@ writeRandomBytes_dev_urandom(void *target, size_t count) {
   int success = 0; /* full count bytes written? */
   size_t bytesWrittenTotal = 0;
 
-  const int fd = open("/dev/urandom", O_RDONLY);
+  const int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
   if (fd < 0) {
     return 0;
   }


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

Because this is library code, it cannot be sure what other sibling threads are doing while it is executing. If one of them calls `execve` (or one of its cousins) while `writeRandomBytes_dev_urandom` is executing, the newly started process will unwillingly inherit a file descriptor to /dev/urandom.

Though the use of `O_CLOEXEC` with `open` is not portable, it is probably fine to use here as this code path is only compiled on platforms that support /dev/urandom. Using `O_CLOEXEC` with `open` works on the BSDs, Linux, and even, despite seemingly being undocumented, on macOS too.