### PR TITLE
Limit output indentation for `EXPAT_ENTITY_DEBUG=1`

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -8706,15 +8706,25 @@ entityTrackingReportStats(XML_Parser rootParser, ENTITY *entity,
   const char *const entityName = entity->name;
 #  endif
 
+  const bool limitingWanted = rootParser->m_entity_stats.debugLevel < 2;
+  const int maxLimitedDepth = 10; // somewhat arbitrary
+  const int candidateIndentDepth
+      = (int)rootParser->m_entity_stats.currentDepth - 1;
+  const bool limitingNeeded
+      = limitingWanted && (candidateIndentDepth > maxLimitedDepth);
+  const char *const ellipisOrEmpty = limitingNeeded ? " [..] " : "";
+  const int indentDepth
+      = limitingNeeded ? (maxLimitedDepth - /* make space for ellipis */ 2)
+                       : candidateIndentDepth;
+
   fprintf(
       stderr,
-      "expat: Entities(%p): Count %9u, depth %2u/%2u %*s%s%s; %s length %d (xmlparse.c:%d)\n",
+      "expat: Entities(%p): Count %9u, depth %2u/%2u %*s%s%s%s; %s length %d (xmlparse.c:%d)\n",
       (void *)rootParser, rootParser->m_entity_stats.countEverOpened,
       rootParser->m_entity_stats.currentDepth,
-      rootParser->m_entity_stats.maximumDepthSeen,
-      ((int)rootParser->m_entity_stats.currentDepth - 1) * 2, "",
-      entity->is_param ? "%" : "&", entityName, action, entity->textLen,
-      sourceLine);
+      rootParser->m_entity_stats.maximumDepthSeen, indentDepth * 2, "",
+      ellipisOrEmpty, entity->is_param ? "%" : "&", entityName, action,
+      entity->textLen, sourceLine);
 }
 
 static void

--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -954,7 +954,7 @@ usage(const XML_Char *prog, int rc) {
       T("environment variables:\n")
       T("  EXPAT_ACCOUNTING_DEBUG=(0|1|2|3)\n")
       T("                 Control verbosity of accounting debugging (default: 0)\n")
-      T("  EXPAT_ENTITY_DEBUG=(0|1)\n")
+      T("  EXPAT_ENTITY_DEBUG=(0|1|2)\n")
       T("                 Control verbosity of entity debugging (default: 0)\n")
       T("  EXPAT_ENTROPY_DEBUG=(0|1)\n")
       T("                 Control verbosity of entropy debugging (default: 0)\n")

--- a/expat/xmlwf/xmlwf_helpgen.py
+++ b/expat/xmlwf/xmlwf_helpgen.py
@@ -37,7 +37,7 @@ epilog = dedent(
     environment variables:
       EXPAT_ACCOUNTING_DEBUG=(0|1|2|3)
                      Control verbosity of accounting debugging (default: 0)
-      EXPAT_ENTITY_DEBUG=(0|1)
+      EXPAT_ENTITY_DEBUG=(0|1|2)
                      Control verbosity of entity debugging (default: 0)
       EXPAT_ENTROPY_DEBUG=(0|1)
                      Control verbosity of entropy debugging (default: 0)


### PR DESCRIPTION
Unlimited indentation will now be produced with `EXPAT_ENTITY_DEBUG=2`.
