### PR TITLE
docs: Standardize CMake commands for compilation

### DIFF
--- a/expat/CMake.README
+++ b/expat/CMake.README
@@ -21,7 +21,8 @@ make install in the usual way:
 If you want to specify the install location for your files, append
 -DCMAKE_INSTALL_PREFIX=/your/install/path to the cmake call.
 
-~/expat-2.7.5/build$ make && make test && make install
+~/expat-2.7.5/build$ cmake --build . && cmake --build . --target test
+    && cmake --build . --target install
 Scanning dependencies of target expat
 [  5%] Building C object CMakeFiles/expat.dir/lib/xmlparse.c.o
 [ 11%] Building C object CMakeFiles/expat.dir/lib/xmlrole.c.o
@@ -36,7 +37,7 @@ Visual Studio Command Prompt or when using mingw, you must open a cmd.exe and
 make sure that gcc can be called. On Windows, you also might want to specify a
 special Generator for CMake:
 for Visual Studio builds do:
-cmake .. -G "Visual Studio 17 2022" && msbuild /m expat.sln
+cmake .. -G "Visual Studio 17 2022" && cmake --build . --parallel
 for mingw builds do:
 cmake .. -G "MinGW Makefiles" -DCMAKE_INSTALL_PREFIX=D:\expat-install
-    && gmake && gmake install
+    && cmake --build . && cmake --build . --target install

--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -615,7 +615,7 @@ end(void *data, const char *el) {
         next section. Otherwise if you have Microsoft's Developer Studio installed, you
         can use CMake to generate a <code>.sln</code> file, e.g. <code>cmake -G"Visual
         Studio 17 2022" -DCMAKE_BUILD_TYPE=RelWithDebInfo .</code> , and build Expat
-        using <code>msbuild /m expat.sln</code> after.
+        using <code>cmake --build . --parallel</code> after.
       </p>
 
       <p>

--- a/expat/win32/README.txt
+++ b/expat/win32/README.txt
@@ -12,7 +12,7 @@ Expat can be built on Windows in two ways:
   md build
   cd build
   cmake -G"Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-  msbuild /m expat.sln
+  cmake --build . --parallel
 
 * All MS C/C++ compilers:
   The output for all projects will be generated in the <CMAKE_BUILD_TYPE>\


### PR DESCRIPTION


<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

By using CMake’s support for calling the underlying build tool, this makes instructions more agnostic to what the default platform build system is.

I am not sure why the MSBuild steps use parallelism (`/m`). But this has been preserved across this change.