### PR TITLE
Limit CI workflow runtime and package installation runtime

### DIFF
--- a/.github/workflows/autotools-cmake.yml
+++ b/.github/workflows/autotools-cmake.yml
@@ -44,6 +44,7 @@ permissions:
 jobs:
   checks:
     name: Ensure that GNU Autotools and CMake build systems agree
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +92,7 @@ jobs:
       run: |-
         set -x
         sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             cmake \
             docbook2x \
             lzip \

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   clang_format:
     name: Enforce clang-format clean code
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -56,7 +57,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository "deb https://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main"
         sudo apt-get update  # due to new repository
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             clang-format-22 \
             moreutils
         echo /usr/lib/llvm-22/bin >>"${GITHUB_PATH}"

--- a/.github/workflows/clang-static-analyzer.yml
+++ b/.github/workflows/clang-static-analyzer.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   clang_static_analyzer:
     name: Enforce Clang Static Analyzer (scan-build) clean code
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -55,7 +56,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository "deb https://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main"
         sudo apt-get update  # due to new repository
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             clang-22 \
             clang-tools-22
         echo /usr/lib/llvm-22/bin >>"${GITHUB_PATH}"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   clang_tidy:
     name: Enforce clang-tidy clean code
+    timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -56,7 +57,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository "deb https://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main"
         sudo apt-get update  # due to new repository
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             clang-tidy-22
         echo /usr/lib/llvm-22/bin >>"${GITHUB_PATH}"
 

--- a/.github/workflows/cmake-required-version.yml
+++ b/.github/workflows/cmake-required-version.yml
@@ -44,6 +44,7 @@ permissions:
 jobs:
   checks:
     name: Ensure realistic minimum CMake version requirement
+    timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   checks:
     name: Enforce codespell-clean spelling
+    timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,6 +45,7 @@ permissions:
 jobs:
   checks:
     name: Collect test coverage
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     env:
       CFLAGS: -g3 -pipe
@@ -62,7 +63,7 @@ jobs:
         sudo dpkg --add-architecture i386  # for wine32
         sudo apt-get update  # due to new architecture
 
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             cmake \
             docbook-xml \
             docbook2x \
@@ -74,7 +75,7 @@ jobs:
             retry
 
         # Install 32bit Wine
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             mingw-w64 \
             wine-stable \
             wine32:i386

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   coverity_scan_upload:
     name: Upload build to Coverity Scan
+    timeout-minutes: 15
     # NOTE: The idea is not to bother fork repositories with a job
     #       that is doomed to fail
     if: ${{ github.repository == 'libexpat/libexpat' }}
@@ -71,7 +72,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository "deb https://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main"
         sudo apt-get update  # due to new repository
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             clang-22 \
             libclang-rt-22-dev \
             llvm-22
@@ -80,7 +81,7 @@ jobs:
     - name: Install build dependencies
       run: |-
         set -x
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             libprotobuf-dev \
             protobuf-compiler
 

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -44,6 +44,7 @@ permissions:
 jobs:
   checks:
     name: Run Cppcheck
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   emscripten:
     name: Build with Emscripten
+    timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -52,7 +53,7 @@ jobs:
       run: |-
         set -x
         sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             cmake \
             emscripten \
             make

--- a/.github/workflows/expat_config_h.yml
+++ b/.github/workflows/expat_config_h.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   checks:
     name: Check expat_config.h.{in,cmake} for regressions
+    timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   freebsd:
     name: Build in a FreeBSD VM
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -56,7 +57,7 @@ jobs:
 
         prepare: |
           set -e -u -x
-          pkg install -y \
+          timeout 10m pkg install -y \
               autoconf \
               automake \
               bash \

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   run_fuzzers:
     name: Run fuzzing regression tests
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -64,7 +65,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         sudo add-apt-repository "deb https://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main"
         sudo apt-get update  # due to new repository
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             clang-22 \
             libclang-rt-22-dev \
             llvm-22
@@ -73,7 +74,7 @@ jobs:
     - name: Install build dependencies
       run: |-
         set -x
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             autoconf \
             automake \
             docbook2x \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,6 +47,7 @@ permissions:
 jobs:
   checks:
     name: Perform checks
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -101,7 +102,7 @@ jobs:
         # Install 32bit Wine
         sudo dpkg --add-architecture i386  # for wine32
         sudo apt-get update  # due to new architecture
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             mingw-w64 \
             retry \
             wine-stable \
@@ -116,14 +117,14 @@ jobs:
         sudo add-apt-repository "deb https://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-22 main"
         sudo apt-get update  # due to new repository
         # NOTE: Please note the version-specific ${PATH} extension for Clang adding /usr/lib/llvm-22/bin in .ci.sh
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             clang-22 \
             libclang-rt-22-dev \
             llvm-22
 
     - name: Install build dependencies (common)
       run: |-
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             cmake \
             docbook2x \
             gcc-multilib \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,7 @@ permissions:
 jobs:
   checks:
     name: Perform checks
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [macos-14, macos-15]

--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   musl:
     name: Build with musl
+    timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -52,7 +53,7 @@ jobs:
       run: |-
         set -x
         sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             cmake \
             musl-tools
 

--- a/.github/workflows/perl-integration.yml
+++ b/.github/workflows/perl-integration.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   perl_integration:
     name: Run Perl XML::Parser integration tests
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +60,7 @@ jobs:
       run: |
         set -x
         sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             libfile-sharedir-install-perl \
             libfile-sharedir-perl
 

--- a/.github/workflows/solaris.yml
+++ b/.github/workflows/solaris.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   solaris:
     name: Build in a Solaris VM
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -60,7 +61,7 @@ jobs:
           #       Exit code 3 means "all now installed and some not before".
           #       Exit code 4 means "all now installed and all already before".
           #       Command "pkg list -a" can show a list of packages available.
-          pkg install \
+          timeout 10m pkg install \
             autoconf \
             automake \
             bash \

--- a/.github/workflows/valid-xml.yml
+++ b/.github/workflows/valid-xml.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   checks:
     name: Ensure well-formed and valid XML
+    timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -55,7 +56,7 @@ jobs:
       run: |-
         set -x
         sudo apt-get update
-        sudo apt-get install --yes --no-install-recommends -V \
+        sudo timeout 10m apt-get install --yes --no-install-recommends -V \
             docbook \
             libxml2-utils \
             moreutils \
@@ -63,7 +64,7 @@ jobs:
 
         # NOTE: Ubuntu 24.04 has tidy 5.6.0 while we need more recent tidy 5.8.0
         wget --progress=dot:giga "https://github.com/htacg/tidy-html5/releases/download/${tidy_version}/tidy-${tidy_version}-Linux-64bit.deb"
-        sudo apt-get install --yes "./tidy-${tidy_version}-Linux-64bit.deb"
+        sudo timeout 10m apt-get install --yes "./tidy-${tidy_version}-Linux-64bit.deb"
 
     - name: Enforce clean XML
       run: |

--- a/.github/workflows/wasi_sdk.yml
+++ b/.github/workflows/wasi_sdk.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   wasi_sdk:
     name: Build with WASI SDK
+    timeout-minutes: 15
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -56,7 +57,7 @@ jobs:
       run: |-
         set -x -u
         wget "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${wasi_sdk_major}/wasi-sdk-${wasi_sdk_major}.${wasi_sdk_minor}-x86_64-linux.deb"
-        sudo apt-get install --yes "./wasi-sdk-${wasi_sdk_major}.${wasi_sdk_minor}-x86_64-linux.deb"
+        sudo timeout 10m apt-get install --yes "./wasi-sdk-${wasi_sdk_major}.${wasi_sdk_minor}-x86_64-linux.deb"
 
     - name: Build using WASI SDK
       run: |

--- a/.github/workflows/windows-binaries.yml
+++ b/.github/workflows/windows-binaries.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   windows_binaries:
     name: Build ${{ matrix.expat_platform }} binaries
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   windows_build:
     name: Build on Windows (${{ matrix.runs-on }}, ${{ matrix.cmake_platform }}, ${{ matrix.expat_char_type }})
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This should stop CI e.g. running for 6 hours just because `apt-get install` is talking to a turtle speed mirror.