### PR TITLE
Teach Memory Sanitizer (MSan) semantics of randomization functions

### DIFF
--- a/expat/lib/Makefile.am
+++ b/expat/lib/Makefile.am
@@ -117,6 +117,7 @@ EXTRA_DIST = \
     internal.h \
     latin1tab.h \
     libexpat.def.cmake \
+    memory_sanitizer.h \
     nametab.h \
     siphash.h \
     utf8tab.h \

--- a/expat/lib/memory_sanitizer.h
+++ b/expat/lib/memory_sanitizer.h
@@ -6,7 +6,7 @@
                         \___/_/\_\ .__/ \__,_|\__|
                                  |_| XML parser
 
-   Copyright (c) 2026 Sebastian Pipping <sebastian@pipping.org>
+   Copyright (c) 2026 Matthew Fernandez <matthew.fernandez@gmail.com>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -29,31 +29,23 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include "random_getentropy.h"
+#if ! defined(MEMORY_SANITIZER_H)
+#  define MEMORY_SANITIZER_H 1
 
-// NOTE: Please keep this block in sync with its two siblings in files
-//       `configure.ac` and `ConfigureChecks.cmake`!
-#if defined(__APPLE__)
-#  include <sys/random.h>
-#else
-#  if defined(__GLIBC__) && ! defined(_DEFAULT_SOURCE)
-#    define _DEFAULT_SOURCE 1
+#  if defined(__has_feature)
+#    if __has_feature(memory_sanitizer)
+#      include <sanitizer/msan_interface.h>
+
+// inform Memory Sanitizer that [base, base + extent) is now initialized
+#      define MSAN_UNPOISON(base, extent) __msan_unpoison((base), (extent))
+
+#    endif
 #  endif
-#  if ! defined(_GNU_SOURCE)
-#    define _GNU_SOURCE 1 /* for musl */
+
+#  if ! defined(MSAN_UNPOISON)
+#    define MSAN_UNPOISON(base, extent)                                        \
+      do {                                                                     \
+      } while (0)
 #  endif
-#  include <unistd.h>
-#endif // ! defined(__APPLE__)
 
-#include "memory_sanitizer.h"
-#include <errno.h>
-
-bool
-writeRandomBytes_getentropy(void *target, size_t count) {
-  errno = 0;
-  const bool success = getentropy(target, count);
-  // MSan does not understand `getentropy`, so explain its effects
-  if (success)
-    MSAN_UNPOISON(target, count);
-  return success;
-}
+#endif // ! defined(MEMORY_SANITIZER_H)

--- a/expat/lib/random_arc4random_buf.c
+++ b/expat/lib/random_arc4random_buf.c
@@ -35,9 +35,12 @@
 #  define _DEFAULT_SOURCE 1 /* for glibc */
 #endif
 
+#include "memory_sanitizer.h"
 #include <stdlib.h> // for arc4random_buf
 
 void
 writeRandomBytes_arc4random_buf(void *target, size_t count) {
   arc4random_buf(target, count);
+  // MSan does not understand `arc4random_buf`, so explain its effects
+  MSAN_UNPOISON(target, count);
 }

--- a/expat/lib/random_getrandom.c
+++ b/expat/lib/random_getrandom.c
@@ -52,6 +52,7 @@
 #  define GRND_NONBLOCK 0x0001
 #endif /* defined(GRND_NONBLOCK) */
 
+#include "memory_sanitizer.h"
 #include <assert.h>
 #include <errno.h>
 #include <limits.h> // for INT_MAX
@@ -74,9 +75,13 @@ writeRandomBytes_getrandom_nonblock(void *target, size_t count) {
     const int bytesWrittenMore =
 #if defined(HAVE_GETRANDOM)
         (int)getrandom(currentTarget, bytesToWrite, getrandomFlags);
+    // MSan understands `getrandom`, so does not need extra guidance
 #else
         (int)syscall(SYS_getrandom, currentTarget, bytesToWrite,
                      getrandomFlags);
+    // MSan does not understand `syscall`, so explain its effects
+    if (bytesWrittenMore > 0)
+      MSAN_UNPOISON(currentTarget, bytesWrittenMore);
 #endif
 
     if (bytesWrittenMore > 0) {

--- a/expat/memory-sanitizer-blacklist.txt
+++ b/expat/memory-sanitizer-blacklist.txt
@@ -1,6 +1,0 @@
-# Line "hash_secret_salt = generate_hash_secret_salt(parser);"
-# is mis-reported as use-of-uninitialized-value because
-# its call to writeRandomBytes_getrandom_nonblock uses syscall
-# SYS_getrandom and MemorySanitizer does not seem to understand that
-# as writing bytes to that memory (which it does).
-fun:startParsing

--- a/expat/qa.sh
+++ b/expat/qa.sh
@@ -98,7 +98,7 @@ populate_environment() {
                 ;;
             memory)
                 # https://clang.llvm.org/docs/MemorySanitizer.html
-                BASE_COMPILE_FLAGS+=" -fsanitize=memory -fno-omit-frame-pointer -g -O2 -fsanitize-memory-track-origins -fsanitize-blacklist=$PWD/memory-sanitizer-blacklist.txt"
+                BASE_COMPILE_FLAGS+=" -fsanitize=memory -fno-omit-frame-pointer -g -O2 -fsanitize-memory-track-origins"
                 ;;
             undefined)
                 # https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html


### PR DESCRIPTION
# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [x] This pull request fixes #1225.
- [ ] This pull request is related to SOME_REFERENCE.
- [ ] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

Memory Sanitizer (MSan), by itself, does not understand the effect of certain libc/kernel functions. This causes it to e.g. report false positives of uninitialized memory access when reading the result of `syscall(SYS_getrandom, …)`. This was dealt with in 2446329958391c5647ba71f6a04964dd9e79b4ef by disabling monitoring in functions that trigger such code paths.

This series uses the MSan API to inform the sanitizer of the effects of functions it does not understand natively. The end result is that we can re-enable full MSan coverage, giving a stronger check against memory safety problems going forwards.
