### PR TITLE
`linux.yml`: Make llvm-symbolizer available in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,7 +113,8 @@ jobs:
         # NOTE: Please note the version-specific ${PATH} extension for Clang adding /usr/lib/llvm-21/bin in .ci.sh
         sudo apt-get install --yes --no-install-recommends -V \
             clang-21 \
-            libclang-rt-21-dev
+            libclang-rt-21-dev \
+            llvm-21
     - name: Install build dependencies (common)
       run: |-
         sudo apt-get install --yes --no-install-recommends -V \


### PR DESCRIPTION
# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [x] This pull request is related to #1225
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

The effect of this is that MSan backtraces now have source path and line number instead of only object file and address. See e.g. https://github.com/Smattr/libexpat/actions/runs/27385449841/job/80931386649 vs https://github.com/Smattr/libexpat/actions/runs/27450119178/job/81143423891.