### PR TITLE
[CVE-2026-56405] lib: Protect function `getAttributeId` from signed integer overflow

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -7196,6 +7196,10 @@ getAttributeId(XML_Parser parser, const ENCODING *enc, const char *start,
     } else {
       int i;
       for (i = 0; name[i]; i++) {
+        /* Detect and prevent signed integer overflow */
+        if (i == INT_MAX) {
+          return NULL;
+        }
         /* attributes without prefix are *not* in the default namespace */
         if (name[i] == XML_T(ASCII_COLON)) {
           if (! poolAppendChars(&dtd->pool, name, i))


### PR DESCRIPTION
Sibling of #1249/#1232: another `int` counter walking past a NUL terminator, here in `getAttributeId` at expat/lib/xmlparse.c:7198 (`for (i = 0; name[i]; i++)`) where the attribute name is scanned for a prefix colon. The name length is bounded by pool block size today, but the post-increment is still signed UB at the boundary, so guard `i` against INT_MAX the same way.