### PR TITLE
cmake|windows: Add missing export for symbol `XML_SetHashSalt16Bytes` (follow-up to #1183)

### DIFF
--- a/expat/lib/libexpat.def.cmake
+++ b/expat/lib/libexpat.def.cmake
@@ -83,3 +83,5 @@ EXPORTS
 ; added with version 2.7.2
 @_EXPAT_COMMENT_DTD_OR_GE@ XML_SetAllocTrackerMaximumAmplification @72
 @_EXPAT_COMMENT_DTD_OR_GE@ XML_SetAllocTrackerActivationThreshold @73
+; added with version 2.8.0
+  XML_SetHashSalt16Bytes @74


### PR DESCRIPTION
A new XML_SetHashSalt16Bytes symbol was added in #1183, but it wasn't added to the def file, so the export is missing when building libexpat on Windows with cmake.

Add the new symbol to the .def template.