### PR TITLE
`perl-integration.yml`: Bump to XML::Parser 2.59

### DIFF
--- a/.github/workflows/perl-integration.yml
+++ b/.github/workflows/perl-integration.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         xml_parser_commit:
           - "7096c4e45a62a23837382cf822d8c2dab780a3a1"  # ==2.47 without AI
-          - "3fb2a0bf51a67a09e30c09351b28b52da9d4a166"  # ==2.58    with AI
+          - "16fff0b90acbfb788f4c16ddc7c594ece91b5089"  # ==2.59    with AI
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
Related:
- https://github.com/cpan-authors/XML-Parser/releases/tag/2.59
- https://github.com/cpan-authors/XML-Parser/compare/2.58...2.59
