### PR TITLE
[CVE-2026-72522] Fix an OOB read and the resulting infinite loop in `*_toUtf16` functions

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -20,7 +20,6 @@ Release 2.8.3 XXX XXX XX XXXX
         Special thanks to:
             City of Munich Open Source Sabbatical
 
-
 Release 2.8.2 Thu June 25 2026
         Security fixes:
            #1246  CVE-2026-50219 -- Disallow calls to functions

--- a/expat/Changes
+++ b/expat/Changes
@@ -17,8 +17,24 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Release 2.8.3 XXX XXX XX XXXX
+        Security fixes:
+           #1296  CVE-2026-TODO -- Fix an out-of-bounds read and the resulting
+                    infinite loop caused by treating low surrogates (Unicode)
+                    the same as high surrogates in functions *_toUtf16.
+                    Needs Expat compiled with 16bit character support
+                    (e.g. with Firefox and/or on Windows) to be affected.
+                    Official CVSS 3.1 vector:
+                    AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (CVSS score: 7.5)
+                    Original bug report from Mozilla at:
+                    https://bugzilla.mozilla.org/show_bug.cgi?id=2053153
+
         Special thanks to:
+            Henri Sivonen
+            Jason Kratzer
+                 and
+            Anthropic
             City of Munich Open Source Sabbatical
+            Mozilla Security Team
 
 Release 2.8.2 Thu June 25 2026
         Security fixes:

--- a/expat/Changes
+++ b/expat/Changes
@@ -17,8 +17,25 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Release 2.8.3 XXX XXX XX XXXX
+        Security fixes:
+           #1296  CVE-2026-72522 -- Fix an out-of-bounds read and the resulting
+                    infinite loop caused by treating low surrogates (Unicode)
+                    the same as high surrogates in functions *_toUtf16.
+                    Needs Expat compiled with 16bit character support
+                    (e.g. with Firefox and/or on Windows) to be affected.
+                    Upstream CVSS 3.1 vector:
+                    AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (CVSS score: 7.5)
+                    (Note the "AV:N" for network/remote, the "AV:L" in NVD by
+                    Mitre is mistaken.)
+                    Original bug report from Mozilla at:
+                    https://bugzilla.mozilla.org/show_bug.cgi?id=2053153
+
         Special thanks to:
+            Henri Sivonen
+                 and
+            Anthropic
             City of Munich Open Source Sabbatical
+            Mozilla Security Team
 
 Release 2.8.2 Thu June 25 2026
         Security fixes:

--- a/expat/lib/xcsinc.c
+++ b/expat/lib/xcsinc.c
@@ -29,6 +29,10 @@
    USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#if defined(XML_UNICODE) && defined(XML_UNICODE_WCHAR_T)
+#  include <wchar.h>
+#endif
+
 static size_t
 xcslen(const XML_Char *s) {
 #ifdef XML_UNICODE

--- a/expat/lib/xcsinc.c
+++ b/expat/lib/xcsinc.c
@@ -31,6 +31,10 @@
    SPDX-License-Identifier: MIT
 */
 
+#if defined(XML_UNICODE) && defined(XML_UNICODE_WCHAR_T)
+#  include <wchar.h>
+#endif
+
 static size_t
 xcslen(const XML_Char *s) {
 #ifdef XML_UNICODE

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -6554,11 +6554,12 @@ storeAttributeValue(XML_Parser parser, const ENCODING *enc, XML_Bool isCdata,
         // Check if entity is complete, if not, mark down how much of it is
         // processed. A XML_SUSPENDED check here is not required as
         // appendAttributeValue will never suspend the parser.
-        if (textEnd != nextInEntity) {
+        if (nextInEntity < textEnd) {
           entity->processed
               = (int)(nextInEntity - (const char *)entity->textPtr);
           continue;
         }
+        assert(nextInEntity == textEnd);
 
         // Entity is complete. We cannot close it here since we need to first
         // process its possible inner entities (which are added to the

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -6556,11 +6556,12 @@ storeAttributeValue(XML_Parser parser, const ENCODING *enc, XML_Bool isCdata,
         // Check if entity is complete, if not, mark down how much of it is
         // processed. A XML_SUSPENDED check here is not required as
         // appendAttributeValue will never suspend the parser.
-        if (textEnd != nextInEntity) {
+        if (nextInEntity < textEnd) {
           entity->processed
               = (int)(nextInEntity - (const char *)entity->textPtr);
           continue;
         }
+        assert(nextInEntity == textEnd);
 
         // Entity is complete. We cannot close it here since we need to first
         // process its possible inner entities (which are added to the

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -707,7 +707,8 @@ unicode_byte_type(char hi, char lo) {
     fromLim = *fromP + (((fromLim - *fromP) >> 1) << 1); /* shrink to even */  \
     /* Avoid copying the first half (2 bytes) of surrogate pairs (4 bytes) */  \
     if (fromLim - *fromP > ((toLim - *toP) << 1)                               \
-        && (GET_HI(fromLim - 2) & 0xF8) == 0xD8) {                             \
+        && /* are the last two bytes a high surrogate (0xD800-0xDBFF)? */      \
+        (GET_HI(fromLim - 2) & 0xFC) == 0xD8) {                                \
       fromLim -= 2;                                                            \
       res = XML_CONVERT_INPUT_INCOMPLETE;                                      \
     }                                                                          \

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -705,7 +705,7 @@ unicode_byte_type(char hi, char lo) {
     enum XML_Convert_Result res = XML_CONVERT_COMPLETED;                       \
     UNUSED_P(enc);                                                             \
     fromLim = *fromP + (((fromLim - *fromP) >> 1) << 1); /* shrink to even */  \
-    /* Avoid copying first half only of surrogate */                           \
+    /* Avoid copying the first half (2 bytes) of surrogate pairs (4 bytes) */  \
     if (fromLim - *fromP > ((toLim - *toP) << 1)                               \
         && (GET_HI(fromLim - 2) & 0xF8) == 0xD8) {                             \
       fromLim -= 2;                                                            \

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -707,7 +707,7 @@ unicode_byte_type(char hi, char lo) {
     enum XML_Convert_Result res = XML_CONVERT_COMPLETED;                       \
     UNUSED_P(enc);                                                             \
     fromLim = *fromP + (((fromLim - *fromP) >> 1) << 1); /* shrink to even */  \
-    /* Avoid copying first half only of surrogate */                           \
+    /* Avoid copying the first half (2 bytes) of surrogate pairs (4 bytes) */  \
     if (fromLim - *fromP > ((toLim - *toP) << 1)                               \
         && (GET_HI(fromLim - 2) & 0xF8) == 0xD8) {                             \
       fromLim -= 2;                                                            \

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -709,7 +709,8 @@ unicode_byte_type(char hi, char lo) {
     fromLim = *fromP + (((fromLim - *fromP) >> 1) << 1); /* shrink to even */  \
     /* Avoid copying the first half (2 bytes) of surrogate pairs (4 bytes) */  \
     if (fromLim - *fromP > ((toLim - *toP) << 1)                               \
-        && (GET_HI(fromLim - 2) & 0xF8) == 0xD8) {                             \
+        && /* are the last two bytes a high surrogate (0xD800-0xDBFF)? */      \
+        (GET_HI(fromLim - 2) & 0xFC) == 0xD8) {                                \
       fromLim -= 2;                                                            \
       res = XML_CONVERT_INPUT_INCOMPLETE;                                      \
     }                                                                          \

--- a/expat/tests/misc_tests.c
+++ b/expat/tests/misc_tests.c
@@ -836,6 +836,40 @@ START_TEST(test_misc_resume_parser_forbidden_from_handler) {
 }
 END_TEST
 
+// General attack payload idea by Jason Kratzer of Mozilla
+START_TEST(test_misc_low_surrogate_mozilla_bug_2053153) {
+  const char doc_before[] = "<\0!\0D\0O\0C\0T\0Y\0P\0E\0 \0d\0 \0[\0\n\0"
+                            " \0 \0<\0!\0E\0N\0T\0I\0T\0Y\0 \0e\0 \0'\0";
+  const char doc_after[] = "'\0>\0\n\0]\0>\0\n\0"
+                           "<\0r\0 \0a\0=\0'\0&\0e\0;\0'\0/\0>\0\n\0";
+
+  for (size_t i = 1021; i <= 1025; i++) {
+    set_subtest("[%d]", (int)i);
+
+    XML_Parser parser = XML_ParserCreate(NULL);
+
+    assert_true(_XML_Parse_SINGLE_BYTES(parser, doc_before,
+                                        (int)sizeof(doc_before) - 1,
+                                        /*isFinal=*/XML_FALSE));
+
+    for (size_t j = 0; j < i; j++) {
+      assert_true(
+          _XML_Parse_SINGLE_BYTES(parser, "a\\0", 2, /*isFinal=*/XML_FALSE));
+    }
+
+    // Thinking Python, this is:
+    // ''.join([f'\\x{e:02x}' for e in '😀'.encode('UTF-16-LE')])
+    assert_true(_XML_Parse_SINGLE_BYTES(parser, "\x3d\xd8\x00\xde", 4,
+                                        /*isFinal=*/XML_FALSE));
+
+    assert_true(_XML_Parse_SINGLE_BYTES(
+        parser, doc_after, (int)sizeof(doc_after) - 1, /*isFinal=*/XML_TRUE));
+
+    XML_ParserFree(parser);
+  }
+}
+END_TEST
+
 void
 make_miscellaneous_test_case(Suite *s) {
   TCase *tc_misc = tcase_create("miscellaneous tests");
@@ -869,4 +903,6 @@ make_miscellaneous_test_case(Suite *s) {
   tcase_add_test(tc_misc, test_misc_no_infinite_loop_issue_1161);
   tcase_add_test(tc_misc, test_misc_calls_forbidden_from_handlers);
   tcase_add_test(tc_misc, test_misc_resume_parser_forbidden_from_handler);
+
+  tcase_add_test(tc_misc, test_misc_low_surrogate_mozilla_bug_2053153);
 }

--- a/expat/tests/misc_tests.c
+++ b/expat/tests/misc_tests.c
@@ -838,6 +838,40 @@ START_TEST(test_misc_resume_parser_forbidden_from_handler) {
 }
 END_TEST
 
+// General attack payload idea by Jason Kratzer of Mozilla
+START_TEST(test_misc_low_surrogate_mozilla_bug_2053153) {
+  const char doc_before[] = "<\0!\0D\0O\0C\0T\0Y\0P\0E\0 \0d\0 \0[\0\n\0"
+                            " \0 \0<\0!\0E\0N\0T\0I\0T\0Y\0 \0e\0 \0'\0";
+  const char doc_after[] = "'\0>\0\n\0]\0>\0\n\0"
+                           "<\0r\0 \0a\0=\0'\0&\0e\0;\0'\0/\0>\0\n\0";
+
+  for (size_t i = 1021; i <= 1025; i++) {
+    set_subtest("[%d]", (int)i);
+
+    XML_Parser parser = XML_ParserCreate(NULL);
+
+    assert_true(_XML_Parse_SINGLE_BYTES(parser, doc_before,
+                                        (int)sizeof(doc_before) - 1,
+                                        /*isFinal=*/XML_FALSE));
+
+    for (size_t j = 0; j < i; j++) {
+      assert_true(
+          _XML_Parse_SINGLE_BYTES(parser, "a\\0", 2, /*isFinal=*/XML_FALSE));
+    }
+
+    // Thinking Python, this is:
+    // ''.join([f'\\x{e:02x}' for e in '😀'.encode('UTF-16-LE')])
+    assert_true(_XML_Parse_SINGLE_BYTES(parser, "\x3d\xd8\x00\xde", 4,
+                                        /*isFinal=*/XML_FALSE));
+
+    assert_true(_XML_Parse_SINGLE_BYTES(
+        parser, doc_after, (int)sizeof(doc_after) - 1, /*isFinal=*/XML_TRUE));
+
+    XML_ParserFree(parser);
+  }
+}
+END_TEST
+
 void
 make_miscellaneous_test_case(Suite *s) {
   TCase *tc_misc = tcase_create("miscellaneous tests");
@@ -871,4 +905,6 @@ make_miscellaneous_test_case(Suite *s) {
   tcase_add_test(tc_misc, test_misc_no_infinite_loop_issue_1161);
   tcase_add_test(tc_misc, test_misc_calls_forbidden_from_handlers);
   tcase_add_test(tc_misc, test_misc_resume_parser_forbidden_from_handler);
+
+  tcase_add_test(tc_misc, test_misc_low_surrogate_mozilla_bug_2053153);
 }


### PR DESCRIPTION
Mozilla bug at https://bugzilla.mozilla.org/show_bug.cgi?id=2053153

@netliomax25-code FYI, I believe this is related but orthogonal to your #1282. 

@berkayurun could you check if my hardening commit 10bb2af603c071fbcd8a7a698e1890cbb53fd4f1 looks sane and "comparing the right direction" to you? Thanks in advance!
