### PR TITLE
[CVE-2026-93990] lib: Reject UTF-16 high surrogate not followed by a low surrogate

### DIFF
--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -228,6 +228,19 @@ struct normal_encoding {
       /* isNmstrt2 */ NULL, /* isNmstrt3 */ NULL, /* isNmstrt4 */ NULL,        \
       /* isInvalid2 */ NULL, /* isInvalid3 */ NULL, /* isInvalid4 */ NULL
 
+/* Like NULL_VTABLE but with a real isInvalid4 so the UTF-16 encodings reject a
+   high surrogate that is not followed by a low surrogate.  Only needed for the
+   XML_MIN_SIZE build, where the shared tokenizer dispatches through the vtable;
+   the regular build inlines the same check via IS_INVALID_CHAR. */
+#ifdef XML_MIN_SIZE
+#  define UTF16_NULL_VTABLE(E)                                                 \
+    /* isName2 */ NULL, /* isName3 */ NULL, /* isName4 */ NULL,                \
+        /* isNmstrt2 */ NULL, /* isNmstrt3 */ NULL, /* isNmstrt4 */ NULL,      \
+        /* isInvalid2 */ NULL, /* isInvalid3 */ NULL, E##isInvalid4
+#else
+#  define UTF16_NULL_VTABLE(E) NULL_VTABLE
+#endif
+
 static int FASTCALL checkCharRefNumber(int result);
 
 #include "xmltok_impl.h"
@@ -744,6 +757,11 @@ DEFINE_UTF16_TO_UTF16(big2_)
   UCS2_GET_NAMING(namePages, (unsigned char)p[1], (unsigned char)p[0])
 #define LITTLE2_IS_NMSTRT_CHAR_MINBPC(p)                                       \
   UCS2_GET_NAMING(nmstrtPages, (unsigned char)p[1], (unsigned char)p[0])
+/* A 4-byte UTF-16 character is a surrogate pair; byteType only reports BT_LEAD4
+   for a high surrogate, so the pair is invalid unless the second unit is a low
+   surrogate (U+DC00..U+DFFF, i.e. high byte 0xDC..0xDF). */
+#define LITTLE2_IS_INVALID_CHAR(p, n)                                          \
+  ((n) == 4 && ((unsigned char)(p)[3] & 0xFC) != 0xDC)
 
 #ifdef XML_MIN_SIZE
 
@@ -776,6 +794,12 @@ little2_isNmstrtMin(const ENCODING *enc, const char *p) {
   return LITTLE2_IS_NMSTRT_CHAR_MINBPC(p);
 }
 
+static int PTRFASTCALL
+little2_isInvalid4(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
+  return LITTLE2_IS_INVALID_CHAR(p, 4);
+}
+
 #  undef VTABLE
 #  define VTABLE VTABLE1, little2_toUtf8, little2_toUtf16
 
@@ -792,6 +816,7 @@ little2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  define IS_NAME_CHAR_MINBPC(enc, p) LITTLE2_IS_NAME_CHAR_MINBPC(p)
 #  define IS_NMSTRT_CHAR(enc, p, n) (0)
 #  define IS_NMSTRT_CHAR_MINBPC(enc, p) LITTLE2_IS_NMSTRT_CHAR_MINBPC(p)
+#  define IS_INVALID_CHAR(enc, p, n) LITTLE2_IS_INVALID_CHAR(p, n)
 
 #  define XML_TOK_IMPL_C
 #  include "xmltok_impl.c"
@@ -823,7 +848,7 @@ static const struct normal_encoding little2_encoding_ns
 #  include "asciitab.h"
 #  include "latin1tab.h"
        },
-       STANDARD_VTABLE(little2_) NULL_VTABLE};
+       STANDARD_VTABLE(little2_) UTF16_NULL_VTABLE(little2_)};
 
 #endif
 
@@ -841,7 +866,7 @@ static const struct normal_encoding little2_encoding
 #undef BT_COLON
 #include "latin1tab.h"
        },
-       STANDARD_VTABLE(little2_) NULL_VTABLE};
+       STANDARD_VTABLE(little2_) UTF16_NULL_VTABLE(little2_)};
 
 #if BYTEORDER != 4321
 
@@ -853,7 +878,7 @@ static const struct normal_encoding internal_little2_encoding_ns
 #    include "iasciitab.h"
 #    include "latin1tab.h"
        },
-       STANDARD_VTABLE(little2_) NULL_VTABLE};
+       STANDARD_VTABLE(little2_) UTF16_NULL_VTABLE(little2_)};
 
 #  endif
 
@@ -865,7 +890,7 @@ static const struct normal_encoding internal_little2_encoding
 #  undef BT_COLON
 #  include "latin1tab.h"
        },
-       STANDARD_VTABLE(little2_) NULL_VTABLE};
+       STANDARD_VTABLE(little2_) UTF16_NULL_VTABLE(little2_)};
 
 #endif
 
@@ -877,6 +902,11 @@ static const struct normal_encoding internal_little2_encoding
   UCS2_GET_NAMING(namePages, (unsigned char)p[0], (unsigned char)p[1])
 #define BIG2_IS_NMSTRT_CHAR_MINBPC(p)                                          \
   UCS2_GET_NAMING(nmstrtPages, (unsigned char)p[0], (unsigned char)p[1])
+/* A 4-byte UTF-16 character is a surrogate pair; byteType only reports BT_LEAD4
+   for a high surrogate, so the pair is invalid unless the second unit is a low
+   surrogate (U+DC00..U+DFFF, i.e. high byte 0xDC..0xDF). */
+#define BIG2_IS_INVALID_CHAR(p, n)                                             \
+  ((n) == 4 && ((unsigned char)(p)[2] & 0xFC) != 0xDC)
 
 #ifdef XML_MIN_SIZE
 
@@ -909,6 +939,12 @@ big2_isNmstrtMin(const ENCODING *enc, const char *p) {
   return BIG2_IS_NMSTRT_CHAR_MINBPC(p);
 }
 
+static int PTRFASTCALL
+big2_isInvalid4(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
+  return BIG2_IS_INVALID_CHAR(p, 4);
+}
+
 #  undef VTABLE
 #  define VTABLE VTABLE1, big2_toUtf8, big2_toUtf16
 
@@ -925,6 +961,7 @@ big2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  define IS_NAME_CHAR_MINBPC(enc, p) BIG2_IS_NAME_CHAR_MINBPC(p)
 #  define IS_NMSTRT_CHAR(enc, p, n) (0)
 #  define IS_NMSTRT_CHAR_MINBPC(enc, p) BIG2_IS_NMSTRT_CHAR_MINBPC(p)
+#  define IS_INVALID_CHAR(enc, p, n) BIG2_IS_INVALID_CHAR(p, n)
 
 #  define XML_TOK_IMPL_C
 #  include "xmltok_impl.c"
@@ -956,7 +993,7 @@ static const struct normal_encoding big2_encoding_ns
 #  include "asciitab.h"
 #  include "latin1tab.h"
        },
-       STANDARD_VTABLE(big2_) NULL_VTABLE};
+       STANDARD_VTABLE(big2_) UTF16_NULL_VTABLE(big2_)};
 
 #endif
 
@@ -974,7 +1011,7 @@ static const struct normal_encoding big2_encoding
 #undef BT_COLON
 #include "latin1tab.h"
        },
-       STANDARD_VTABLE(big2_) NULL_VTABLE};
+       STANDARD_VTABLE(big2_) UTF16_NULL_VTABLE(big2_)};
 
 #if BYTEORDER != 1234
 
@@ -986,7 +1023,7 @@ static const struct normal_encoding internal_big2_encoding_ns
 #    include "iasciitab.h"
 #    include "latin1tab.h"
        },
-       STANDARD_VTABLE(big2_) NULL_VTABLE};
+       STANDARD_VTABLE(big2_) UTF16_NULL_VTABLE(big2_)};
 
 #  endif
 
@@ -998,7 +1035,7 @@ static const struct normal_encoding internal_big2_encoding
 #  undef BT_COLON
 #  include "latin1tab.h"
        },
-       STANDARD_VTABLE(big2_) NULL_VTABLE};
+       STANDARD_VTABLE(big2_) UTF16_NULL_VTABLE(big2_)};
 
 #endif
 

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -232,6 +232,19 @@ struct normal_encoding {
       /* isNmstrt2 */ NULL, /* isNmstrt3 */ NULL, /* isNmstrt4 */ NULL,        \
       /* isInvalid2 */ NULL, /* isInvalid3 */ NULL, /* isInvalid4 */ NULL
 
+/* Like NULL_VTABLE but with a real isInvalid4 so the UTF-16 encodings reject a
+   high surrogate that is not followed by a low surrogate.  Only needed for the
+   XML_MIN_SIZE build, where the shared tokenizer dispatches through the vtable;
+   the regular build inlines the same check via IS_INVALID_CHAR. */
+#ifdef XML_MIN_SIZE
+#  define UTF16_NULL_VTABLE(E)                                                 \
+    /* isName2 */ NULL, /* isName3 */ NULL, /* isName4 */ NULL,                \
+        /* isNmstrt2 */ NULL, /* isNmstrt3 */ NULL, /* isNmstrt4 */ NULL,      \
+        /* isInvalid2 */ NULL, /* isInvalid3 */ NULL, E##isInvalid4
+#else
+#  define UTF16_NULL_VTABLE(E) NULL_VTABLE
+#endif
+
 static int checkCharRefNumber(int result);
 
 #include "xmltok_impl.h"
@@ -749,6 +762,11 @@ DEFINE_UTF16_TO_UTF16(big2_)
   UCS2_GET_NAMING(namePages, (unsigned char)p[1], (unsigned char)p[0])
 #define LITTLE2_IS_NMSTRT_CHAR_MINBPC(p)                                       \
   UCS2_GET_NAMING(nmstrtPages, (unsigned char)p[1], (unsigned char)p[0])
+/* A 4-byte UTF-16 character is a surrogate pair; byteType only reports BT_LEAD4
+   for a high surrogate, so the pair is invalid unless the second unit is a low
+   surrogate (U+DC00..U+DFFF, i.e. high byte 0xDC..0xDF). */
+#define LITTLE2_IS_INVALID_CHAR(p, n)                                          \
+  ((n) == 4 && ((unsigned char)(p)[3] & 0xFC) != 0xDC)
 
 #ifdef XML_MIN_SIZE
 
@@ -781,6 +799,12 @@ little2_isNmstrtMin(const ENCODING *enc, const char *p) {
   return LITTLE2_IS_NMSTRT_CHAR_MINBPC(p);
 }
 
+static int
+little2_isInvalid4(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
+  return LITTLE2_IS_INVALID_CHAR(p, 4);
+}
+
 #  undef VTABLE
 #  define VTABLE VTABLE1, little2_toUtf8, little2_toUtf16
 
@@ -797,6 +821,7 @@ little2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  define IS_NAME_CHAR_MINBPC(enc, p) LITTLE2_IS_NAME_CHAR_MINBPC(p)
 #  define IS_NMSTRT_CHAR(enc, p, n) (0)
 #  define IS_NMSTRT_CHAR_MINBPC(enc, p) LITTLE2_IS_NMSTRT_CHAR_MINBPC(p)
+#  define IS_INVALID_CHAR(enc, p, n) LITTLE2_IS_INVALID_CHAR(p, n)
 
 #  define XML_TOK_IMPL_C
 #  include "xmltok_impl.c"
@@ -828,7 +853,7 @@ static const struct normal_encoding little2_encoding_ns
 #  include "asciitab.h"
 #  include "latin1tab.h"
        },
-       STANDARD_VTABLE(little2_) NULL_VTABLE};
+       STANDARD_VTABLE(little2_) UTF16_NULL_VTABLE(little2_)};
 
 #endif
 
@@ -846,7 +871,7 @@ static const struct normal_encoding little2_encoding
 #undef BT_COLON
 #include "latin1tab.h"
        },
-       STANDARD_VTABLE(little2_) NULL_VTABLE};
+       STANDARD_VTABLE(little2_) UTF16_NULL_VTABLE(little2_)};
 
 #if BYTEORDER != 4321
 
@@ -858,7 +883,7 @@ static const struct normal_encoding internal_little2_encoding_ns
 #    include "iasciitab.h"
 #    include "latin1tab.h"
        },
-       STANDARD_VTABLE(little2_) NULL_VTABLE};
+       STANDARD_VTABLE(little2_) UTF16_NULL_VTABLE(little2_)};
 
 #  endif
 
@@ -870,7 +895,7 @@ static const struct normal_encoding internal_little2_encoding
 #  undef BT_COLON
 #  include "latin1tab.h"
        },
-       STANDARD_VTABLE(little2_) NULL_VTABLE};
+       STANDARD_VTABLE(little2_) UTF16_NULL_VTABLE(little2_)};
 
 #endif
 
@@ -882,6 +907,11 @@ static const struct normal_encoding internal_little2_encoding
   UCS2_GET_NAMING(namePages, (unsigned char)p[0], (unsigned char)p[1])
 #define BIG2_IS_NMSTRT_CHAR_MINBPC(p)                                          \
   UCS2_GET_NAMING(nmstrtPages, (unsigned char)p[0], (unsigned char)p[1])
+/* A 4-byte UTF-16 character is a surrogate pair; byteType only reports BT_LEAD4
+   for a high surrogate, so the pair is invalid unless the second unit is a low
+   surrogate (U+DC00..U+DFFF, i.e. high byte 0xDC..0xDF). */
+#define BIG2_IS_INVALID_CHAR(p, n)                                             \
+  ((n) == 4 && ((unsigned char)(p)[2] & 0xFC) != 0xDC)
 
 #ifdef XML_MIN_SIZE
 
@@ -914,6 +944,12 @@ big2_isNmstrtMin(const ENCODING *enc, const char *p) {
   return BIG2_IS_NMSTRT_CHAR_MINBPC(p);
 }
 
+static int
+big2_isInvalid4(const ENCODING *enc, const char *p) {
+  UNUSED_P(enc);
+  return BIG2_IS_INVALID_CHAR(p, 4);
+}
+
 #  undef VTABLE
 #  define VTABLE VTABLE1, big2_toUtf8, big2_toUtf16
 
@@ -930,6 +966,7 @@ big2_isNmstrtMin(const ENCODING *enc, const char *p) {
 #  define IS_NAME_CHAR_MINBPC(enc, p) BIG2_IS_NAME_CHAR_MINBPC(p)
 #  define IS_NMSTRT_CHAR(enc, p, n) (0)
 #  define IS_NMSTRT_CHAR_MINBPC(enc, p) BIG2_IS_NMSTRT_CHAR_MINBPC(p)
+#  define IS_INVALID_CHAR(enc, p, n) BIG2_IS_INVALID_CHAR(p, n)
 
 #  define XML_TOK_IMPL_C
 #  include "xmltok_impl.c"
@@ -961,7 +998,7 @@ static const struct normal_encoding big2_encoding_ns
 #  include "asciitab.h"
 #  include "latin1tab.h"
        },
-       STANDARD_VTABLE(big2_) NULL_VTABLE};
+       STANDARD_VTABLE(big2_) UTF16_NULL_VTABLE(big2_)};
 
 #endif
 
@@ -979,7 +1016,7 @@ static const struct normal_encoding big2_encoding
 #undef BT_COLON
 #include "latin1tab.h"
        },
-       STANDARD_VTABLE(big2_) NULL_VTABLE};
+       STANDARD_VTABLE(big2_) UTF16_NULL_VTABLE(big2_)};
 
 #if BYTEORDER != 1234
 
@@ -991,7 +1028,7 @@ static const struct normal_encoding internal_big2_encoding_ns
 #    include "iasciitab.h"
 #    include "latin1tab.h"
        },
-       STANDARD_VTABLE(big2_) NULL_VTABLE};
+       STANDARD_VTABLE(big2_) UTF16_NULL_VTABLE(big2_)};
 
 #  endif
 
@@ -1003,7 +1040,7 @@ static const struct normal_encoding internal_big2_encoding
 #  undef BT_COLON
 #  include "latin1tab.h"
        },
-       STANDARD_VTABLE(big2_) NULL_VTABLE};
+       STANDARD_VTABLE(big2_) UTF16_NULL_VTABLE(big2_)};
 
 #endif
 

--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -41,7 +41,7 @@
 
 #ifdef XML_TOK_IMPL_C
 
-#  ifndef IS_INVALID_CHAR // i.e. for UTF-16 and XML_MIN_SIZE not defined
+#  ifndef IS_INVALID_CHAR // currently unused: all includers define it
 #    define IS_INVALID_CHAR(enc, ptr, n) (0)
 #  endif
 

--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -44,7 +44,7 @@
 
 #ifdef XML_TOK_IMPL_C
 
-#  ifndef IS_INVALID_CHAR // i.e. for UTF-16 and XML_MIN_SIZE not defined
+#  ifndef IS_INVALID_CHAR // currently unused: all includers define it
 #    define IS_INVALID_CHAR(enc, ptr, n) (0)
 #  endif
 

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -1819,6 +1819,36 @@ START_TEST(test_utf16_bad_surrogate_pair) {
 }
 END_TEST
 
+/* Test that a UTF-16 high surrogate not followed by a low surrogate is
+   rejected.  Without validation the high surrogate would consume the next
+   code unit as a fake low surrogate, hiding e.g. a following '<' from the
+   tokenizer. */
+START_TEST(test_utf16_high_surrogate_without_low) {
+  /* Test data is:
+   *   <?xml version='1.0' encoding='utf-16'?>
+   *   <a>{HIGH}X</a>
+   *
+   * where {HIGH} is the high surrogate 0xd800 and 'X' (0x0058) is a regular
+   * BMP character that is not a low surrogate.
+   */
+  const char text[] = "\0<\0?\0x\0m\0l\0"
+                      " \0v\0e\0r\0s\0i\0o\0n\0=\0'\0\x31\0.\0\x30\0'\0"
+                      " \0e\0n\0c\0o\0d\0i\0n\0g\0=\0'\0u\0t\0f\0-\0"
+                      "1\0"
+                      "6\0'"
+                      "\0?\0>\0\n"
+                      "\0<\0a\0>"
+                      "\xd8\x00\0X"
+                      "\0<\0/\0a\0>";
+
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)sizeof(text) - 1, XML_TRUE)
+      != XML_STATUS_ERROR)
+    fail("Lone UTF-16 high surrogate not faulted");
+  if (XML_GetErrorCode(g_parser) != XML_ERROR_INVALID_TOKEN)
+    xml_failure(g_parser);
+}
+END_TEST
+
 START_TEST(test_bad_cdata) {
   struct CaseData {
     const char *text;
@@ -6680,6 +6710,7 @@ make_basic_test_case(Suite *s) {
   tcase_add_test(tc_basic, test_long_cdata_utf16);
   tcase_add_test(tc_basic, test_multichar_cdata_utf16);
   tcase_add_test(tc_basic, test_utf16_bad_surrogate_pair);
+  tcase_add_test(tc_basic, test_utf16_high_surrogate_without_low);
   tcase_add_test(tc_basic, test_bad_cdata);
   tcase_add_test(tc_basic, test_bad_cdata_utf16);
   tcase_add_test(tc_basic, test_stop_parser_between_cdata_calls);

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -1841,11 +1841,16 @@ START_TEST(test_utf16_high_surrogate_without_low) {
                       "\xd8\x00\0X"
                       "\0<\0/\0a\0>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)sizeof(text) - 1, XML_TRUE)
+  XML_Parser parser = XML_ParserCreate(NULL);
+  assert_true(parser != NULL);
+
+  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)sizeof(text) - 1, XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Lone UTF-16 high surrogate not faulted");
-  if (XML_GetErrorCode(g_parser) != XML_ERROR_INVALID_TOKEN)
-    xml_failure(g_parser);
+  if (XML_GetErrorCode(parser) != XML_ERROR_INVALID_TOKEN)
+    xml_failure(parser);
+
+  XML_ParserFree(parser);
 }
 END_TEST
 

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -1890,6 +1890,36 @@ START_TEST(test_utf16_bad_surrogate_pair) {
 }
 END_TEST
 
+/* Test that a UTF-16 high surrogate not followed by a low surrogate is
+   rejected.  Without validation the high surrogate would consume the next
+   code unit as a fake low surrogate, hiding e.g. a following '<' from the
+   tokenizer. */
+START_TEST(test_utf16_high_surrogate_without_low) {
+  /* Test data is:
+   *   <?xml version='1.0' encoding='utf-16'?>
+   *   <a>{HIGH}X</a>
+   *
+   * where {HIGH} is the high surrogate 0xd800 and 'X' (0x0058) is a regular
+   * BMP character that is not a low surrogate.
+   */
+  const char text[] = "\0<\0?\0x\0m\0l\0"
+                      " \0v\0e\0r\0s\0i\0o\0n\0=\0'\0\x31\0.\0\x30\0'\0"
+                      " \0e\0n\0c\0o\0d\0i\0n\0g\0=\0'\0u\0t\0f\0-\0"
+                      "1\0"
+                      "6\0'"
+                      "\0?\0>\0\n"
+                      "\0<\0a\0>"
+                      "\xd8\x00\0X"
+                      "\0<\0/\0a\0>";
+
+  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)sizeof(text) - 1, XML_TRUE)
+      != XML_STATUS_ERROR)
+    fail("Lone UTF-16 high surrogate not faulted");
+  if (XML_GetErrorCode(g_parser) != XML_ERROR_INVALID_TOKEN)
+    xml_failure(g_parser);
+}
+END_TEST
+
 START_TEST(test_bad_cdata) {
   struct CaseData {
     const char *text;
@@ -6835,6 +6865,7 @@ make_basic_test_case(Suite *s) {
   tcase_add_test(tc_basic, test_long_cdata_utf16);
   tcase_add_test(tc_basic, test_multichar_cdata_utf16);
   tcase_add_test(tc_basic, test_utf16_bad_surrogate_pair);
+  tcase_add_test(tc_basic, test_utf16_high_surrogate_without_low);
   tcase_add_test(tc_basic, test_bad_cdata);
   tcase_add_test(tc_basic, test_bad_cdata_utf16);
   tcase_add_test(tc_basic, test_stop_parser_between_cdata_calls);

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -1912,11 +1912,16 @@ START_TEST(test_utf16_high_surrogate_without_low) {
                       "\xd8\x00\0X"
                       "\0<\0/\0a\0>";
 
-  if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)sizeof(text) - 1, XML_TRUE)
+  XML_Parser parser = XML_ParserCreate(NULL);
+  assert_true(parser != NULL);
+
+  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)sizeof(text) - 1, XML_TRUE)
       != XML_STATUS_ERROR)
     fail("Lone UTF-16 high surrogate not faulted");
-  if (XML_GetErrorCode(g_parser) != XML_ERROR_INVALID_TOKEN)
-    xml_failure(g_parser);
+  if (XML_GetErrorCode(parser) != XML_ERROR_INVALID_TOKEN)
+    xml_failure(parser);
+
+  XML_ParserFree(parser);
 }
 END_TEST
 


### PR DESCRIPTION
# Self-Diagnosis

- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [ ] This pull request is small, uncontroversial, complete, and easy to review.
- [ ] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

For UTF-16 input the tokenizer reports a high surrogate (U+D800..U+DBFF) as a four-byte lead character but never verifies that the following 16-bit code unit is a low surrogate, since `IS_INVALID_CHAR` is a no-op for the `little2` and `big2` encodings. A high surrogate that is not part of a valid pair is accepted and silently consumes the next code unit as a fake low surrogate, so a following markup byte such as `<` gets absorbed into character data and hidden from the parser; a lone low surrogate is already rejected (`BT_TRAIL`). This adds a real `isInvalid4` for the UTF-16 encodings that rejects a high surrogate whose second unit is not in U+DC00..U+DFFF, reached through `IS_INVALID_CHAR` in the regular build and through the vtable in the `XML_MIN_SIZE` build, matching how `utf8_isInvalid4` validates UTF-8. Valid surrogate pairs are unaffected. I verified the full test suite (with the added regression) and clang-format pass for both the default and `XML_MIN_SIZE` builds.
