### PR TITLE
[CVE-2026-56411] xmlwf: protect notation list allocation from integer overflow

### DIFF
--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -384,15 +384,22 @@ static void XMLCALL
 endDoctypeDecl(void *userData) {
   XmlwfUserData *data = userData;
   NotationList **notations;
-  int notationCount = 0;
+  size_t notationCount = 0;
   NotationList *p;
-  int i;
+  size_t i;
 
   /* How many notations do we have? */
   for (p = data->notationListHead; p != NULL; p = p->next)
     notationCount++;
   if (notationCount == 0) {
     /* Nothing to report */
+    goto cleanUp;
+  }
+
+  /* Detect and prevent integer overflow in the multiplication, mirroring
+     the guards in xcsdup() and resolveSystemId() */
+  if (notationCount > SIZE_MAX / sizeof(NotationList *)) {
+    fprintf(stderr, "Unable to sort notations");
     goto cleanUp;
   }
 


### PR DESCRIPTION
endDoctypeDecl() counts NOTATION declarations from the DTD into a plain int and then mallocs notationCount * sizeof(NotationList *) with no overflow guard, so on 32-bit the multiply can wrap and under-allocate before the following write loop fills it. Switch the count to size_t and add the SIZE_MAX/sizeof guard already used in xcsdup() and resolveSystemId().