### PR TITLE
[CVE-2026-56407] Cap entity `textLen` against signed integer overflow

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -5534,6 +5534,10 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
             parser, enc, s + enc->minBytesPerChar, next - enc->minBytesPerChar,
             XML_ACCOUNT_NONE);
         if (parser->m_declEntity) {
+          /* Detect and prevent signed integer overflow */
+          if ((size_t)poolLength(&dtd->entityValuePool) > (size_t)INT_MAX) {
+            return XML_ERROR_NO_MEMORY;
+          }
           parser->m_declEntity->textPtr = poolStart(&dtd->entityValuePool);
           parser->m_declEntity->textLen
               = (int)(poolLength(&dtd->entityValuePool));
@@ -6944,6 +6948,11 @@ storeSelfEntityValue(XML_Parser parser, ENTITY *entity) {
     return XML_ERROR_NO_MEMORY;
   }
 
+  /* Detect and prevent signed integer overflow */
+  if ((size_t)poolLength(pool) > (size_t)INT_MAX) {
+    poolDiscard(pool);
+    return XML_ERROR_NO_MEMORY;
+  }
   entity->textPtr = poolStart(pool);
   entity->textLen = (int)(poolLength(pool));
   poolFinish(pool);


### PR DESCRIPTION
Hit this while fuzzing internal entity declarations. storeEntityValue stashes
the replacement text length with (int)poolLength(...), but the entity value
pool can grow past INT_MAX, so a huge <!ENTITY> value truncates textLen to a
negative int. When the entity is later referenced, textEnd = textPtr + textLen
lands before textPtr and the entity walk runs off the buffer. Cap the length
before the cast, the same way getAttributeId and addBinding already do.
