### PR TITLE
lib: Reject empty version in the XML declaration

### DIFF
--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -1177,6 +1177,13 @@ doParseXmlDecl(const ENCODING *(*encodingFinder)(const ENCODING *, const char *,
       *versionPtr = val;
     if (versionEndPtr)
       *versionEndPtr = ptr;
+    /* The version number must not be empty; VersionNum requires at least
+       one character.  The encoding and standalone pseudo-attributes below
+       already reject an empty value, so keep version consistent. */
+    if (val == ptr - enc->minBytesPerChar) {
+      *badPtr = val;
+      return 0;
+    }
     if (! parsePseudoAttribute(enc, ptr, end, &name, &nameEnd, &val, &ptr)) {
       *badPtr = ptr;
       return 0;

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -971,6 +971,14 @@ START_TEST(test_xmldecl_missing_value) {
 }
 END_TEST
 
+START_TEST(test_xmldecl_empty_version) {
+  expect_failure("<?xml version=''?>\n"
+                 "<doc/>",
+                 XML_ERROR_XML_DECL,
+                 "Failed to report empty version in XML declaration");
+}
+END_TEST
+
 /* Regression test for SF bug #584832. */
 START_TEST(test_unknown_encoding_internal_entity) {
   const char *text = "<?xml version='1.0' encoding='unsupported-encoding'?>\n"
@@ -6647,6 +6655,7 @@ make_basic_test_case(Suite *s) {
   tcase_add_test(tc_basic, test_xmldecl_invalid);
   tcase_add_test(tc_basic, test_xmldecl_missing_attr);
   tcase_add_test(tc_basic, test_xmldecl_missing_value);
+  tcase_add_test(tc_basic, test_xmldecl_empty_version);
   tcase_add_test__if_xml_ge(tc_basic, test_unknown_encoding_internal_entity);
   tcase_add_test(tc_basic, test_unrecognised_encoding_internal_entity);
   tcase_add_test__ifdef_xml_dtd(tc_basic, test_ext_entity_set_encoding);


### PR DESCRIPTION
# Self-Diagnosis

- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [ ] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire. (Please elaborate.)


# Description

1. `doParseXmlDecl` records the version pseudo-attribute value but never checks that it is non-empty, so `<?xml version=''?>` is accepted as well-formed.
2. `VersionNum` requires at least one character, and the encoding and standalone pseudo-attributes just below already reject an empty value, so version was the only one left lenient.
3. Added the same non-empty check on the version value span, failing with `XML_ERROR_XML_DECL`, and a regression test `test_xmldecl_empty_version`.

Verified with the existing suite plus the new test (fails before the change, passes after) in both the UTF-8 and UTF-16 declaration paths; valid non-empty versions keep parsing.