### PR TITLE
Autotools: Fix syntax of C test for `getentropy` (follow-up to #1180)

### DIFF
--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -261,7 +261,7 @@ AS_IF([test "x$with_getentropy" != xno],
   [AC_MSG_CHECKING([for getentropy (BSD, macOS 10.12+, glibc 2.25+)])
    AC_LINK_IFELSE([AC_LANG_SOURCE([
        // NOTE: Please keep this block in sync with its two siblings in files
-       //       `ConfigureChecks.cmake` and `lib/random_getentropy.c`!
+       //       'ConfigureChecks.cmake' and 'lib/random_getentropy.c'!
        #if defined(__APPLE__)
        #  include <sys/random.h>
        #else


### PR DESCRIPTION
Follow-up to #1180

The symptom was:
```
checking for getentropy (BSD, macOS 10.12+, glibc 2.25+)... ../configure: line 21519: ConfigureChecks.cmake: command not found
../configure: line 21519: lib/random_getentropy.c: No such file or directory
```