### PR TITLE
lib: Avoid assuming `uint8_t` is a character type

### DIFF
--- a/expat/lib/random_arc4random.c
+++ b/expat/lib/random_arc4random.c
@@ -31,8 +31,9 @@
 
 #include "random_arc4random.h"
 
-#include <stdint.h> // for uint8_t, uint32_t
+#include <stdint.h> // for uint32_t
 #include <stdlib.h> // for arc4random
+#include <string.h> // for memcpy
 
 // Help clang-tidy out with prototype of function `arc4random`
 #if defined(XML_CLANG_TIDY)
@@ -45,12 +46,11 @@ writeRandomBytes_arc4random(void *target, size_t count) {
 
   while (bytesWrittenTotal < count) {
     const uint32_t random32 = arc4random();
-    size_t i = 0;
 
-    for (; (i < sizeof(random32)) && (bytesWrittenTotal < count);
-         i++, bytesWrittenTotal++) {
-      const uint8_t random8 = (uint8_t)(random32 >> (i * 8));
-      ((uint8_t *)target)[bytesWrittenTotal] = random8;
-    }
+    size_t toUse = count - bytesWrittenTotal;
+    if (toUse > sizeof(random32))
+      toUse = sizeof(random32);
+    memcpy((char *)target + bytesWrittenTotal, &random32, toUse);
+    bytesWrittenTotal += toUse;
   }
 }

--- a/expat/lib/random_rand_s.c
+++ b/expat/lib/random_rand_s.c
@@ -46,8 +46,8 @@
 #  include <errno.h>
 #endif
 
-#include <stdint.h> // for uint8_t
 #include <stdlib.h> // for rand_s
+#include <string.h> // for memcpy
 
 // Help clang-tidy out with prototype of function `rand_s`
 #if defined(XML_CLANG_TIDY)
@@ -73,16 +73,15 @@ writeRandomBytes_rand_s(void *target, size_t count) {
 
   while (bytesWrittenTotal < count) {
     unsigned int random32 = 0;
-    size_t i = 0;
 
     if (rand_s(&random32))
       return 0; /* failure */
 
-    for (; (i < sizeof(random32)) && (bytesWrittenTotal < count);
-         i++, bytesWrittenTotal++) {
-      const uint8_t random8 = (uint8_t)(random32 >> (i * 8));
-      ((uint8_t *)target)[bytesWrittenTotal] = random8;
-    }
+    size_t toUse = count - bytesWrittenTotal;
+    if (toUse > sizeof(random32))
+      toUse = sizeof(random32);
+    memcpy((char *)target + bytesWrittenTotal, &random32, toUse);
+    bytesWrittenTotal += toUse;
   }
   return 1; /* success */
 }


### PR DESCRIPTION

<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

C99 §6.5p7 says:

>  An object shall have its stored value accessed only by an lvalue expression that has one of the following types:
    — a type compatible with the effective type of the object,
    — a qualified version of a type compatible with the effective type of the object,
    — a type that is the signed or unsigned type corresponding to the effective type of the object,
    — a type that is the signed or unsigned type corresponding to a qualified version of the effective type of the object,
    — an aggregate or union type that includes one of the aforementioned types among its members (including, recursively, a member of a subaggregate or contained union), or
    — a character type.

and §6.2.5p15 says:

>  The three types `char`, `signed char`, and `unsigned char` are collectively called the character types. The implementation shall define `char` to have the same range, representation, and behavior as either `signed char` or `unsigned char`.

Putting these together, `uint8_t` is only a character type on the subset of platforms where it is a `typedef` to `unsigned char`. On other platforms, accessing an object of another type through a `uint8_t` pointer appears to be Undefined Behavior.
