### PR TITLE
lib/xmlparse.c: avoid signed left shift in storeAtts growth check

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -51,6 +51,7 @@
    Copyright (c) 2026      Kartik Kenchi <netliomax25@gmail.com>
    Copyright (c) 2026      Haris Hussain <hextheshadow0x@gmail.com>
    Copyright (c) 2026      Evgeny Kotkov <kotkov@apache.org>
+   Copyright (c) 2026      Alberto Maschietto <albertomaschietto9@gmail.com>
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -4067,8 +4068,8 @@ storeAtts(XML_Parser parser, const ENCODING *enc, const char *attStr,
     unsigned int nsAttsSize = 1u << parser->m_nsAttsPower;
     unsigned char oldNsAttsPower = parser->m_nsAttsPower;
     /* size of hash table must be at least 2 * (# of prefixed attributes) */
-    if ((nPrefixes << 1)
-        >> parser->m_nsAttsPower) { /* true for m_nsAttsPower = 0 */
+    if (parser->m_nsAttsPower == 0
+        || (nPrefixes >> (parser->m_nsAttsPower - 1))) {
       /* hash table size must also be a power of 2 and >= 8 */
       while (nPrefixes >> parser->m_nsAttsPower++)
         ;


### PR DESCRIPTION
## Self-Diagnosis

- [ ] This pull request fixes #ISSUE_NUMBER.
- [ ] This pull request is related to SOME_REFERENCE.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [ ] I have enabled and run all GitHub Actions CI in my fork repository, and hence expect CI to be all-green for this pull request.
- [x] I have read the contribution guidelines, and this pull request meets those guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire.

## Description

In `storeAtts()`, `nPrefixes` is a non-negative attribute-prefix count declared as `int`. The hash-table growth check only needs to answer whether the current table is already at least `2 * nPrefixes`. The previous formulation used a signed left shift to ask that question.

Rewrite the check to avoid the signed left shift entirely:

- `parser->m_nsAttsPower == 0` handles the one-bit edge case directly
- `nPrefixes >> (parser->m_nsAttsPower - 1)` answers the remaining capacity question without changing the surrounding `int` bookkeeping

This keeps the change narrowly scoped to the arithmetic in the growth test. It does not broaden the patch into a full type cleanup of `storeAtts()`.

## Validation

- Local CMake build completed with GCC in `RelWithDebInfo`.
- CTest: 1/1 test passed.
- The author personally reviewed the resulting arithmetic and validated that `nPrefixes` remains non-negative along this path.
- GitHub Actions workflows are enabled in the fork; earlier runs on the same one-commit PR were green apart from the known non-mergeable AppVeyor status on the draft PR.