### PR TITLE
lib: Fix header comment typo

### DIFF
--- a/expat/lib/expat_external.h
+++ b/expat/lib/expat_external.h
@@ -45,7 +45,7 @@
 /* Expat tries very hard to make the API boundary very specifically
    defined.  There are two macros defined to control this boundary;
    each of these can be defined before including this header to
-   achieve some different behavior, but doing so it not recommended or
+   achieve some different behavior, but doing so is not recommended or
    tested frequently.
 
    XMLCALL    - The calling convention to use for all calls across the


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

Just a simple non-functional typo fix.
