### PR TITLE
Add Windows ARM64 Workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -60,6 +60,13 @@ jobs:
             expat_char_type: wchar_t
             expat_dll: libexpatwd.dll
             expat_sln: expat.sln
+          - runs-on: windows-11-arm
+            cmake_build_type: Debug
+            cmake_generator: Visual Studio 17 2022
+            cmake_platform: ARM64
+            expat_char_type: wchar_t
+            expat_dll: libexpatwd.dll
+            expat_sln: expat.sln
           - runs-on: windows-2025-vs2026
             cmake_build_type: Debug
             cmake_generator: Visual Studio 18 2026


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [ ] This pull request is small, uncontroversial, complete, and easy to review.
- [ ] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

This pull request adds a native Windows ARM64 job to the existing Windows CI workflow.

The change introduces a configuration that runs on the `windows-11-arm` runner and builds
Expat using **Visual Studio 17 2022** with `ARM64` as the target platform. The job exercises
the wide‑character (`wchar_t`) build and produces the corresponding debug DLL
(`libexpatwd.dll`).

No existing CI jobs or platforms are modified.
This is a minimal, additive change intended to improve CI coverage for Windows on ARM and enable native Windows ARM64 builds.
