### PR TITLE
[CVE-2026-56410] xmlwf: protect resolveSystemId from integer overflow

### DIFF
--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -139,7 +139,14 @@ resolveSystemId(const XML_Char *base, const XML_Char *systemId,
 #endif
   )
     return systemId;
-  *toFree = malloc((tcslen(base) + tcslen(systemId) + 2) * sizeof(XML_Char));
+
+  const size_t charsRequired = tcslen(base) + tcslen(systemId) + 2;
+
+  /* Detect and prevent integer overflow */
+  if (charsRequired > SIZE_MAX / sizeof(XML_Char))
+    return systemId;
+
+  *toFree = malloc(charsRequired * sizeof(XML_Char));
   if (! *toFree)
     return systemId;
   tcscpy(*toFree, base);

--- a/expat/xmlwf/xmlfile.c
+++ b/expat/xmlwf/xmlfile.c
@@ -140,9 +140,17 @@ resolveSystemId(const XML_Char *base, const XML_Char *systemId,
   )
     return systemId;
 
-  const size_t charsRequired = tcslen(base) + tcslen(systemId) + 2;
+  const size_t baseLen = tcslen(base);
+  const size_t systemIdLen = tcslen(systemId);
 
-  /* Detect and prevent integer overflow */
+  /* Detect and prevent integer overflow in the addition (without risking
+     underflow) */
+  if (baseLen > SIZE_MAX - systemIdLen || baseLen > SIZE_MAX - systemIdLen - 2)
+    return systemId;
+
+  const size_t charsRequired = baseLen + systemIdLen + 2;
+
+  /* Detect and prevent integer overflow in the multiplication */
   if (charsRequired > SIZE_MAX / sizeof(XML_Char))
     return systemId;
 


### PR DESCRIPTION
resolveSystemId builds an absolute path by allocating (tcslen(base) + tcslen(systemId) + 2) * sizeof(XML_Char), then copies base and systemId in. systemId comes from an external entity SYSTEM identifier, so on a wide-char build the multiply can wrap and under-allocate, leaving the following tcscpy/tcscat to overflow the heap. Guard the count against SIZE_MAX / sizeof(XML_Char) before the malloc, like copyString does, and fall back to systemId as the malloc-failure path already does.