### PR TITLE
lib: Fix counting of heap statistics following tolerable increase check

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -839,7 +839,7 @@ expat_heap_increase_tolerable(XML_Parser rootParser, XmlBigCount increase,
     }
   }
 
-  if (! tolerable && (rootParser->m_alloc_tracker.debugLevel >= 1)) {
+  if (tolerable && (rootParser->m_alloc_tracker.debugLevel >= 1)) {
     expat_heap_stat(rootParser, '+', increase, newTotal, newTotal, sourceLine);
   }
 


### PR DESCRIPTION
# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

A typo I noticed while working on recent development. If this is a genuine fix, perhaps we should introduce a test case for this.
