### PR TITLE
examples: Build warning-free with `-Wdiscarded-qualifiers -Wwrite-strings`

### DIFF
--- a/expat/examples/element_declarations.c
+++ b/expat/examples/element_declarations.c
@@ -82,7 +82,7 @@ stackPopFree(Stack *stackTop) {
   return newStackTop;
 }
 
-static char *
+static const char *
 contentTypeName(enum XML_Content_Type contentType) {
   switch (contentType) {
   case XML_CTYPE_EMPTY:
@@ -102,7 +102,7 @@ contentTypeName(enum XML_Content_Type contentType) {
   }
 }
 
-static char *
+static const char *
 contentQuantName(enum XML_Content_Quant contentQuant) {
   switch (contentQuant) {
   case XML_CQUANT_NONE:


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

`-Wwrite-strings` is not applied by expat’s build system. But I was using a build workflow that resulted in this being added anyway, yielding some extra warnings. This change resolves them.
