### PR TITLE
lib: Use PRI macros from `inttypes.h` for printf formats (fixes #1305)

### DIFF
--- a/expat/lib/internal.h
+++ b/expat/lib/internal.h
@@ -125,20 +125,11 @@
 #    define EXPAT_FMT_SIZE_T(midpart) "%" midpart "u"
 #  endif
 #else
+#  include <inttypes.h> // PRIdPTR, PRIuPTR
 #  define EXPAT_FMT_LLX(midpart) "%" midpart "llx"
 #  define EXPAT_FMT_ULL(midpart) "%" midpart "llu"
-#  if ! defined(ULONG_MAX)
-#    error Compiler did not define ULONG_MAX for us
-#  elif ULONG_MAX == 18446744073709551615u // 2^64-1
-#    define EXPAT_FMT_PTRDIFF_T(midpart) "%" midpart "ld"
-#    define EXPAT_FMT_SIZE_T(midpart) "%" midpart "lu"
-#  elif defined(__wasm32__) // 32bit mode Emscripten or WASI SDK
-#    define EXPAT_FMT_PTRDIFF_T(midpart) "%" midpart "ld"
-#    define EXPAT_FMT_SIZE_T(midpart) "%" midpart "zu"
-#  else
-#    define EXPAT_FMT_PTRDIFF_T(midpart) "%" midpart "d"
-#    define EXPAT_FMT_SIZE_T(midpart) "%" midpart "u"
-#  endif
+#  define EXPAT_FMT_PTRDIFF_T(midpart) "%" midpart PRIdPTR
+#  define EXPAT_FMT_SIZE_T(midpart) "%" midpart PRIuPTR
 #endif
 
 #ifndef UNUSED_P


### PR DESCRIPTION
 <!-- Thanks for your interest in contributing to the libexpat project or "Expat"! -->

# Self-Diagnosis

<!-- PLEASE ANSWER THE FOLLOWING: -->
- [x] This pull request fixes #1305
- [x] This pull request is related to #1299.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.


# Description

This addresses the `-Wformat` warning on AIX reported in #1299:

```
xmlparse.c:8602:11: warning: format specifies type 'int' but the argument
has type 'ptrdiff_t' (aka 'long') [-Wformat]
```

`EXPAT_FMT_PTRDIFF_T`/`EXPAT_FMT_SIZE_T` in `lib/internal.h` pick a printf
conversion specifier by inspecting `ULONG_MAX` (plus a `__wasm32__` special
case). On any non-wasm32 platform where `long` is 32-bit — including AIX,
32-bit and 64-bit — that logic picks `%d`/`%u`, even though `ptrdiff_t` is
`long` there, hence the warning.

Instead of guessing, this prefers `PRIdPTR`/`PRIuPTR` from `<inttypes.h>`
when the header is available, letting the platform's own vendor header
report the specifier matching its actual `intptr_t`/`uintptr_t`. Falls back
to the previous `ULONG_MAX`-based logic when `<inttypes.h>` isn't available.
The Windows branch and `EXPAT_FMT_LLX`/`EXPAT_FMT_ULL` (already an exact,
portable match for `unsigned long long`) are untouched.

CMake's `ConfigureChecks.cmake` already had a `check_include_file("inttypes.h"
HAVE_INTTYPES_H)`, defined but unused anywhere in the source; this adds the
equivalent `AC_CHECK_HEADERS([inttypes.h])` to `configure.ac` for Autotools
parity.

I also double-checked the assumption that `<inttypes.h>` is available on
AIX: IBM's docs confirm it (with `intptr_t`/`uintptr_t`) for both AIX 7.1
and AIX 7.3.

Tested locally on Windows with MSVC (no AIX/Linux box on hand):
- A standalone repro of the new branch (forcing `_WIN32` undefined +
  `HAVE_INTTYPES_H` defined) compiles clean under `/W4` and prints correct
  `ptrdiff_t`/`size_t` values.
- Full CMake configure + build (MSVC auto-detects `HAVE_INTTYPES_H`) and the
  full test suite pass (4836/4836).
- `xmlwf` with `EXPAT_ACCOUNTING_DEBUG=2` exercises the exact
  `accountingReportDiff` call site from the original warning at runtime with
  correct output.
- All CI workflows in my fork are green for this branch.
