### PR TITLE
xmlwf: Pick a safe quote for notation system and public IDs

### DIFF
--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -380,6 +380,18 @@ notationCmp(const void *a, const void *b) {
   return xcscmp(n1->notationName, n2->notationName);
 }
 
+/* Write a SystemLiteral/PubidLiteral, choosing a delimiter that does not
+   occur in the value.  The grammar forbids a literal from containing its
+   own delimiter, so a value reported by Expat never holds both quote
+   characters and a safe delimiter always exists. */
+static void
+writeLiteral(FILE *fp, const XML_Char *value) {
+  const XML_Char quote = (tcschr(value, T('\'')) != NULL) ? T('"') : T('\'');
+  puttc(quote, fp);
+  fputts(value, fp);
+  puttc(quote, fp);
+}
+
 static void XMLCALL
 endDoctypeDecl(void *userData) {
   XmlwfUserData *data = userData;
@@ -424,19 +436,15 @@ endDoctypeDecl(void *userData) {
     fputts(T("<!NOTATION "), data->fp);
     fputts(notations[i]->notationName, data->fp);
     if (notations[i]->publicId != NULL) {
-      fputts(T(" PUBLIC '"), data->fp);
-      fputts(notations[i]->publicId, data->fp);
-      puttc(T('\''), data->fp);
+      fputts(T(" PUBLIC "), data->fp);
+      writeLiteral(data->fp, notations[i]->publicId);
       if (notations[i]->systemId != NULL) {
         puttc(T(' '), data->fp);
-        puttc(T('\''), data->fp);
-        fputts(notations[i]->systemId, data->fp);
-        puttc(T('\''), data->fp);
+        writeLiteral(data->fp, notations[i]->systemId);
       }
     } else if (notations[i]->systemId != NULL) {
-      fputts(T(" SYSTEM '"), data->fp);
-      fputts(notations[i]->systemId, data->fp);
-      puttc(T('\''), data->fp);
+      fputts(T(" SYSTEM "), data->fp);
+      writeLiteral(data->fp, notations[i]->systemId);
     }
     puttc(T('>'), data->fp);
     puttc(T('\n'), data->fp);


### PR DESCRIPTION
1. `endDoctypeDecl` reconstructs the DOCTYPE in the default (`-N`, not `-m`) output and writes each notation's `publicId`/`systemId` into a literal that always uses single quotes, with no escaping.
2. a `SystemLiteral` declared with double quotes may legally contain a single quote (same for an apostrophe in a double-quoted `PubidLiteral`), so an id such as `SYSTEM "harmless'><!ENTITY injected 'pwned'>"` closes the literal early and injects extra DTD markup into the reproduced output.
3. `writeLiteral` now picks a delimiter the value does not contain. The grammar forbids a literal from holding its own delimiter, so a value reported by Expat never has both quote characters and a safe delimiter always exists, leaving the id reproduced unchanged.

Checked with `-N -d`: a notation system id carrying a quote now stays inside the literal and the emitted DOCTYPE re-parses, while ids without quotes keep the previous single-quote form.