### PR TITLE
Fix interpretation of `errno` after randomization calls

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1106,6 +1106,8 @@ writeRandomBytes_dev_urandom(void *target, size_t count) {
     void *const currentTarget = (void *)((char *)target + bytesWrittenTotal);
     const size_t bytesToWrite = count - bytesWrittenTotal;
 
+    errno = 0;
+
     const ssize_t bytesWrittenMore = read(fd, currentTarget, bytesToWrite);
 
     if (bytesWrittenMore > 0) {

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1065,6 +1065,8 @@ writeRandomBytes_getrandom_nonblock(void *target, size_t count) {
 
     assert(bytesToWrite <= INT_MAX);
 
+    errno = 0;
+
     const int bytesWrittenMore =
 #      if defined(HAVE_GETRANDOM)
         (int)getrandom(currentTarget, bytesToWrite, getrandomFlags);


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

Calls to some of the randomization functions check for failure exclusively based on `errno`. To ensure this works out correctly, resetting `errno` before these calls is wise. This avoids a preexisting non-zero `errno` value being misinterpreted.
