### PR TITLE
Add a 7 day cooldown to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,19 +35,12 @@ updates:
       include: "scope"
       prefix: "Actions"
     directory: "/"
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
-    groups:
-      actions:
-        patterns:
-          - "*"
+    labels:
+      - "enhancement"
     schedule:
-      interval: "quarterly"
+      interval: "weekly"
     cooldown:
       # https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
       # Cooldowns protect against supply chain attacks by avoiding the
       # highest-risk window immediately after new releases.
-      default-days: 14
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,7 +35,19 @@ updates:
       include: "scope"
       prefix: "Actions"
     directory: "/"
-    labels:
-      - "enhancement"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    groups:
+      actions:
+        patterns:
+          - "*"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
+    cooldown:
+      # https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+      # Cooldowns protect against supply chain attacks by avoiding the
+      # highest-risk window immediately after new releases.
+      default-days: 14


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [ ] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [ ] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description
Hi @hartwork, since @dependabot is given free reign here and can push, I suggest you add a 14-day cool down. This protects against supply chain attacks by avoiding the highest-risk window immediately after new releases. I also suggest two other things, but they aren't for security, so I can revert them if that is preferred.

- Only update on a new major version, this should decrease the frequency of updates.
- Group all actions updates into one commit.
- Bump interval to quarterly, note that Dependabot ignores this in the event of a security vulnerability.
- Removed label, it's not used anyway.
