### PR TITLE
lib: `XML_ParserReset`: Extract repeated linked-list move logic + Unify entity free lists

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1840,7 +1840,6 @@ destroyBindings(BINDING *bindings, XML_Parser parser) {
 void XMLCALL
 XML_ParserFree(XML_Parser parser) {
   TAG *tagList;
-  OPEN_INTERNAL_ENTITY *entityList;
   if ((parser == NULL) || isCalledFromInsideHandler(parser))
     return;
   /* free m_tagStack and m_freeTagList */
@@ -1860,42 +1859,30 @@ XML_ParserFree(XML_Parser parser) {
     FREE(parser, p);
   }
   /* free m_openInternalEntities */
-  entityList = parser->m_openInternalEntities;
-  for (;;) {
-    OPEN_INTERNAL_ENTITY *openEntity;
-    if (entityList == NULL)
-      break;
-    openEntity = entityList;
+  for (OPEN_INTERNAL_ENTITY *entityList = parser->m_openInternalEntities;
+       entityList != NULL;) {
+    OPEN_INTERNAL_ENTITY *const openEntity = entityList;
     entityList = entityList->next;
     FREE(parser, openEntity);
   }
   /* free m_openAttributeEntities */
-  entityList = parser->m_openAttributeEntities;
-  for (;;) {
-    OPEN_INTERNAL_ENTITY *openEntity;
-    if (entityList == NULL)
-      break;
-    openEntity = entityList;
+  for (OPEN_INTERNAL_ENTITY *entityList = parser->m_openAttributeEntities;
+       entityList != NULL;) {
+    OPEN_INTERNAL_ENTITY *const openEntity = entityList;
     entityList = entityList->next;
     FREE(parser, openEntity);
   }
   /* free m_openValueEntities */
-  entityList = parser->m_openValueEntities;
-  for (;;) {
-    OPEN_INTERNAL_ENTITY *openEntity;
-    if (entityList == NULL)
-      break;
-    openEntity = entityList;
+  for (OPEN_INTERNAL_ENTITY *entityList = parser->m_openValueEntities;
+       entityList != NULL;) {
+    OPEN_INTERNAL_ENTITY *const openEntity = entityList;
     entityList = entityList->next;
     FREE(parser, openEntity);
   }
   /* free m_freeEntities */
-  entityList = parser->m_freeEntities;
-  for (;;) {
-    OPEN_INTERNAL_ENTITY *openEntity;
-    if (entityList == NULL)
-      break;
-    openEntity = entityList;
+  for (OPEN_INTERNAL_ENTITY *entityList = parser->m_freeEntities;
+       entityList != NULL;) {
+    OPEN_INTERNAL_ENTITY *const openEntity = entityList;
     entityList = entityList->next;
     FREE(parser, openEntity);
   }

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -1566,10 +1566,20 @@ moveToFreeBindingList(XML_Parser parser, BINDING *bindings) {
   }
 }
 
+/* Moves a list of entities onto the start of another list. */
+static void
+moveEntityList(OPEN_INTERNAL_ENTITY **dst, OPEN_INTERNAL_ENTITY **src) {
+  for (OPEN_INTERNAL_ENTITY *head = *src; head != NULL;) {
+    OPEN_INTERNAL_ENTITY *const openEntity = head;
+    head = head->next;
+    openEntity->next = *dst;
+    *dst = openEntity;
+  }
+}
+
 XML_Bool XMLCALL
 XML_ParserReset(XML_Parser parser, const XML_Char *encodingName) {
   TAG *tStk;
-  OPEN_INTERNAL_ENTITY *openEntityList;
 
   if ((parser == NULL) || isCalledFromInsideHandler(parser))
     return XML_FALSE;
@@ -1587,31 +1597,15 @@ XML_ParserReset(XML_Parser parser, const XML_Char *encodingName) {
     parser->m_freeTagList = tag;
   }
   /* move m_openInternalEntities to m_freeInternalEntities */
-  openEntityList = parser->m_openInternalEntities;
-  while (openEntityList) {
-    OPEN_INTERNAL_ENTITY *openEntity = openEntityList;
-    openEntityList = openEntity->next;
-    openEntity->next = parser->m_freeInternalEntities;
-    parser->m_freeInternalEntities = openEntity;
-  }
+  moveEntityList(&parser->m_freeInternalEntities,
+                 &parser->m_openInternalEntities);
   /* move m_openAttributeEntities to m_freeAttributeEntities (i.e. same task but
    * for attributes) */
-  openEntityList = parser->m_openAttributeEntities;
-  while (openEntityList) {
-    OPEN_INTERNAL_ENTITY *openEntity = openEntityList;
-    openEntityList = openEntity->next;
-    openEntity->next = parser->m_freeAttributeEntities;
-    parser->m_freeAttributeEntities = openEntity;
-  }
+  moveEntityList(&parser->m_freeAttributeEntities,
+                 &parser->m_openAttributeEntities);
   /* move m_openValueEntities to m_freeValueEntities (i.e. same task but
    * for value entities) */
-  openEntityList = parser->m_openValueEntities;
-  while (openEntityList) {
-    OPEN_INTERNAL_ENTITY *openEntity = openEntityList;
-    openEntityList = openEntity->next;
-    openEntity->next = parser->m_freeValueEntities;
-    parser->m_freeValueEntities = openEntity;
-  }
+  moveEntityList(&parser->m_freeValueEntities, &parser->m_openValueEntities);
   moveToFreeBindingList(parser, parser->m_inheritedBindings);
   FREE(parser, parser->m_unknownEncodingMem);
   if (parser->m_unknownEncodingRelease)

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -762,11 +762,9 @@ struct XML_ParserStruct {
   const char *m_eventEndPtr;
   const char *m_positionPtr;
   OPEN_INTERNAL_ENTITY *m_openInternalEntities;
-  OPEN_INTERNAL_ENTITY *m_freeInternalEntities;
   OPEN_INTERNAL_ENTITY *m_openAttributeEntities;
-  OPEN_INTERNAL_ENTITY *m_freeAttributeEntities;
   OPEN_INTERNAL_ENTITY *m_openValueEntities;
-  OPEN_INTERNAL_ENTITY *m_freeValueEntities;
+  OPEN_INTERNAL_ENTITY *m_freeEntities;
   XML_Bool m_defaultExpandInternalEntities;
   int m_tagLevel;
   ENTITY *m_declEntity;
@@ -1414,9 +1412,7 @@ parserCreate(const XML_Char *encodingName,
 
   parser->m_freeBindingList = NULL;
   parser->m_freeTagList = NULL;
-  parser->m_freeInternalEntities = NULL;
-  parser->m_freeAttributeEntities = NULL;
-  parser->m_freeValueEntities = NULL;
+  parser->m_freeEntities = NULL;
 
   parser->m_groupSize = 0;
   parser->m_groupConnector = NULL;
@@ -1596,16 +1592,14 @@ XML_ParserReset(XML_Parser parser, const XML_Char *encodingName) {
     tag->bindings = NULL;
     parser->m_freeTagList = tag;
   }
-  /* move m_openInternalEntities to m_freeInternalEntities */
-  moveEntityList(&parser->m_freeInternalEntities,
-                 &parser->m_openInternalEntities);
-  /* move m_openAttributeEntities to m_freeAttributeEntities (i.e. same task but
-   * for attributes) */
-  moveEntityList(&parser->m_freeAttributeEntities,
-                 &parser->m_openAttributeEntities);
-  /* move m_openValueEntities to m_freeValueEntities (i.e. same task but
-   * for value entities) */
-  moveEntityList(&parser->m_freeValueEntities, &parser->m_openValueEntities);
+  /* move m_openInternalEntities to m_freeEntities */
+  moveEntityList(&parser->m_freeEntities, &parser->m_openInternalEntities);
+  /* move m_openAttributeEntities to m_freeEntities (i.e. same task but for
+   * attributes) */
+  moveEntityList(&parser->m_freeEntities, &parser->m_openAttributeEntities);
+  /* move m_openValueEntities to m_freeEntities (i.e. same task but for value
+   * entities) */
+  moveEntityList(&parser->m_freeEntities, &parser->m_openValueEntities);
   moveToFreeBindingList(parser, parser->m_inheritedBindings);
   FREE(parser, parser->m_unknownEncodingMem);
   if (parser->m_unknownEncodingRelease)
@@ -1865,48 +1859,47 @@ XML_ParserFree(XML_Parser parser) {
     destroyBindings(p->bindings, parser);
     FREE(parser, p);
   }
-  /* free m_openInternalEntities and m_freeInternalEntities */
+  /* free m_openInternalEntities */
   entityList = parser->m_openInternalEntities;
   for (;;) {
     OPEN_INTERNAL_ENTITY *openEntity;
-    if (entityList == NULL) {
-      if (parser->m_freeInternalEntities == NULL)
-        break;
-      entityList = parser->m_freeInternalEntities;
-      parser->m_freeInternalEntities = NULL;
-    }
+    if (entityList == NULL)
+      break;
     openEntity = entityList;
     entityList = entityList->next;
     FREE(parser, openEntity);
   }
-  /* free m_openAttributeEntities and m_freeAttributeEntities */
+  /* free m_openAttributeEntities */
   entityList = parser->m_openAttributeEntities;
   for (;;) {
     OPEN_INTERNAL_ENTITY *openEntity;
-    if (entityList == NULL) {
-      if (parser->m_freeAttributeEntities == NULL)
-        break;
-      entityList = parser->m_freeAttributeEntities;
-      parser->m_freeAttributeEntities = NULL;
-    }
+    if (entityList == NULL)
+      break;
     openEntity = entityList;
     entityList = entityList->next;
     FREE(parser, openEntity);
   }
-  /* free m_openValueEntities and m_freeValueEntities */
+  /* free m_openValueEntities */
   entityList = parser->m_openValueEntities;
   for (;;) {
     OPEN_INTERNAL_ENTITY *openEntity;
-    if (entityList == NULL) {
-      if (parser->m_freeValueEntities == NULL)
-        break;
-      entityList = parser->m_freeValueEntities;
-      parser->m_freeValueEntities = NULL;
-    }
+    if (entityList == NULL)
+      break;
     openEntity = entityList;
     entityList = entityList->next;
     FREE(parser, openEntity);
   }
+  /* free m_freeEntities */
+  entityList = parser->m_freeEntities;
+  for (;;) {
+    OPEN_INTERNAL_ENTITY *openEntity;
+    if (entityList == NULL)
+      break;
+    openEntity = entityList;
+    entityList = entityList->next;
+    FREE(parser, openEntity);
+  }
+  parser->m_freeEntities = NULL;
   destroyBindings(parser->m_freeBindingList, parser);
   destroyBindings(parser->m_inheritedBindings, parser);
   poolDestroy(&parser->m_tempPool);
@@ -6389,20 +6382,18 @@ epilogProcessor(XML_Parser parser, const char *s, const char *end,
 static enum XML_Error
 processEntity(XML_Parser parser, ENTITY *entity, XML_Bool betweenDecl,
               enum EntityType type) {
-  OPEN_INTERNAL_ENTITY *openEntity, **openEntityList, **freeEntityList;
+  OPEN_INTERNAL_ENTITY *openEntity, **openEntityList;
+  OPEN_INTERNAL_ENTITY **const freeEntityList = &parser->m_freeEntities;
   switch (type) {
   case ENTITY_INTERNAL:
     parser->m_processor = internalEntityProcessor;
     openEntityList = &parser->m_openInternalEntities;
-    freeEntityList = &parser->m_freeInternalEntities;
     break;
   case ENTITY_ATTRIBUTE:
     openEntityList = &parser->m_openAttributeEntities;
-    freeEntityList = &parser->m_freeAttributeEntities;
     break;
   case ENTITY_VALUE:
     openEntityList = &parser->m_openValueEntities;
-    freeEntityList = &parser->m_freeValueEntities;
     break;
     /* default case serves merely as a safety net in case of a
      * wrong entityType. Therefore we exclude the following lines
@@ -6519,8 +6510,8 @@ internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
   parser->m_openInternalEntities = parser->m_openInternalEntities->next;
 
   /* put openEntity back in list of free instances */
-  openEntity->next = parser->m_freeInternalEntities;
-  parser->m_freeInternalEntities = openEntity;
+  openEntity->next = parser->m_freeEntities;
+  parser->m_freeEntities = openEntity;
 
   if (parser->m_openInternalEntities == NULL) {
     parser->m_processor = entity->is_param ? prologProcessor : contentProcessor;
@@ -6596,8 +6587,8 @@ storeAttributeValue(XML_Parser parser, const ENCODING *enc, XML_Bool isCdata,
       parser->m_openAttributeEntities = parser->m_openAttributeEntities->next;
 
       /* put openEntity back in list of free instances */
-      openEntity->next = parser->m_freeAttributeEntities;
-      parser->m_freeAttributeEntities = openEntity;
+      openEntity->next = parser->m_freeEntities;
+      parser->m_freeEntities = openEntity;
     }
 
     // Break if an error occurred or there is nothing left to process
@@ -7056,8 +7047,8 @@ callStoreEntityValue(XML_Parser parser, const ENCODING *enc,
       parser->m_openValueEntities = parser->m_openValueEntities->next;
 
       /* put openEntity back in list of free instances */
-      openEntity->next = parser->m_freeValueEntities;
-      parser->m_freeValueEntities = openEntity;
+      openEntity->next = parser->m_freeEntities;
+      parser->m_freeEntities = openEntity;
     }
 
     // Break if an error occurred or there is nothing left to process


### PR DESCRIPTION
# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

> [!NOTE]
> While midway through making these changes, it occurred to me it might be simpler to just unify `m_freeInternalEntities`, `m_freeAttributeEntities`, and `m_freeValueEntities` into a single linked-list. Is there any reason these are separate free lists? I went back in history, but could not find an answer. Unifying them would both simplify the code and, seemingly, reduce memory pressure.

This removes unrelated reuse of the local `openEntityList`, adopts some more C99 style, and removes some opportunities for typos in this repetitive code.

Note that the outlined functionality is designed to be more general, making the source list empty, whereas the previous logic omitted this because the containing structure is thereafter freed. It seems safer to include this zeroing in case a future caller is expecting this safe behavior.

