### PR TITLE
lib: Relocate some integer overflow checks to be more exact

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -7211,10 +7211,6 @@ getAttributeId(XML_Parser parser, const ENCODING *enc, const char *start,
     } else {
       int i;
       for (i = 0; name[i]; i++) {
-        /* Detect and prevent signed integer overflow */
-        if (i == INT_MAX) {
-          return NULL;
-        }
         /* attributes without prefix are *not* in the default namespace */
         if (name[i] == XML_T(ASCII_COLON)) {
           if (! poolAppendChars(&dtd->pool, name, i))
@@ -7230,6 +7226,10 @@ getAttributeId(XML_Parser parser, const ENCODING *enc, const char *start,
           else
             poolDiscard(&dtd->pool);
           break;
+        }
+        /* Detect and prevent signed integer overflow */
+        if (i == INT_MAX) {
+          return NULL;
         }
       }
     }

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -4374,10 +4374,6 @@ addBinding(XML_Parser parser, PREFIX *prefix, const ATTRIBUTE_ID *attId,
   }
 
   for (len = 0; uri[len]; len++) {
-    /* Detect and prevent signed integer overflow */
-    if (len == INT_MAX) {
-      return XML_ERROR_NO_MEMORY;
-    }
     if (isXML && (len > xmlLen || uri[len] != xmlNamespace[len]))
       isXML = XML_FALSE;
 
@@ -4406,6 +4402,10 @@ addBinding(XML_Parser parser, PREFIX *prefix, const ATTRIBUTE_ID *attId,
     if (parser->m_ns && (uri[len] == parser->m_namespaceSeparator)
         && ! is_rfc3986_uri_char(uri[len])) {
       return XML_ERROR_SYNTAX;
+    }
+    /* Detect and prevent signed integer overflow */
+    if (len == INT_MAX) {
+      return XML_ERROR_NO_MEMORY;
     }
   }
   isXML = isXML && len == xmlLen;


### PR DESCRIPTION
# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

A couple of integer overflow checks that landed in #1249 and #1251 are, I think, in an overly conservative location. This PR moves them to somewhere more precise. This probably sounds a little odd, but hopefully the diff makes it clear what I mean.

CC @netliomax25-code
