### PR TITLE
[CVE-2026-56412] lib: Guard `XML_TOK_DATA_CHARS` handler calls in `doCdataSection`

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -4612,16 +4612,21 @@ doCdataSection(XML_Parser parser, const ENCODING *enc, const char **startPtr,
             const enum XML_Convert_Result convert_res = XmlConvert(
                 enc, &s, next, &dataPtr, (ICHAR *)parser->m_dataBufEnd);
             *eventEndPP = next;
+            beforeHandler(parser);
             charDataHandler(parser->m_handlerArg, parser->m_dataBuf,
                             (int)(dataPtr - (ICHAR *)parser->m_dataBuf));
+            afterHandler(parser);
             if ((convert_res == XML_CONVERT_COMPLETED)
                 || (convert_res == XML_CONVERT_INPUT_INCOMPLETE))
               break;
             *eventPP = s;
           }
-        } else
+        } else {
+          beforeHandler(parser);
           charDataHandler(parser->m_handlerArg, (const XML_Char *)s,
                           (int)((const XML_Char *)next - (const XML_Char *)s));
+          afterHandler(parser);
+        }
       } else if (parser->m_defaultHandler)
         reportDefault(parser, enc, s, next);
     } break;


### PR DESCRIPTION
<!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [ ] This pull request fixes #ISSUE_NUMBER.
- [x] This pull request is related to #1246.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [x] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

doCdataSection() invokes m_characterDataHandler for XML_TOK_DATA_CHARS
without beforeHandler()/afterHandler(), leaving m_handlerCallDepth at 0.
This allows isCalledFromInsideHandler() to incorrectly return false during
handler execution inside a CDATA section, bypassing the CVE-2026-50219 fix
(PR #1246) on all five protected functions.

Fix wraps both charDataHandler call sites in doCdataSection() with
beforeHandler()/afterHandler(), matching the existing pattern in doContent()
and XML_TOK_DATA_NEWLINE in the same function.

Verified with ASan  clean after fix. All 4800 existing tests pass.

Opened in agreement with @hartwork.
