### PR TITLE
[CVE-2026-56409] xmlwf: Protect output path join from integer overflow

### DIFF
--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -1235,8 +1235,26 @@ tmain(int argc, XML_Char **argv) {
         }
 #endif
       }
-      outName
-          = malloc((tcslen(outputDir) + tcslen(file) + 2) * sizeof(XML_Char));
+      const size_t outputDirLen = tcslen(outputDir);
+      const size_t fileLen = tcslen(file);
+
+      /* Detect and prevent integer overflow in the addition (without
+         risking underflow) and the multiplication, mirroring the guards
+         in xcsdup() and resolveSystemId() */
+      if (outputDirLen > SIZE_MAX - fileLen
+          || outputDirLen > SIZE_MAX - fileLen - 2) {
+        tperror(T("Could not allocate memory"));
+        exit(XMLWF_EXIT_INTERNAL_ERROR);
+      }
+
+      const size_t charsRequired = outputDirLen + fileLen + 2;
+
+      if (charsRequired > SIZE_MAX / sizeof(XML_Char)) {
+        tperror(T("Could not allocate memory"));
+        exit(XMLWF_EXIT_INTERNAL_ERROR);
+      }
+
+      outName = malloc(charsRequired * sizeof(XML_Char));
       if (! outName) {
         tperror(T("Could not allocate memory"));
         exit(XMLWF_EXIT_INTERNAL_ERROR);


### PR DESCRIPTION
Noticed the `-d outputDir` branch in main() sizes the output filename with `(tcslen(outputDir) + tcslen(file) + 2) * sizeof(XML_Char)` and then tcscpy/tcscat the parts in, with neither the addition nor the multiply guarded. On long names the size wraps and under-allocates, then the copies overflow the heap. Added the same SIZE_MAX addition and multiplication guards already used in `xcsdup` and `resolveSystemId`, failing through the existing could-not-allocate path.