### PR TITLE
[CVE-2026-56131] lib: Protect `XML_ResumeParser` from being called from a handler

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2658,7 +2658,7 @@ enum XML_Status XMLCALL
 XML_ResumeParser(XML_Parser parser) {
   enum XML_Status result = XML_STATUS_OK;
 
-  if (parser == NULL)
+  if ((parser == NULL) || isCalledFromInsideHandler(parser))
     return XML_STATUS_ERROR;
   if (parser->m_parsingStatus.parsing != XML_SUSPENDED) {
     parser->m_errorCode = XML_ERROR_NOT_SUSPENDED;

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -2016,3 +2016,27 @@ forbidden_calls_character_handler(void *userData, const XML_Char *s, int len) {
 
   assert_true(XML_GetErrorCode(parser) == XML_ERROR_NONE);
 }
+
+void XMLCALL
+suspend_then_resume_character_handler(void *userData, const XML_Char *s,
+                                      int len) {
+  UNUSED_P(s);
+  UNUSED_P(len);
+  ResumeFromHandlerData *const data = (ResumeFromHandlerData *)userData;
+
+  data->callCount++;
+  if (data->callCount > 1) {
+    // Reached only if the guard under test is missing: XML_ResumeParser would
+    // then have driven the parser re-entrantly and called us again.  Bail out
+    // so the test fails by assertion below rather than recursing without bound.
+    return;
+  }
+
+  // Put the parser into XML_SUSPENDED so that, without the guard,
+  // XML_ResumeParser would proceed into a re-entrant parse.
+  assert_true(XML_StopParser(data->parser, /*resumable=*/XML_TRUE)
+              == XML_STATUS_OK);
+
+  // Resuming the parser from inside a handler must be rejected.
+  assert_true(XML_ResumeParser(data->parser) == XML_STATUS_ERROR);
+}

--- a/expat/tests/handlers.h
+++ b/expat/tests/handlers.h
@@ -617,6 +617,15 @@ extern void XMLCALL forbidden_calls_character_handler(void *userData,
                                                       const XML_Char *s,
                                                       int len);
 
+typedef struct {
+  XML_Parser parser;
+  int callCount;
+} ResumeFromHandlerData;
+
+extern void XMLCALL suspend_then_resume_character_handler(void *userData,
+                                                          const XML_Char *s,
+                                                          int len);
+
 #endif /* XML_HANDLERS_H */
 
 #ifdef __cplusplus

--- a/expat/tests/misc_tests.c
+++ b/expat/tests/misc_tests.c
@@ -816,6 +816,25 @@ START_TEST(test_misc_calls_forbidden_from_handlers) {
 }
 END_TEST
 
+START_TEST(test_misc_resume_parser_forbidden_from_handler) {
+  const char *const doc = "<doc>Hello world!</doc>";
+
+  XML_Parser parser = XML_ParserCreate(NULL);
+  ResumeFromHandlerData data = {parser, 0};
+  XML_SetUserData(parser, &data);
+  XML_SetCharacterDataHandler(parser, suspend_then_resume_character_handler);
+
+  // The handler suspends the parser, so the top-level parse reports suspension
+  // rather than completion.  The handler also asserts that resuming from inside
+  // itself is rejected.
+  assert_true(XML_Parse(parser, doc, (int)strlen(doc), /*isFinal=*/XML_TRUE)
+              == XML_STATUS_SUSPENDED);
+  assert_true(data.callCount == 1);
+
+  XML_ParserFree(parser);
+}
+END_TEST
+
 void
 make_miscellaneous_test_case(Suite *s) {
   TCase *tc_misc = tcase_create("miscellaneous tests");
@@ -848,4 +867,5 @@ make_miscellaneous_test_case(Suite *s) {
   tcase_add_test(tc_misc, test_misc_async_entity_rejected);
   tcase_add_test(tc_misc, test_misc_no_infinite_loop_issue_1161);
   tcase_add_test(tc_misc, test_misc_calls_forbidden_from_handlers);
+  tcase_add_test(tc_misc, test_misc_resume_parser_forbidden_from_handler);
 }


### PR DESCRIPTION
1. The handler-reentrancy guards from CVE-2026-50219 (#1246) added the `isCalledFromInsideHandler` check to `XML_Parse`, `XML_ParseBuffer`, `XML_GetBuffer`, `XML_ParserFree` and `XML_ParserReset`, but `XML_ResumeParser` was left out.
2. `XML_ResumeParser` drives the parser through `callProcessor` just like `XML_Parse`, so a handler that first suspends with `XML_StopParser(parser, XML_TRUE)` (which is allowed from handlers) and then calls `XML_ResumeParser(parser)` re-enters the parser while the outer parse is still on the stack, the same memory-corruption path the other guards close.
3. Added the same `isCalledFromInsideHandler` check at the top of `XML_ResumeParser`, matching `XML_ParseBuffer`.

Validation: a regression test suspends from a character data handler and asserts the in-handler resume is rejected. It fails before the change (the resume returns a non-error status and re-enters the parser) and passes after. Full suite green afterwards (Checks: 4812, Failed: 0).