### PR TITLE
lib|tests: Include header `expat_config.h` first (fixes #1239)

### DIFF
--- a/expat/lib/random_getrandom.c
+++ b/expat/lib/random_getrandom.c
@@ -32,9 +32,9 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include "random_getrandom.h"
-
 #include "expat_config.h" // for HAVE_GETRANDOM, HAVE_SYSCALL_GETRANDOM
+
+#include "random_getrandom.h"
 
 #if defined(HAVE_GETRANDOM)
 #  include <sys/random.h> /* getrandom */

--- a/expat/tests/acc_tests.c
+++ b/expat/tests/acc_tests.c
@@ -41,11 +41,11 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include "expat_config.h"
+
 #include <math.h> /* NAN, INFINITY */
 #include <stdio.h>
 #include <string.h>
-
-#include "expat_config.h"
 
 #include "expat.h"
 #include "internal.h"

--- a/expat/tests/alloc_tests.c
+++ b/expat/tests/alloc_tests.c
@@ -47,13 +47,13 @@
 #  undef NDEBUG /* because test suite relies on assert(...) at the moment */
 #endif
 
+#include "expat_config.h"
+
 #include <math.h> /* NAN, INFINITY */
 #include <stdbool.h>
 #include <stdint.h> /* for SIZE_MAX */
 #include <string.h>
 #include <assert.h>
-
-#include "expat_config.h"
 
 #include "expat.h"
 #include "internal.h"

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -48,14 +48,14 @@
 #  undef NDEBUG /* because test suite relies on assert(...) at the moment */
 #endif
 
+#include "expat_config.h"
+
 #include <assert.h>
 
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-
-#include "expat_config.h"
 
 #include "expat.h"
 #include "internal.h"

--- a/expat/tests/common.c
+++ b/expat/tests/common.c
@@ -42,13 +42,14 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include "expat_config.h"
+
 #include <assert.h>
 #include <errno.h>
 #include <stdint.h> // for SIZE_MAX
 #include <stdio.h>
 #include <string.h>
 
-#include "expat_config.h"
 #include "expat.h"
 #include "internal.h"
 #include "chardata.h"

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -47,12 +47,12 @@
 #  undef NDEBUG /* because test suite relies on assert(...) at the moment */
 #endif
 
+#include "expat_config.h"
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
-
-#include "expat_config.h"
 
 #include "expat.h"
 #include "internal.h"

--- a/expat/tests/misc_tests.c
+++ b/expat/tests/misc_tests.c
@@ -47,10 +47,10 @@
 #  undef NDEBUG /* because test suite relies on assert(...) at the moment */
 #endif
 
+#include "expat_config.h"
+
 #include <assert.h>
 #include <string.h>
-
-#include "expat_config.h"
 
 #include "expat.h"
 #include "internal.h"


### PR DESCRIPTION
Fixes #1239