### PR TITLE
lib: Make internal `m_parseEndByteIndex` use `uint64_t` to support >2 GiB documents on all platforms (fixes #1297)

### DIFF
--- a/expat/doc/reference.html
+++ b/expat/doc/reference.html
@@ -2917,6 +2917,13 @@ XML_GetCurrentByteIndex(XML_Parser p);
         <code><a href="#XML_GetCurrentColumnNumber">XML_GetCurrentColumnNumber</a></code>.
       </div>
 
+      <p>
+        <strong>Note:</strong> Type <code>XML_Index</code> is known to wrap around on
+        32bit platforms and 64bit Windows unless Expat has been compiled with
+        (non-default and uncommon) macro <code><a href=
+        "#XML_LARGE_SIZE">XML_LARGE_SIZE</a></code>.
+      </p>
+
       <h4 id="XML_GetCurrentLineNumber">
         XML_GetCurrentLineNumber
       </h4>
@@ -2930,6 +2937,13 @@ XML_GetCurrentLineNumber(XML_Parser p);
         <code>1</code>.
       </div>
 
+      <p>
+        <strong>Note:</strong> Type <code>XML_Size</code> is known to wrap around on
+        32bit platforms and 64bit Windows unless Expat has been compiled with
+        (non-default and uncommon) macro <code><a href=
+        "#XML_LARGE_SIZE">XML_LARGE_SIZE</a></code>.
+      </p>
+
       <h4 id="XML_GetCurrentColumnNumber">
         XML_GetCurrentColumnNumber
       </h4>
@@ -2942,6 +2956,13 @@ XML_GetCurrentColumnNumber(XML_Parser p);
         Return the <em>offset</em>, from the beginning of the current line, of the
         position. The first column is reported as <code>0</code>.
       </div>
+
+      <p>
+        <strong>Note:</strong> Type <code>XML_Size</code> is known to wrap around on
+        32bit platforms and 64bit Windows unless Expat has been compiled with
+        (non-default and uncommon) macro <code><a href=
+        "#XML_LARGE_SIZE">XML_LARGE_SIZE</a></code>.
+      </p>
 
       <h4 id="XML_GetCurrentByteCount">
         XML_GetCurrentByteCount
@@ -3404,6 +3425,13 @@ typedef struct {
         counts as 1; thus the number of entries in the array is
         <code>XML_GetSpecifiedAttributeCount(parser) / 2</code>.
       </div>
+
+      <p>
+        <strong>Note:</strong> Type <code>XML_Index</code> is known to wrap around on
+        32bit platforms and 64bit Windows unless Expat has been compiled with
+        (non-default and uncommon) macro <code><a href=
+        "#XML_LARGE_SIZE">XML_LARGE_SIZE</a></code>.
+      </p>
 
       <h4 id="XML_SetEncoding">
         XML_SetEncoding

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2738,7 +2738,12 @@ XML_GetCurrentLineNumber(XML_Parser parser) {
                       parser->m_eventPtr, &parser->m_position);
     parser->m_positionPtr = parser->m_eventPtr;
   }
-  return parser->m_position.lineNumber + 1;
+  // NOTE: XML_Size is known to wrap around for >2 4iB content
+  //       on 32bit machines and 64bit Windows, unless (non-default and
+  //       uncommon) XML_LARGE_SIZE is defined.
+  //       That's a bug and it only lives on because we cannot break
+  //       ABI compatibility of public API.
+  return (XML_Size)(parser->m_position.lineNumber + 1);
 }
 
 XML_Size XMLCALL
@@ -2750,7 +2755,12 @@ XML_GetCurrentColumnNumber(XML_Parser parser) {
                       parser->m_eventPtr, &parser->m_position);
     parser->m_positionPtr = parser->m_eventPtr;
   }
-  return parser->m_position.columnNumber;
+  // NOTE: XML_Size is known to wrap around for >2 4iB content
+  //       on 32bit machines and 64bit Windows, unless (non-default and
+  //       uncommon) XML_LARGE_SIZE is defined.
+  //       That's a bug and it only lives on because we cannot break
+  //       ABI compatibility of public API.
+  return (XML_Size)parser->m_position.columnNumber;
 }
 
 void XMLCALL

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -95,7 +95,7 @@
 #include <stddef.h>
 #include <string.h> /* memset(), memcpy() */
 #include <assert.h>
-#include <limits.h> /* INT_MAX, LLONG_MAX, LONG_MAX, UINT_MAX */
+#include <limits.h> /* INT_MAX, LONG_MAX, UINT_MAX, ULLONG_MAX */
 #include <stdio.h>  /* fprintf */
 #include <stdlib.h> /* getenv */
 #include <stdint.h> /* SIZE_MAX, uintptr_t */
@@ -211,12 +211,6 @@ typedef char ICHAR;
 #  define XML_T(x) x
 #  define XML_L(x) x
 
-#endif
-
-#ifdef XML_LARGE_SIZE
-#  define XML_INDEX_MAX LLONG_MAX
-#else
-#  define XML_INDEX_MAX LONG_MAX
 #endif
 
 /* Round up n to be a multiple of sz, where sz is a power of 2. */
@@ -721,7 +715,7 @@ struct XML_ParserStruct {
   char *m_bufferEnd;       // past last character to be parsed
   const char *m_bufferLim; // allocated end of m_buffer
 
-  XML_Index m_parseEndByteIndex;
+  unsigned long long m_parseEndByteIndex;
   const char *m_parseEndPtr;
   size_t m_partialTokenBytesBefore; /* used in heuristic to avoid O(n^2) */
   XML_Bool m_reparseDeferralEnabled;
@@ -2314,7 +2308,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
     int nLeftOver;
     enum XML_Status result;
     /* Detect overflow (a+b > MAX <==> b > MAX-a) */
-    if (len > XML_INDEX_MAX - parser->m_parseEndByteIndex) {
+    if ((unsigned long long)len > ULLONG_MAX - parser->m_parseEndByteIndex) {
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       parser->m_eventPtr = parser->m_eventEndPtr = NULL;
       parser->m_processor = errorProcessor;
@@ -2432,7 +2426,7 @@ XML_ParseBuffer(XML_Parser parser, int len, int isFinal) {
   }
 
   // Detect and avoid integer overflow
-  if (len > XML_INDEX_MAX - parser->m_parseEndByteIndex) {
+  if ((unsigned long long)len > ULLONG_MAX - parser->m_parseEndByteIndex) {
     parser->m_errorCode = XML_ERROR_NO_MEMORY;
     parser->m_eventPtr = parser->m_eventEndPtr = NULL;
     parser->m_processor = errorProcessor;
@@ -2694,9 +2688,15 @@ XML_Index XMLCALL
 XML_GetCurrentByteIndex(XML_Parser parser) {
   if (parser == NULL)
     return -1;
-  if (parser->m_eventPtr)
+  if (parser->m_eventPtr) {
+    // NOTE: XML_Index is known to wrap around for >2 GiB content
+    //       on 32bit machines and 64bit Windows, unless (non-default and
+    //       uncommon) XML_LARGE_SIZE is defined.
+    //       That's a bug and it only lives on because we cannot break
+    //       ABI compatibility of public API.
     return (XML_Index)(parser->m_parseEndByteIndex
                        - (parser->m_parseEndPtr - parser->m_eventPtr));
+  }
   return -1;
 }
 
@@ -3907,14 +3907,22 @@ storeAtts(XML_Parser parser, const ENCODING *enc, const char *attStr,
     if (! attId)
       return XML_ERROR_NO_MEMORY;
 #ifdef XML_ATTR_INFO
+    // NOTE: XML_Index is known to wrap around for >2 GiB content
+    //       on 32bit machines and 64bit Windows, unless (non-default and
+    //       uncommon) XML_LARGE_SIZE is defined.
+    //       That's a bug and it only lives on because we cannot break
+    //       ABI compatibility of public API.
     currAttInfo->nameStart
-        = parser->m_parseEndByteIndex - (parser->m_parseEndPtr - currAtt->name);
+        = (XML_Index)(parser->m_parseEndByteIndex
+                      - (parser->m_parseEndPtr - currAtt->name));
     currAttInfo->nameEnd
         = currAttInfo->nameStart + XmlNameLength(enc, currAtt->name);
-    currAttInfo->valueStart = parser->m_parseEndByteIndex
-                              - (parser->m_parseEndPtr - currAtt->valuePtr);
-    currAttInfo->valueEnd = parser->m_parseEndByteIndex
-                            - (parser->m_parseEndPtr - currAtt->valueEnd);
+    currAttInfo->valueStart
+        = (XML_Index)(parser->m_parseEndByteIndex
+                      - (parser->m_parseEndPtr - currAtt->valuePtr));
+    currAttInfo->valueEnd
+        = (XML_Index)(parser->m_parseEndByteIndex
+                      - (parser->m_parseEndPtr - currAtt->valueEnd));
 #endif
     /* Detect duplicate attributes by their QNames. This does not work when
        namespace processing is turned on and different prefixes for the same

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -95,10 +95,10 @@
 #include <stddef.h>
 #include <string.h> /* memset(), memcpy() */
 #include <assert.h>
-#include <limits.h> /* INT_MAX, LLONG_MAX, LONG_MAX, UINT_MAX */
+#include <limits.h> /* INT_MAX, UINT_MAX */
 #include <stdio.h>  /* fprintf */
 #include <stdlib.h> /* getenv */
-#include <stdint.h> /* SIZE_MAX, uintptr_t */
+#include <stdint.h> /* SIZE_MAX, UINT64_MAX, uint64_t, uintptr_t */
 #include <math.h>   /* isnan */
 #include <errno.h>
 
@@ -211,12 +211,6 @@ typedef char ICHAR;
 #  define XML_T(x) x
 #  define XML_L(x) x
 
-#endif
-
-#ifdef XML_LARGE_SIZE
-#  define XML_INDEX_MAX LLONG_MAX
-#else
-#  define XML_INDEX_MAX LONG_MAX
 #endif
 
 /* Round up n to be a multiple of sz, where sz is a power of 2. */
@@ -721,7 +715,7 @@ struct XML_ParserStruct {
   char *m_bufferEnd;       // past last character to be parsed
   const char *m_bufferLim; // allocated end of m_buffer
 
-  XML_Index m_parseEndByteIndex;
+  uint64_t m_parseEndByteIndex;
   const char *m_parseEndPtr;
   size_t m_partialTokenBytesBefore; /* used in heuristic to avoid O(n^2) */
   XML_Bool m_reparseDeferralEnabled;
@@ -2314,7 +2308,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
     int nLeftOver;
     enum XML_Status result;
     /* Detect overflow (a+b > MAX <==> b > MAX-a) */
-    if (len > XML_INDEX_MAX - parser->m_parseEndByteIndex) {
+    if ((uint64_t)len > UINT64_MAX - parser->m_parseEndByteIndex) {
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       parser->m_eventPtr = parser->m_eventEndPtr = NULL;
       parser->m_processor = errorProcessor;
@@ -2432,7 +2426,7 @@ XML_ParseBuffer(XML_Parser parser, int len, int isFinal) {
   }
 
   // Detect and avoid integer overflow
-  if (len > XML_INDEX_MAX - parser->m_parseEndByteIndex) {
+  if ((uint64_t)len > UINT64_MAX - parser->m_parseEndByteIndex) {
     parser->m_errorCode = XML_ERROR_NO_MEMORY;
     parser->m_eventPtr = parser->m_eventEndPtr = NULL;
     parser->m_processor = errorProcessor;
@@ -2694,9 +2688,15 @@ XML_Index XMLCALL
 XML_GetCurrentByteIndex(XML_Parser parser) {
   if (parser == NULL)
     return -1;
-  if (parser->m_eventPtr)
+  if (parser->m_eventPtr) {
+    // NOTE: XML_Index is known to wrap around for >2 GiB content
+    //       on 32bit machines and 64bit Windows, unless (non-default and
+    //       uncommon) XML_LARGE_SIZE is defined.
+    //       That's a bug and it only lives on because we cannot break
+    //       ABI compatibility of public API.
     return (XML_Index)(parser->m_parseEndByteIndex
                        - (parser->m_parseEndPtr - parser->m_eventPtr));
+  }
   return -1;
 }
 
@@ -3907,14 +3907,22 @@ storeAtts(XML_Parser parser, const ENCODING *enc, const char *attStr,
     if (! attId)
       return XML_ERROR_NO_MEMORY;
 #ifdef XML_ATTR_INFO
+    // NOTE: XML_Index is known to wrap around for >2 GiB content
+    //       on 32bit machines and 64bit Windows, unless (non-default and
+    //       uncommon) XML_LARGE_SIZE is defined.
+    //       That's a bug and it only lives on because we cannot break
+    //       ABI compatibility of public API.
     currAttInfo->nameStart
-        = parser->m_parseEndByteIndex - (parser->m_parseEndPtr - currAtt->name);
+        = (XML_Index)(parser->m_parseEndByteIndex
+                      - (parser->m_parseEndPtr - currAtt->name));
     currAttInfo->nameEnd
         = currAttInfo->nameStart + XmlNameLength(enc, currAtt->name);
-    currAttInfo->valueStart = parser->m_parseEndByteIndex
-                              - (parser->m_parseEndPtr - currAtt->valuePtr);
-    currAttInfo->valueEnd = parser->m_parseEndByteIndex
-                            - (parser->m_parseEndPtr - currAtt->valueEnd);
+    currAttInfo->valueStart
+        = (XML_Index)(parser->m_parseEndByteIndex
+                      - (parser->m_parseEndPtr - currAtt->valuePtr));
+    currAttInfo->valueEnd
+        = (XML_Index)(parser->m_parseEndByteIndex
+                      - (parser->m_parseEndPtr - currAtt->valueEnd));
 #endif
     /* Detect duplicate attributes by their QNames. This does not work when
        namespace processing is turned on and different prefixes for the same

--- a/expat/lib/xmltok.h
+++ b/expat/lib/xmltok.h
@@ -147,8 +147,8 @@ extern "C" {
 
 typedef struct position {
   /* first line and first column are 0 not 1 */
-  XML_Size lineNumber;
-  XML_Size columnNumber;
+  unsigned long long lineNumber;
+  unsigned long long columnNumber;
 } POSITION;
 
 typedef struct {

--- a/expat/lib/xmltok.h
+++ b/expat/lib/xmltok.h
@@ -39,6 +39,8 @@
 #ifndef XmlTok_INCLUDED
 #  define XmlTok_INCLUDED 1
 
+#  include <stdint.h> // uint64_t
+
 #  ifdef __cplusplus
 extern "C" {
 #  endif
@@ -147,8 +149,8 @@ extern "C" {
 
 typedef struct position {
   /* first line and first column are 0 not 1 */
-  XML_Size lineNumber;
-  XML_Size columnNumber;
+  uint64_t lineNumber;
+  uint64_t columnNumber;
 } POSITION;
 
 typedef struct {

--- a/expat/tests/misc_tests.c
+++ b/expat/tests/misc_tests.c
@@ -872,6 +872,36 @@ START_TEST(test_misc_low_surrogate_mozilla_bug_2053153) {
 }
 END_TEST
 
+START_TEST(test_misc_input_2gb) {
+  XML_Parser parser;
+  const char *const doc = "<?xml version='1.0'?><doc/>";
+  unsigned long long offset = 0;
+  char buf[4096];
+
+  if (g_chunkSize != 0) {
+    return; // this test is slow, and doesn't use _XML_Parse_SINGLE_BYTES().
+  }
+
+  memset(buf, ' ', sizeof(buf));
+
+  parser = XML_ParserCreate(NULL);
+
+  assert_true(XML_Parse(parser, doc, (int)strlen(doc), XML_FALSE)
+              == XML_STATUS_OK);
+  offset += strlen(doc);
+
+  while (offset < 2ULL * 1024 * 1024 * 1024) {
+    assert_true(XML_Parse(parser, buf, sizeof(buf), XML_FALSE)
+                == XML_STATUS_OK);
+    offset += sizeof(buf);
+  }
+
+  assert_true(XML_Parse(parser, NULL, 0, XML_TRUE) == XML_STATUS_OK);
+
+  XML_ParserFree(parser);
+}
+END_TEST
+
 void
 make_miscellaneous_test_case(Suite *s) {
   TCase *tc_misc = tcase_create("miscellaneous tests");
@@ -905,6 +935,6 @@ make_miscellaneous_test_case(Suite *s) {
   tcase_add_test(tc_misc, test_misc_no_infinite_loop_issue_1161);
   tcase_add_test(tc_misc, test_misc_calls_forbidden_from_handlers);
   tcase_add_test(tc_misc, test_misc_resume_parser_forbidden_from_handler);
-
+  tcase_add_test(tc_misc, test_misc_input_2gb);
   tcase_add_test(tc_misc, test_misc_low_surrogate_mozilla_bug_2053153);
 }


### PR DESCRIPTION
Fixes #1297

CC @evgenykotkov @Smattr 