### PR TITLE
Fix in-code comment for Chinese Visual Studio 2026 compiler

### DIFF
--- a/expat/lib/random_rand_s.c
+++ b/expat/lib/random_rand_s.c
@@ -42,7 +42,7 @@
 
 // Workaround MinGW GCC trouble with recognizing `rand_s`, likely related
 // to return type `error_t`; the symptom was:
-// > error: implicit declaration of function ‘rand_s’
+// > error: implicit declaration of function 'rand_s'
 #if defined(__MINGW32__)
 #  include <errno.h>
 #endif


### PR DESCRIPTION
the \u2018 and \u2019 marks in the comment causes visual studio fail to compile with the 'extra #endif' error, at least on Chinese locale system. Haven't test on other CJK locale systems.

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [x] This pull request fixes #1287.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.