### PR TITLE
[CVE-2026-56404] lib: Protect function `addBinding` from signed integer overflow

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -4368,6 +4368,10 @@ addBinding(XML_Parser parser, PREFIX *prefix, const ATTRIBUTE_ID *attId,
   }
 
   for (len = 0; uri[len]; len++) {
+    /* Detect and prevent signed integer overflow */
+    if (len == INT_MAX) {
+      return XML_ERROR_NO_MEMORY;
+    }
     if (isXML && (len > xmlLen || uri[len] != xmlNamespace[len]))
       isXML = XML_FALSE;
 
@@ -4408,8 +4412,13 @@ addBinding(XML_Parser parser, PREFIX *prefix, const ATTRIBUTE_ID *attId,
   if (isXMLNS)
     return XML_ERROR_RESERVED_NAMESPACE_URI;
 
-  if (parser->m_namespaceSeparator)
+  if (parser->m_namespaceSeparator) {
+    /* Detect and prevent signed integer overflow */
+    if (len == INT_MAX) {
+      return XML_ERROR_NO_MEMORY;
+    }
     len++;
+  }
   if (parser->m_freeBindingList) {
     b = parser->m_freeBindingList;
     if (len > b->uriAlloc) {


### PR DESCRIPTION
Sibling of #1232: same `int` counter walking past a NUL terminator, here in `addBinding` at expat/lib/xmlparse.c:4370 (`for (len = 0; uri[len]; len++)`) and at line 4411 (`if (parser->m_namespaceSeparator) len++;`). `uri` length is bounded by pool block size today, but the post-increment is still signed UB at the boundary.