### PR TITLE
Drop casts around `void *` that C99 does not need

### DIFF
--- a/expat/tests/alloc_tests.c
+++ b/expat/tests/alloc_tests.c
@@ -2136,8 +2136,7 @@ START_TEST(test_alloc_tracker_pointer_alignment) {
   XML_Parser parser = XML_ParserCreate(NULL);
 #if XML_GE == 1
   assert_true(sizeof(long long) >= sizeof(size_t)); // self-test
-  long long *const ptr
-      = (long long *)expat_malloc(parser, 4 * sizeof(long long), -1);
+  long long *const ptr = expat_malloc(parser, 4 * sizeof(long long), -1);
   ptr[0] = 0LL;
   ptr[1] = 1LL;
   ptr[2] = 2LL;

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -5501,7 +5501,7 @@ START_TEST(test_deep_nested_entity) {
   const size_t N_LINES = 60000;
   const size_t SIZE_PER_LINE = 50;
 
-  char *const text = (char *)malloc((N_LINES + 4) * SIZE_PER_LINE);
+  char *const text = malloc((N_LINES + 4) * SIZE_PER_LINE);
   if (text == NULL) {
     fail("malloc failed");
   }
@@ -5547,7 +5547,7 @@ START_TEST(test_deep_nested_attribute_entity) {
   const size_t N_LINES = 60000;
   const size_t SIZE_PER_LINE = 100;
 
-  char *const text = (char *)malloc((N_LINES + 4) * SIZE_PER_LINE);
+  char *const text = malloc((N_LINES + 4) * SIZE_PER_LINE);
   if (text == NULL) {
     fail("malloc failed");
   }
@@ -5590,7 +5590,7 @@ START_TEST(test_deep_nested_entity_delayed_interpretation) {
   const size_t N_LINES = 70000;
   const size_t SIZE_PER_LINE = 100;
 
-  char *const text = (char *)malloc((N_LINES + 4) * SIZE_PER_LINE);
+  char *const text = malloc((N_LINES + 4) * SIZE_PER_LINE);
   if (text == NULL) {
     fail("malloc failed");
   }
@@ -6069,7 +6069,7 @@ START_TEST(test_bypass_heuristic_when_close_to_bufsize) {
   }
 
   const int document_length = 65536;
-  char *const document = (char *)malloc(document_length);
+  char *const document = malloc(document_length);
   assert_true(document != NULL);
 
   const XML_Memory_Handling_Suite memfuncs = {
@@ -6180,7 +6180,7 @@ START_TEST(test_varying_buffer_fills) {
     return; // this test is slow, and doesn't use _XML_Parse_SINGLE_BYTES().
   }
 
-  char *const document = (char *)malloc(document_length);
+  char *const document = malloc(document_length);
   assert_true(document != NULL);
   memset(document, 'x', document_length);
   document[0] = '<';

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -3435,8 +3435,7 @@ external_bom_checker(XML_Parser parser, const XML_Char *context,
     fail("Could not create external entity parser");
 
   if (! xcstrcmp(systemId, XCS("004-2.ent"))) {
-    struct bom_testdata *const testdata
-        = (struct bom_testdata *)XML_GetUserData(parser);
+    struct bom_testdata *const testdata = XML_GetUserData(parser);
     const char *const external = testdata->external;
     const int split = testdata->split;
     testdata->nested_callback_happened = XML_TRUE;

--- a/expat/tests/common.c
+++ b/expat/tests/common.c
@@ -261,7 +261,7 @@ _run_attribute_check(const char *text, const XML_Char *expected,
 void
 _run_ext_character_check(const char *text, ExtTest *test_data,
                          const XML_Char *expected, const char *file, int line) {
-  CharData *const storage = (CharData *)malloc(sizeof(CharData));
+  CharData *const storage = malloc(sizeof(CharData));
 
   CharData_Init(storage);
   test_data->storage = storage;
@@ -320,7 +320,7 @@ portable_strndup(const char *s, size_t n) {
 
   n = portable_strnlen(s, n);
 
-  char *const buffer = (char *)malloc(n + 1);
+  char *const buffer = malloc(n + 1);
   if (buffer == NULL) {
     errno = ENOMEM;
     return NULL;

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -423,7 +423,7 @@ int XMLCALL
 external_entity_optioner(XML_Parser parser, const XML_Char *context,
                          const XML_Char *base, const XML_Char *systemId,
                          const XML_Char *publicId) {
-  ExtOption *options = (ExtOption *)XML_GetUserData(parser);
+  ExtOption *options = XML_GetUserData(parser);
   XML_Parser ext_parser;
 
   UNUSED_P(base);
@@ -449,7 +449,7 @@ int XMLCALL
 external_entity_loader(XML_Parser parser, const XML_Char *context,
                        const XML_Char *base, const XML_Char *systemId,
                        const XML_Char *publicId) {
-  ExtTest *test_data = (ExtTest *)XML_GetUserData(parser);
+  ExtTest *test_data = XML_GetUserData(parser);
   XML_Parser extparser;
 
   UNUSED_P(base);
@@ -477,7 +477,7 @@ external_entity_faulter(XML_Parser parser, const XML_Char *context,
                         const XML_Char *base, const XML_Char *systemId,
                         const XML_Char *publicId) {
   XML_Parser ext_parser;
-  ExtFaults *fault = (ExtFaults *)XML_GetUserData(parser);
+  ExtFaults *fault = XML_GetUserData(parser);
 
   UNUSED_P(base);
   UNUSED_P(systemId);
@@ -650,7 +650,7 @@ external_entity_suspending_faulter(XML_Parser parser, const XML_Char *context,
                                    const XML_Char *systemId,
                                    const XML_Char *publicId) {
   XML_Parser ext_parser;
-  ExtFaults *fault = (ExtFaults *)XML_GetUserData(parser);
+  ExtFaults *fault = XML_GetUserData(parser);
   void *buffer;
   int parse_len = (int)strlen(fault->parse_text);
 
@@ -981,7 +981,7 @@ external_entity_valuer(XML_Parser parser, const XML_Char *context,
         == XML_STATUS_ERROR)
       xml_failure(ext_parser);
   } else if (! xcstrcmp(systemId, XCS("004-2.ent"))) {
-    ExtFaults *fault = (ExtFaults *)XML_GetUserData(parser);
+    ExtFaults *fault = XML_GetUserData(parser);
     enum XML_Status status;
     enum XML_Error error;
 
@@ -1083,7 +1083,7 @@ int XMLCALL
 external_entity_public(XML_Parser parser, const XML_Char *context,
                        const XML_Char *base, const XML_Char *systemId,
                        const XML_Char *publicId) {
-  const char *text1 = (const char *)XML_GetUserData(parser);
+  const char *text1 = XML_GetUserData(parser);
   const char *text2 = "<!ATTLIST doc a CDATA 'value'>";
   const char *text = NULL;
   XML_Parser ext_parser;
@@ -1139,7 +1139,7 @@ int XMLCALL
 external_entity_oneshot_loader(XML_Parser parser, const XML_Char *context,
                                const XML_Char *base, const XML_Char *systemId,
                                const XML_Char *publicId) {
-  ExtHdlrData *test_data = (ExtHdlrData *)XML_GetUserData(parser);
+  ExtHdlrData *test_data = XML_GetUserData(parser);
   XML_Parser ext_parser;
 
   UNUSED_P(base);
@@ -1164,7 +1164,7 @@ int XMLCALL
 external_entity_loader2(XML_Parser parser, const XML_Char *context,
                         const XML_Char *base, const XML_Char *systemId,
                         const XML_Char *publicId) {
-  ExtTest2 *test_data = (ExtTest2 *)XML_GetUserData(parser);
+  ExtTest2 *test_data = XML_GetUserData(parser);
   XML_Parser extparser;
 
   UNUSED_P(base);
@@ -1191,7 +1191,7 @@ int XMLCALL
 external_entity_faulter2(XML_Parser parser, const XML_Char *context,
                          const XML_Char *base, const XML_Char *systemId,
                          const XML_Char *publicId) {
-  ExtFaults2 *test_data = (ExtFaults2 *)XML_GetUserData(parser);
+  ExtFaults2 *test_data = XML_GetUserData(parser);
   XML_Parser extparser;
 
   UNUSED_P(base);
@@ -1309,7 +1309,7 @@ int XMLCALL
 external_entity_dbl_handler(XML_Parser parser, const XML_Char *context,
                             const XML_Char *base, const XML_Char *systemId,
                             const XML_Char *publicId) {
-  int *pcallno = (int *)XML_GetUserData(parser);
+  int *pcallno = XML_GetUserData(parser);
   int callno = *pcallno;
   const char *text;
   XML_Parser new_parser = NULL;
@@ -1366,7 +1366,7 @@ int XMLCALL
 external_entity_dbl_handler_2(XML_Parser parser, const XML_Char *context,
                               const XML_Char *base, const XML_Char *systemId,
                               const XML_Char *publicId) {
-  int *pcallno = (int *)XML_GetUserData(parser);
+  int *pcallno = XML_GetUserData(parser);
   int callno = *pcallno;
   const char *text;
   XML_Parser new_parser;
@@ -1461,7 +1461,7 @@ int XMLCALL
 external_entity_alloc(XML_Parser parser, const XML_Char *context,
                       const XML_Char *base, const XML_Char *systemId,
                       const XML_Char *publicId) {
-  const char *text = (const char *)XML_GetUserData(parser);
+  const char *text = XML_GetUserData(parser);
   XML_Parser ext_parser;
   int parse_res;
 
@@ -1516,8 +1516,7 @@ accounting_external_entity_ref_handler(XML_Parser parser,
   UNUSED_P(base);
   UNUSED_P(publicId);
 
-  const struct AccountingTestCase *const testCase
-      = (const struct AccountingTestCase *)XML_GetUserData(parser);
+  const struct AccountingTestCase *const testCase = XML_GetUserData(parser);
 
   const char *externalText = NULL;
   if (xcstrcmp(systemId, XCS("first.ent")) == 0) {

--- a/expat/tests/memcheck.c
+++ b/expat/tests/memcheck.c
@@ -55,8 +55,7 @@ static AllocationEntry *find_allocation(const void *ptr);
 /* Allocate some memory and keep track of it. */
 void *
 tracking_malloc(size_t size) {
-  AllocationEntry *const entry
-      = (AllocationEntry *)malloc(sizeof(AllocationEntry));
+  AllocationEntry *const entry = malloc(sizeof(AllocationEntry));
 
   if (entry == NULL) {
     printf("Allocator failure\n");
@@ -142,7 +141,7 @@ tracking_realloc(void *ptr, size_t size) {
   entry = find_allocation(ptr);
   if (entry == NULL) {
     printf("Attempting to realloc unallocated memory at %p\n", ptr);
-    entry = (AllocationEntry *)malloc(sizeof(AllocationEntry));
+    entry = malloc(sizeof(AllocationEntry));
     if (entry == NULL) {
       printf("Reallocator failure\n");
       return NULL;

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -54,7 +54,7 @@
 
 Suite *
 suite_create(const char *name) {
-  Suite *suite = (Suite *)calloc(1, sizeof(Suite));
+  Suite *suite = calloc(1, sizeof(Suite));
   if (suite != NULL) {
     suite->name = name;
   }
@@ -63,7 +63,7 @@ suite_create(const char *name) {
 
 TCase *
 tcase_create(const char *name) {
-  TCase *tc = (TCase *)calloc(1, sizeof(TCase));
+  TCase *tc = calloc(1, sizeof(TCase));
   if (tc != NULL) {
     tc->name = name;
   }
@@ -129,7 +129,7 @@ suite_free(Suite *suite) {
 
 SRunner *
 srunner_create(Suite *suite) {
-  SRunner *const runner = (SRunner *)calloc(1, sizeof(SRunner));
+  SRunner *const runner = calloc(1, sizeof(SRunner));
   if (runner != NULL) {
     runner->suite = suite;
   }

--- a/expat/tests/minicheck.c
+++ b/expat/tests/minicheck.c
@@ -94,8 +94,7 @@ tcase_add_test(TCase *tc, tcase_test_function test) {
   if (tc->allocated == tc->ntests) {
     int nalloc = tc->allocated + 100;
     size_t new_size = sizeof(tcase_test_function) * nalloc;
-    tcase_test_function *const new_tests
-        = (tcase_test_function *)realloc(tc->tests, new_size);
+    tcase_test_function *const new_tests = realloc(tc->tests, new_size);
     assert(new_tests != NULL);
     tc->tests = new_tests;
     tc->allocated = nalloc;

--- a/expat/tests/misc_tests.c
+++ b/expat/tests/misc_tests.c
@@ -298,7 +298,7 @@ START_TEST(test_misc_stop_during_end_handler_issue_240_1) {
 
   parser = XML_ParserCreate(NULL);
   XML_SetElementHandler(parser, start_element_issue_240, end_element_issue_240);
-  mydata = (DataIssue240 *)malloc(sizeof(DataIssue240));
+  mydata = malloc(sizeof(DataIssue240));
   assert_true(mydata != NULL);
   mydata->parser = parser;
   mydata->deep = 0;
@@ -320,7 +320,7 @@ START_TEST(test_misc_stop_during_end_handler_issue_240_2) {
 
   parser = XML_ParserCreate(NULL);
   XML_SetElementHandler(parser, start_element_issue_240, end_element_issue_240);
-  mydata = (DataIssue240 *)malloc(sizeof(DataIssue240));
+  mydata = malloc(sizeof(DataIssue240));
   assert_true(mydata != NULL);
   mydata->parser = parser;
   mydata->deep = 0;

--- a/expat/tests/structdata.c
+++ b/expat/tests/structdata.c
@@ -87,8 +87,8 @@ StructData_AddItem(StructData *storage, const XML_Char *s, int data0, int data1,
     StructDataEntry *new_entries;
 
     storage->max_count += STRUCT_EXTENSION_COUNT;
-    new_entries = (StructDataEntry *)realloc(
-        storage->entries, storage->max_count * sizeof(StructDataEntry));
+    new_entries = realloc(storage->entries,
+                          storage->max_count * sizeof(StructDataEntry));
     assert(new_entries != NULL);
     storage->entries = new_entries;
   }

--- a/expat/tests/structdata.c
+++ b/expat/tests/structdata.c
@@ -61,7 +61,7 @@
 static XML_Char *
 xmlstrdup(const XML_Char *s) {
   size_t byte_count = (xcstrlen(s) + 1) * sizeof(XML_Char);
-  XML_Char *const dup = (XML_Char *)malloc(byte_count);
+  XML_Char *const dup = malloc(byte_count);
 
   assert(dup != NULL);
   memcpy(dup, s, byte_count);

--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -138,8 +138,7 @@ resolveSystemId(const XML_Char *base, const XML_Char *systemId,
 #endif
   )
     return systemId;
-  *toFree = (XML_Char *)malloc((tcslen(base) + tcslen(systemId) + 2)
-                               * sizeof(XML_Char));
+  *toFree = malloc((tcslen(base) + tcslen(systemId) + 2) * sizeof(XML_Char));
   if (! *toFree)
     return systemId;
   tcscpy(*toFree, base);

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -1235,8 +1235,8 @@ tmain(int argc, XML_Char **argv) {
         }
 #endif
       }
-      outName = (XML_Char *)malloc((tcslen(outputDir) + tcslen(file) + 2)
-                                   * sizeof(XML_Char));
+      outName
+          = malloc((tcslen(outputDir) + tcslen(file) + 2) * sizeof(XML_Char));
       if (! outName) {
         tperror(T("Could not allocate memory"));
         exit(XMLWF_EXIT_INTERNAL_ERROR);

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -324,7 +324,7 @@ static void XMLCALL
 startDoctypeDecl(void *userData, const XML_Char *doctypeName,
                  const XML_Char *sysid, const XML_Char *publid,
                  int has_internal_subset) {
-  XmlwfUserData *data = (XmlwfUserData *)userData;
+  XmlwfUserData *data = userData;
   UNUSED_P(sysid);
   UNUSED_P(publid);
   UNUSED_P(has_internal_subset);
@@ -380,7 +380,7 @@ notationCmp(const void *a, const void *b) {
 
 static void XMLCALL
 endDoctypeDecl(void *userData) {
-  XmlwfUserData *data = (XmlwfUserData *)userData;
+  XmlwfUserData *data = userData;
   NotationList **notations;
   int notationCount = 0;
   NotationList *p;
@@ -447,7 +447,7 @@ cleanUp:
 static void XMLCALL
 notationDecl(void *userData, const XML_Char *notationName, const XML_Char *base,
              const XML_Char *systemId, const XML_Char *publicId) {
-  XmlwfUserData *data = (XmlwfUserData *)userData;
+  XmlwfUserData *data = userData;
   NotationList *entry = malloc(sizeof(NotationList));
   const char *errorMessage = "Unable to store NOTATION for output\n";
 
@@ -496,7 +496,7 @@ static void XMLCALL
 defaultCharacterData(void *userData, const XML_Char *s, int len) {
   UNUSED_P(s);
   UNUSED_P(len);
-  XML_DefaultCurrent((XML_Parser)userData);
+  XML_DefaultCurrent(userData);
 }
 
 static void XMLCALL
@@ -504,13 +504,13 @@ defaultStartElement(void *userData, const XML_Char *name,
                     const XML_Char **atts) {
   UNUSED_P(name);
   UNUSED_P(atts);
-  XML_DefaultCurrent((XML_Parser)userData);
+  XML_DefaultCurrent(userData);
 }
 
 static void XMLCALL
 defaultEndElement(void *userData, const XML_Char *name) {
   UNUSED_P(name);
-  XML_DefaultCurrent((XML_Parser)userData);
+  XML_DefaultCurrent(userData);
 }
 
 static void XMLCALL
@@ -518,7 +518,7 @@ defaultProcessingInstruction(void *userData, const XML_Char *target,
                              const XML_Char *data) {
   UNUSED_P(target);
   UNUSED_P(data);
-  XML_DefaultCurrent((XML_Parser)userData);
+  XML_DefaultCurrent(userData);
 }
 
 static void XMLCALL
@@ -551,7 +551,7 @@ nopProcessingInstruction(void *userData, const XML_Char *target,
 
 static void XMLCALL
 markup(void *userData, const XML_Char *s, int len) {
-  FILE *fp = ((XmlwfUserData *)XML_GetUserData((XML_Parser)userData))->fp;
+  FILE *fp = ((XmlwfUserData *)XML_GetUserData(userData))->fp;
   for (; len > 0; --len, ++s)
     puttc(*s, fp);
 }
@@ -573,19 +573,17 @@ metaLocation(XML_Parser parser) {
 
 static void
 metaStartDocument(void *userData) {
-  fputts(T("<document>\n"),
-         ((XmlwfUserData *)XML_GetUserData((XML_Parser)userData))->fp);
+  fputts(T("<document>\n"), ((XmlwfUserData *)XML_GetUserData(userData))->fp);
 }
 
 static void
 metaEndDocument(void *userData) {
-  fputts(T("</document>\n"),
-         ((XmlwfUserData *)XML_GetUserData((XML_Parser)userData))->fp);
+  fputts(T("</document>\n"), ((XmlwfUserData *)XML_GetUserData(userData))->fp);
 }
 
 static void XMLCALL
 metaStartElement(void *userData, const XML_Char *name, const XML_Char **atts) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   const XML_Char **specifiedAttsEnd
@@ -618,7 +616,7 @@ metaStartElement(void *userData, const XML_Char *name, const XML_Char **atts) {
 
 static void XMLCALL
 metaEndElement(void *userData, const XML_Char *name) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   ftprintf(fp, T("<endtag name=\"%s\""), name);
@@ -629,7 +627,7 @@ metaEndElement(void *userData, const XML_Char *name) {
 static void XMLCALL
 metaProcessingInstruction(void *userData, const XML_Char *target,
                           const XML_Char *data) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *usrData = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = usrData->fp;
   ftprintf(fp, T("<pi target=\"%s\" data=\""), target);
@@ -641,7 +639,7 @@ metaProcessingInstruction(void *userData, const XML_Char *target,
 
 static void XMLCALL
 metaComment(void *userData, const XML_Char *data) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *usrData = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = usrData->fp;
   fputts(T("<comment data=\""), fp);
@@ -653,7 +651,7 @@ metaComment(void *userData, const XML_Char *data) {
 
 static void XMLCALL
 metaStartCdataSection(void *userData) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<startcdata"), fp);
@@ -663,7 +661,7 @@ metaStartCdataSection(void *userData) {
 
 static void XMLCALL
 metaEndCdataSection(void *userData) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<endcdata"), fp);
@@ -673,7 +671,7 @@ metaEndCdataSection(void *userData) {
 
 static void XMLCALL
 metaCharacterData(void *userData, const XML_Char *s, int len) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<chars str=\""), fp);
@@ -687,7 +685,7 @@ static void XMLCALL
 metaStartDoctypeDecl(void *userData, const XML_Char *doctypeName,
                      const XML_Char *sysid, const XML_Char *pubid,
                      int has_internal_subset) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   UNUSED_P(sysid);
@@ -700,7 +698,7 @@ metaStartDoctypeDecl(void *userData, const XML_Char *doctypeName,
 
 static void XMLCALL
 metaEndDoctypeDecl(void *userData) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<enddoctype"), fp);
@@ -712,7 +710,7 @@ static void XMLCALL
 metaNotationDecl(void *userData, const XML_Char *notationName,
                  const XML_Char *base, const XML_Char *systemId,
                  const XML_Char *publicId) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   UNUSED_P(base);
@@ -733,7 +731,7 @@ metaEntityDecl(void *userData, const XML_Char *entityName, int is_param,
                const XML_Char *value, int value_length, const XML_Char *base,
                const XML_Char *systemId, const XML_Char *publicId,
                const XML_Char *notationName) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
 
@@ -770,7 +768,7 @@ metaEntityDecl(void *userData, const XML_Char *entityName, int is_param,
 static void XMLCALL
 metaStartNamespaceDecl(void *userData, const XML_Char *prefix,
                        const XML_Char *uri) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<startns"), fp);
@@ -786,7 +784,7 @@ metaStartNamespaceDecl(void *userData, const XML_Char *prefix,
 
 static void XMLCALL
 metaEndNamespaceDecl(void *userData, const XML_Char *prefix) {
-  XML_Parser parser = (XML_Parser)userData;
+  XML_Parser parser = userData;
   XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
   FILE *fp = data->fp;
   if (! prefix)

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -584,7 +584,7 @@ metaEndDocument(void *userData) {
 static void XMLCALL
 metaStartElement(void *userData, const XML_Char *name, const XML_Char **atts) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   const XML_Char **specifiedAttsEnd
       = atts + XML_GetSpecifiedAttributeCount(parser);
@@ -617,7 +617,7 @@ metaStartElement(void *userData, const XML_Char *name, const XML_Char **atts) {
 static void XMLCALL
 metaEndElement(void *userData, const XML_Char *name) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   ftprintf(fp, T("<endtag name=\"%s\""), name);
   metaLocation(parser);
@@ -628,7 +628,7 @@ static void XMLCALL
 metaProcessingInstruction(void *userData, const XML_Char *target,
                           const XML_Char *data) {
   XML_Parser parser = userData;
-  XmlwfUserData *usrData = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *usrData = XML_GetUserData(parser);
   FILE *fp = usrData->fp;
   ftprintf(fp, T("<pi target=\"%s\" data=\""), target);
   characterData(usrData, data, (int)tcslen(data));
@@ -640,7 +640,7 @@ metaProcessingInstruction(void *userData, const XML_Char *target,
 static void XMLCALL
 metaComment(void *userData, const XML_Char *data) {
   XML_Parser parser = userData;
-  XmlwfUserData *usrData = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *usrData = XML_GetUserData(parser);
   FILE *fp = usrData->fp;
   fputts(T("<comment data=\""), fp);
   characterData(usrData, data, (int)tcslen(data));
@@ -652,7 +652,7 @@ metaComment(void *userData, const XML_Char *data) {
 static void XMLCALL
 metaStartCdataSection(void *userData) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<startcdata"), fp);
   metaLocation(parser);
@@ -662,7 +662,7 @@ metaStartCdataSection(void *userData) {
 static void XMLCALL
 metaEndCdataSection(void *userData) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<endcdata"), fp);
   metaLocation(parser);
@@ -672,7 +672,7 @@ metaEndCdataSection(void *userData) {
 static void XMLCALL
 metaCharacterData(void *userData, const XML_Char *s, int len) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<chars str=\""), fp);
   characterData(data, s, len);
@@ -686,7 +686,7 @@ metaStartDoctypeDecl(void *userData, const XML_Char *doctypeName,
                      const XML_Char *sysid, const XML_Char *pubid,
                      int has_internal_subset) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   UNUSED_P(sysid);
   UNUSED_P(pubid);
@@ -699,7 +699,7 @@ metaStartDoctypeDecl(void *userData, const XML_Char *doctypeName,
 static void XMLCALL
 metaEndDoctypeDecl(void *userData) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<enddoctype"), fp);
   metaLocation(parser);
@@ -711,7 +711,7 @@ metaNotationDecl(void *userData, const XML_Char *notationName,
                  const XML_Char *base, const XML_Char *systemId,
                  const XML_Char *publicId) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   UNUSED_P(base);
   ftprintf(fp, T("<notation name=\"%s\""), notationName);
@@ -732,7 +732,7 @@ metaEntityDecl(void *userData, const XML_Char *entityName, int is_param,
                const XML_Char *systemId, const XML_Char *publicId,
                const XML_Char *notationName) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
 
   UNUSED_P(is_param);
@@ -769,7 +769,7 @@ static void XMLCALL
 metaStartNamespaceDecl(void *userData, const XML_Char *prefix,
                        const XML_Char *uri) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   fputts(T("<startns"), fp);
   if (prefix)
@@ -785,7 +785,7 @@ metaStartNamespaceDecl(void *userData, const XML_Char *prefix,
 static void XMLCALL
 metaEndNamespaceDecl(void *userData, const XML_Char *prefix) {
   XML_Parser parser = userData;
-  XmlwfUserData *data = (XmlwfUserData *)XML_GetUserData(parser);
+  XmlwfUserData *data = XML_GetUserData(parser);
   FILE *fp = data->fp;
   if (! prefix)
     fputts(T("<endns/>\n"), fp);

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -196,7 +196,7 @@ startElement(void *userData, const XML_Char *name, const XML_Char **atts) {
     ++p;
   nAtts = (int)((p - atts) >> 1);
   if (nAtts > 1)
-    qsort((void *)atts, nAtts, sizeof(XML_Char *) * 2, attcmp);
+    qsort(atts, nAtts, sizeof(XML_Char *) * 2, attcmp);
   while (*atts) {
     puttc(T(' '), fp);
     fputts(*atts++, fp);
@@ -252,7 +252,7 @@ startElementNS(void *userData, const XML_Char *name, const XML_Char **atts) {
     ++p;
   nAtts = (int)((p - atts) >> 1);
   if (nAtts > 1)
-    qsort((void *)atts, nAtts, sizeof(XML_Char *) * 2, nsattcmp);
+    qsort(atts, nAtts, sizeof(XML_Char *) * 2, nsattcmp);
   while (*atts) {
     name = *atts++;
     sep = tcsrchr(name, NSSEP);


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [x] This pull request is related to
  - #497
  - #553 
  - #697 
  - #807 
  - #934 
  - #1033 
  - #1036
- [ ] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

Apologies for the grab bag of issue/PR references above. It seems like this has been a steady trickle of (1) users reporting problems when compiling expat C files as C++ and (2) explicit casts from/to `void *` being removed. This PR tries to advance (2) further.

IMHO we should continue down this road, removing all such casts for several motivations:
1. Removing these casts, in many cases, leads to significantly more readable code.
2. C casts are, in some ways, too powerful. They (deliberately or accidentally) silence a variety of warnings and impede the compiler’s ability to diagnose typos. Personally I try to avoid casts everywhere I can.

These changes might surface more breakage for people building this code as C++. That is not an aim of this PR but perhaps this is not an undesirable outcome. C and C++ have subtly different semantics in a number of cases. People building expat’s C code as C++ may be silently getting broken output without realising it. Surfacing that the wrong compiler is in use may be valuable.
