### PR TITLE
lib: Make `XML_Index` overflow check more intuitive 

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -90,7 +90,7 @@
 #include <stddef.h>
 #include <string.h> /* memset(), memcpy() */
 #include <assert.h>
-#include <limits.h> /* INT_MAX, UINT_MAX */
+#include <limits.h> /* INT_MAX, LLONG_MAX, LONG_MAX, UINT_MAX */
 #include <stdio.h>  /* fprintf */
 #include <stdlib.h> /* getenv */
 #include <stdint.h> /* SIZE_MAX, uintptr_t */
@@ -206,6 +206,12 @@ typedef char ICHAR;
 #  define XML_T(x) x
 #  define XML_L(x) x
 
+#endif
+
+#ifdef XML_LARGE_SIZE
+#  define XML_INDEX_MAX LLONG_MAX
+#else
+#  define XML_INDEX_MAX LONG_MAX
 #endif
 
 /* Round up n to be a multiple of sz, where sz is a power of 2. */
@@ -2307,7 +2313,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
     int nLeftOver;
     enum XML_Status result;
     /* Detect overflow (a+b > MAX <==> b > MAX-a) */
-    if ((XML_Size)len > ((XML_Size)-1) / 2 - parser->m_parseEndByteIndex) {
+    if (len > XML_INDEX_MAX - parser->m_parseEndByteIndex) {
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       parser->m_eventPtr = parser->m_eventEndPtr = NULL;
       parser->m_processor = errorProcessor;


### PR DESCRIPTION
# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

In fixing a bug, https://github.com/libexpat/libexpat/commit/7e5b71b748491b6e459e5c9a1d090820f94544d8 introduced a magic number `2` in this code that made it difficult to understand the rationale for this overflow check without reading the commit log. This change introduces some more readable constants to use in these situations.

This PR has a couple of other minor commits included too.