### PR TITLE
lib: XML_GetInputContext: Remove use of `0` for `NULL`

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2725,7 +2725,7 @@ XML_GetInputContext(XML_Parser parser, int *offset, int *size) {
   (void)offset;
   (void)size;
 #endif /* XML_CONTEXT_BYTES > 0 */
-  return (const char *)0;
+  return NULL;
 }
 
 XML_Size XMLCALL


### PR DESCRIPTION

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

This small change was extracted out of the original version of https://github.com/libexpat/libexpat/pull/1248.
