### PR TITLE
Squash `-Wcast-align` warnings

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1250,7 +1250,7 @@ parserCreate(const XML_Char *encodingName,
                                + sizeof(struct XML_ParserStruct));
     if (sizeAndParser != NULL) {
       *(size_t *)sizeAndParser = sizeof(struct XML_ParserStruct);
-      parser = (XML_Parser)((char *)sizeAndParser + sizeof(size_t)
+      parser = (XML_Parser)((uintptr_t)sizeAndParser + sizeof(size_t)
                             + EXPAT_MALLOC_PADDING);
 #else
     parser = memsuite->malloc_fcn(sizeof(struct XML_ParserStruct));
@@ -1268,7 +1268,7 @@ parserCreate(const XML_Char *encodingName,
                                        + sizeof(struct XML_ParserStruct));
     if (sizeAndParser != NULL) {
       *(size_t *)sizeAndParser = sizeof(struct XML_ParserStruct);
-      parser = (XML_Parser)((char *)sizeAndParser + sizeof(size_t)
+      parser = (XML_Parser)((uintptr_t)sizeAndParser + sizeof(size_t)
                             + EXPAT_MALLOC_PADDING);
 #else
     parser = malloc(sizeof(struct XML_ParserStruct));

--- a/expat/tests/alloc_tests.c
+++ b/expat/tests/alloc_tests.c
@@ -48,7 +48,7 @@
 
 #include <math.h> /* NAN, INFINITY */
 #include <stdbool.h>
-#include <stdint.h> /* for SIZE_MAX */
+#include <stdint.h> /* for SIZE_MAX, uintptr_t */
 #include <string.h>
 #include <assert.h>
 
@@ -2094,7 +2094,7 @@ END_TEST
 #if XML_GE == 1
 static size_t
 sizeRecordedFor(void *ptr) {
-  return *(size_t *)((char *)ptr - EXPAT_MALLOC_PADDING - sizeof(size_t));
+  return *(size_t *)((uintptr_t)ptr - EXPAT_MALLOC_PADDING - sizeof(size_t));
 }
 #endif // XML_GE == 1
 


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

Expat is not compiled with `-Wcast-align`, but when this flag is injected from an outer build system it adds some build warnings. This PR squashes these warnings, which are all false positives. Not sure if squashing these kind of non-default warnings is a priority, so this PR may not be appropriate.
