### PR TITLE
Stop using `/dev/urandom` by default (related to #1244, follow-up to #1254)

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -151,7 +151,7 @@ expat_shy_set(EXPAT_NS ON CACHE BOOL "Define to make XML Namespaces functionalit
 mark_as_advanced(EXPAT_NS)
 expat_shy_set(EXPAT_WARNINGS_AS_ERRORS OFF CACHE BOOL "Treat all compiler warnings as errors")
 if(UNIX OR _EXPAT_HELP)
-    expat_shy_set(EXPAT_DEV_URANDOM ON CACHE BOOL "Define to include code reading entropy from `/dev/urandom'.")
+    expat_shy_set(EXPAT_DEV_URANDOM OFF CACHE BOOL "Define to include code reading entropy from `/dev/urandom'.")
     mark_as_advanced(EXPAT_DEV_URANDOM)
 endif()
 if(UNIX OR WASI OR _EXPAT_HELP)

--- a/expat/configure.ac
+++ b/expat/configure.ac
@@ -395,8 +395,23 @@ AC_DEFINE([XML_GE], 1,
           [Define as 1/0 to enable/disable support for general entities.])
 AC_DEFINE([XML_DTD], 1,
           [Define to make parameter entity parsing functionality available.])
-AC_DEFINE([XML_DEV_URANDOM], 1,
-          [Define to include code reading entropy from `/dev/urandom'.])
+
+
+have_dev_urandom=false
+
+AC_ARG_WITH([dev-urandom],
+  [AS_HELP_STRING([--with-dev-urandom],
+                  [enforce the use of /dev/urandom in the system @<:@default=no@:>@])
+AS_HELP_STRING([--without-dev-urandom],
+               [enforce not using /dev/urandom in the system @<:@default=no@:>@])],
+  [with_dev_urandom=${withval}],
+  [])
+
+AS_IF([test "x${with_dev_urandom}" = "xyes"],
+  [have_dev_urandom=true
+   AC_DEFINE([XML_DEV_URANDOM], 1,
+             [Define to include code reading entropy from `/dev/urandom'.])])
+
 
 AC_ARG_ENABLE([xml-attr-info],
   [AS_HELP_STRING([--enable-xml-attr-info],
@@ -580,7 +595,7 @@ Entropy sources:
              getentropy: ${have_getentropy}
               getrandom: ${have_getrandom_function}
   syscall SYS_getrandom: ${have_getrandom_syscall}
-           /dev/urandom: true
+           /dev/urandom: ${have_dev_urandom}
 
 Continue with e.g.:
   make -j2

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -157,7 +157,7 @@
       * Windows >=Vista (rand_s): _WIN32. \
     \
     If you insist on not using any of these, bypass this error by defining \
-    XML_POOR_ENTROPY; you have been warned. \
+    XML_POOR_ENTROPY and be vulnerable to hash flooding; you have been warned. \
     \
     If you have reasons to patch this detection code away or need changes \
     to the build system, please open a bug.  Thank you!


### PR DESCRIPTION
In reaction to https://github.com/libexpat/libexpat/issues/1244#issuecomment-4587071130 …

Related to #1244, follow-up to #1254

CC @Smattr @dq193
