### PR TITLE
lib: Shrink size of `XML_GetBuffer`

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2557,15 +2557,17 @@ XML_GetBuffer(XML_Parser parser, int len) {
         //       is not being allocated with MALLOC(..) but with plain
         //       .malloc_fcn(..).
         parser->m_mem.free_fcn(parser->m_buffer);
+        parser->m_buffer = newBuf;
         parser->m_bufferEnd
             = newBuf
               + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
               + keep;
       } else {
         /* This must be a brand new buffer with no data in it yet */
+        parser->m_buffer = newBuf;
         parser->m_bufferEnd = newBuf;
       }
-      parser->m_bufferPtr = parser->m_buffer = newBuf;
+      parser->m_bufferPtr = newBuf;
 #endif /* XML_CONTEXT_BYTES > 0 */
     }
     parser->m_eventPtr = parser->m_eventEndPtr = NULL;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2471,7 +2471,9 @@ XML_GetBuffer(XML_Parser parser, int len) {
       return NULL;
     }
 #if XML_CONTEXT_BYTES > 0
-    int keep = (int)EXPAT_SAFE_PTR_DIFF(parser->m_bufferPtr, parser->m_buffer);
+    const int parsed
+        = (int)EXPAT_SAFE_PTR_DIFF(parser->m_bufferPtr, parser->m_buffer);
+    int keep = parsed;
     if (keep > XML_CONTEXT_BYTES)
       keep = XML_CONTEXT_BYTES;
     /* Detect and prevent integer overflow */
@@ -2485,10 +2487,8 @@ XML_GetBuffer(XML_Parser parser, int len) {
         && neededSize
                <= EXPAT_SAFE_PTR_DIFF(parser->m_bufferLim, parser->m_buffer)) {
 #if XML_CONTEXT_BYTES > 0
-      if (keep < EXPAT_SAFE_PTR_DIFF(parser->m_bufferPtr, parser->m_buffer)) {
-        int offset
-            = (int)EXPAT_SAFE_PTR_DIFF(parser->m_bufferPtr, parser->m_buffer)
-              - keep;
+      if (keep < parsed) {
+        int offset = parsed - keep;
         /* The buffer pointers cannot be NULL here; we have at least some bytes
          * in the buffer */
         memmove(parser->m_buffer, &parser->m_buffer[offset],

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2439,6 +2439,31 @@ XML_ParseBuffer(XML_Parser parser, int len, int isFinal) {
   return result;
 }
 
+/* Modifies `parser`’s buffer to be backed by `newBuf`. */
+static void
+setParserBuffer(XML_Parser parser, char *newBuf, int newBufSize, int keep) {
+  parser->m_bufferLim = newBuf + newBufSize;
+  if (parser->m_bufferPtr) {
+    memcpy(newBuf, parser->m_bufferPtr - keep,
+           EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
+               + keep);
+    // NOTE: We are avoiding FREE(..) here because parser->m_buffer
+    //       is not being allocated with MALLOC(..) but with plain
+    //       .malloc_fcn(..).
+    parser->m_mem.free_fcn(parser->m_buffer);
+    parser->m_buffer = newBuf;
+    parser->m_bufferEnd
+        = newBuf + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
+          + keep;
+    parser->m_bufferPtr = parser->m_buffer + keep;
+  } else {
+    /* This must be a brand new buffer with no data in it yet */
+    parser->m_buffer = newBuf;
+    parser->m_bufferEnd = newBuf;
+    parser->m_bufferPtr = newBuf;
+  }
+}
+
 void *XMLCALL
 XML_GetBuffer(XML_Parser parser, int len) {
   if (parser == NULL)
@@ -2526,27 +2551,7 @@ XML_GetBuffer(XML_Parser parser, int len) {
         parser->m_errorCode = XML_ERROR_NO_MEMORY;
         return NULL;
       }
-      parser->m_bufferLim = newBuf + bufferSize;
-      if (parser->m_bufferPtr) {
-        memcpy(newBuf, parser->m_bufferPtr - keep,
-               EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
-                   + keep);
-        // NOTE: We are avoiding FREE(..) here because parser->m_buffer
-        //       is not being allocated with MALLOC(..) but with plain
-        //       .malloc_fcn(..).
-        parser->m_mem.free_fcn(parser->m_buffer);
-        parser->m_buffer = newBuf;
-        parser->m_bufferEnd
-            = newBuf
-              + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
-              + keep;
-        parser->m_bufferPtr = parser->m_buffer + keep;
-      } else {
-        /* This must be a brand new buffer with no data in it yet */
-        parser->m_buffer = newBuf;
-        parser->m_bufferEnd = newBuf;
-        parser->m_bufferPtr = newBuf;
-      }
+      setParserBuffer(parser, newBuf, bufferSize, keep);
     }
     parser->m_eventPtr = parser->m_eventEndPtr = NULL;
     parser->m_positionPtr = NULL;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2549,8 +2549,9 @@ XML_GetBuffer(XML_Parser parser, int len) {
       }
 #else
       if (parser->m_bufferPtr) {
-        memcpy(newBuf, parser->m_bufferPtr,
-               EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr));
+        memcpy(newBuf, parser->m_bufferPtr - keep,
+               EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
+                   + keep);
         // NOTE: We are avoiding FREE(..) here because parser->m_buffer
         //       is not being allocated with MALLOC(..) but with plain
         //       .malloc_fcn(..).

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2538,7 +2538,7 @@ XML_GetBuffer(XML_Parser parser, int len) {
         parser->m_mem.free_fcn(parser->m_buffer);
         parser->m_buffer = newBuf;
         parser->m_bufferEnd
-            = parser->m_buffer
+            = newBuf
               + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
               + keep;
         parser->m_bufferPtr = parser->m_buffer + keep;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2444,17 +2444,15 @@ static void
 setParserBuffer(XML_Parser parser, char *newBuf, int newBufSize, int keep) {
   parser->m_bufferLim = newBuf + newBufSize;
   if (parser->m_bufferPtr) {
-    memcpy(newBuf, parser->m_bufferPtr - keep,
-           EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
-               + keep);
+    const int parsing
+        = (int)EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr);
+    memcpy(newBuf, parser->m_bufferPtr - keep, parsing + keep);
     // NOTE: We are avoiding FREE(..) here because parser->m_buffer
     //       is not being allocated with MALLOC(..) but with plain
     //       .malloc_fcn(..).
     parser->m_mem.free_fcn(parser->m_buffer);
     parser->m_buffer = newBuf;
-    parser->m_bufferEnd
-        = newBuf + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
-          + keep;
+    parser->m_bufferEnd = newBuf + parsing + keep;
     parser->m_bufferPtr = newBuf + keep;
   } else {
     /* This must be a brand new buffer with no data in it yet */

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2527,7 +2527,6 @@ XML_GetBuffer(XML_Parser parser, int len) {
         return NULL;
       }
       parser->m_bufferLim = newBuf + bufferSize;
-#if XML_CONTEXT_BYTES > 0
       if (parser->m_bufferPtr) {
         memcpy(newBuf, parser->m_bufferPtr - keep,
                EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
@@ -2548,28 +2547,6 @@ XML_GetBuffer(XML_Parser parser, int len) {
         parser->m_bufferEnd = newBuf;
         parser->m_bufferPtr = newBuf;
       }
-#else
-      if (parser->m_bufferPtr) {
-        memcpy(newBuf, parser->m_bufferPtr - keep,
-               EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
-                   + keep);
-        // NOTE: We are avoiding FREE(..) here because parser->m_buffer
-        //       is not being allocated with MALLOC(..) but with plain
-        //       .malloc_fcn(..).
-        parser->m_mem.free_fcn(parser->m_buffer);
-        parser->m_buffer = newBuf;
-        parser->m_bufferEnd
-            = newBuf
-              + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
-              + keep;
-        parser->m_bufferPtr = parser->m_buffer + keep;
-      } else {
-        /* This must be a brand new buffer with no data in it yet */
-        parser->m_buffer = newBuf;
-        parser->m_bufferEnd = newBuf;
-        parser->m_bufferPtr = newBuf;
-      }
-#endif /* XML_CONTEXT_BYTES > 0 */
     }
     parser->m_eventPtr = parser->m_eventEndPtr = NULL;
     parser->m_positionPtr = NULL;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2455,7 +2455,7 @@ setParserBuffer(XML_Parser parser, char *newBuf, int newBufSize, int keep) {
     parser->m_bufferEnd
         = newBuf + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
           + keep;
-    parser->m_bufferPtr = parser->m_buffer + keep;
+    parser->m_bufferPtr = newBuf + keep;
   } else {
     /* This must be a brand new buffer with no data in it yet */
     parser->m_buffer = newBuf;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2562,12 +2562,13 @@ XML_GetBuffer(XML_Parser parser, int len) {
             = newBuf
               + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
               + keep;
+        parser->m_bufferPtr = parser->m_buffer + keep;
       } else {
         /* This must be a brand new buffer with no data in it yet */
         parser->m_buffer = newBuf;
         parser->m_bufferEnd = newBuf;
+        parser->m_bufferPtr = newBuf;
       }
-      parser->m_bufferPtr = newBuf;
 #endif /* XML_CONTEXT_BYTES > 0 */
     }
     parser->m_eventPtr = parser->m_eventEndPtr = NULL;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2529,7 +2529,7 @@ XML_GetBuffer(XML_Parser parser, int len) {
       parser->m_bufferLim = newBuf + bufferSize;
 #if XML_CONTEXT_BYTES > 0
       if (parser->m_bufferPtr) {
-        memcpy(newBuf, &parser->m_bufferPtr[-keep],
+        memcpy(newBuf, parser->m_bufferPtr - keep,
                EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
                    + keep);
         // NOTE: We are avoiding FREE(..) here because parser->m_buffer

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2481,8 +2481,10 @@ XML_GetBuffer(XML_Parser parser, int len) {
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       return NULL;
     }
-    neededSize += keep;
+#else
+    int keep = 0;
 #endif /* XML_CONTEXT_BYTES > 0 */
+    neededSize += keep;
     if (parser->m_buffer && parser->m_bufferPtr
         && neededSize
                <= EXPAT_SAFE_PTR_DIFF(parser->m_bufferLim, parser->m_buffer)) {

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2558,7 +2558,8 @@ XML_GetBuffer(XML_Parser parser, int len) {
         parser->m_mem.free_fcn(parser->m_buffer);
         parser->m_bufferEnd
             = newBuf
-              + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr);
+              + EXPAT_SAFE_PTR_DIFF(parser->m_bufferEnd, parser->m_bufferPtr)
+              + keep;
       } else {
         /* This must be a brand new buffer with no data in it yet */
         parser->m_bufferEnd = newBuf;

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2544,8 +2544,9 @@ XML_GetBuffer(XML_Parser parser, int len) {
         parser->m_bufferPtr = parser->m_buffer + keep;
       } else {
         /* This must be a brand new buffer with no data in it yet */
+        parser->m_buffer = newBuf;
         parser->m_bufferEnd = newBuf;
-        parser->m_bufferPtr = parser->m_buffer = newBuf;
+        parser->m_bufferPtr = newBuf;
       }
 #else
       if (parser->m_bufferPtr) {


### PR DESCRIPTION
# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

This PR step-by-step tries to unify some logic in `XML_GetBuffer` between `XML_CONTEXT_BYTES > 0`/`XML_CONTEXT_BYTES <= 0` branches. The overall intention is to reduce the size and branching complexity of this function.