### PR TITLE
[CVE-2026-66046] lib: Migrate `.isCdata` lookup from a linear loop to a hash table lookup

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -16,6 +16,25 @@
 !!                                   Sebastian Pipping -- Berlin, 2026-08-03 !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+Release 2.8.4 XXX XXXXXX XX XXXX
+        Security fixes:
+           #1321  CVE-2026-66046 -- Fix quadratic runtime from "attribute
+                    isCdata lookups" that allowed denial of service attacks
+                    through moderately sized crafted XML input (CWE-407).
+                    The vulnerability is closely related to past CVE-2026-45186
+                    that was fixed with Expat 2.8.1.
+                    Please note that a layer of compression around XML can
+                    significantly reduce the minimum attack payload size.
+                    Upstream CVSS 3.1 vector:
+                    AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (CVSS score: 7.5)
+                    (Note the "AV:N" for network/remote.)
+
+        Special thanks to:
+            Fabian Wahle (Hap Security)
+                 and
+            Moonshot AI
+            Z.ai
+
 Release 2.8.3 Mon August 10 2026
         Security fixes:
            #1296  CVE-2026-72522 -- Fix an out-of-bounds read and the resulting

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -394,7 +394,7 @@ typedef struct {
   size_t nDefaultAtts;
   size_t allocDefaultAtts;
   DEFAULT_ATTRIBUTE *defaultAtts;
-  HASH_TABLE defaultAttsNames;
+  HASH_TABLE defaultAttForName;
 } ELEMENT_TYPE;
 
 typedef struct {
@@ -3837,8 +3837,8 @@ storeAtts(XML_Parser parser, const ENCODING *enc, const char *attStr,
                                          sizeof(ELEMENT_TYPE));
     if (! elementType)
       return XML_ERROR_NO_MEMORY;
-    if (! elementType->defaultAttsNames.parser)
-      hashTableInit(&(elementType->defaultAttsNames), parser);
+    if (! elementType->defaultAttForName.parser)
+      hashTableInit(&(elementType->defaultAttForName), parser);
     if (parser->m_ns && ! setElementTypePrefix(parser, elementType))
       return XML_ERROR_NO_MEMORY;
   }
@@ -7239,7 +7239,7 @@ defineAttribute(ELEMENT_TYPE *type, ATTRIBUTE_ID *attId, XML_Bool isCdata,
     /* The handling of default attributes gets messed up if we have
        a default which duplicates a non-default. */
     NAMED *const nameFound
-        = lookup(parser, &(type->defaultAttsNames), attId->name, 0);
+        = lookup(parser, &(type->defaultAttForName), attId->name, 0);
     if (nameFound)
       return 1;
     if (isId && ! type->idAtt && ! attId->xmlns)
@@ -7276,7 +7276,7 @@ defineAttribute(ELEMENT_TYPE *type, ATTRIBUTE_ID *attId, XML_Bool isCdata,
     attId->maybeTokenized = XML_TRUE;
 
   NAMED *const nameAddedOrFound
-      = lookup(parser, &(type->defaultAttsNames), attId->name, sizeof(NAMED));
+      = lookup(parser, &(type->defaultAttForName), attId->name, sizeof(NAMED));
   if (! nameAddedOrFound)
     return 0;
 
@@ -7597,7 +7597,7 @@ dtdReset(DTD *p, XML_Parser parser) {
     ELEMENT_TYPE *e = (ELEMENT_TYPE *)hashTableIterNext(&iter);
     if (! e)
       break;
-    hashTableDestroy(&(e->defaultAttsNames));
+    hashTableDestroy(&(e->defaultAttForName));
     FREE(parser, e->defaultAtts);
   }
   hashTableClear(&(p->generalEntities));
@@ -7639,7 +7639,7 @@ dtdDestroy(DTD *p, XML_Bool isDocEntity, XML_Parser parser) {
     ELEMENT_TYPE *e = (ELEMENT_TYPE *)hashTableIterNext(&iter);
     if (! e)
       break;
-    hashTableDestroy(&(e->defaultAttsNames));
+    hashTableDestroy(&(e->defaultAttForName));
     FREE(parser, e->defaultAtts);
   }
   hashTableDestroy(&(p->generalEntities));
@@ -7732,8 +7732,8 @@ dtdCopy(XML_Parser oldParser, DTD *newDtd, const DTD *oldDtd,
     if (! newE)
       return 0;
 
-    if (! newE->defaultAttsNames.parser)
-      hashTableInit(&(newE->defaultAttsNames), parser);
+    if (! newE->defaultAttForName.parser)
+      hashTableInit(&(newE->defaultAttForName), parser);
 
     if (oldE->nDefaultAtts) {
       /* Detect and prevent integer overflow. */
@@ -7766,7 +7766,7 @@ dtdCopy(XML_Parser oldParser, DTD *newDtd, const DTD *oldDtd,
       } else
         newE->defaultAtts[i].value = NULL;
 
-      NAMED *const nameAddedOrFound = lookup(parser, &(newE->defaultAttsNames),
+      NAMED *const nameAddedOrFound = lookup(parser, &(newE->defaultAttForName),
                                              attributeName, sizeof(NAMED));
       if (! nameAddedOrFound) {
         return 0;
@@ -8535,8 +8535,8 @@ getElementType(XML_Parser parser, const ENCODING *enc, const char *ptr,
                                sizeof(ELEMENT_TYPE));
   if (! ret)
     return NULL;
-  if (! ret->defaultAttsNames.parser)
-    hashTableInit(&(ret->defaultAttsNames), getRootParserOf(parser, NULL));
+  if (! ret->defaultAttForName.parser)
+    hashTableInit(&(ret->defaultAttForName), getRootParserOf(parser, NULL));
   if (ret->name != name)
     poolDiscard(&dtd->pool);
   else {

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -381,6 +381,22 @@ typedef struct {
   const XML_Char *value;
 } DEFAULT_ATTRIBUTE;
 
+// This structure allows mapping attribute names to instances of
+// `DEFAULT_ATTRIBUTE`.
+typedef struct {
+  // Member `name` goes first to make this structure compatible with structure
+  // `NAMED` (further up), which is needed to support use of structure
+  // `NAME_AND_DEFAULT_ATTRIBUTE` in a hash table as implemented by function
+  // `lookup` (further down).
+  const XML_Char *name;
+  // We would store a `DEFAULT_ATTRIBUTE *` here but the backing array
+  // can be reallocated which would invalidate the pointer. Using an index
+  // into the array instead, avoids that problem.
+  size_t attIndex;
+  // This is set to `false` by function `lookup`.
+  bool initialized;
+} NAME_AND_DEFAULT_ATTRIBUTE;
+
 typedef struct {
   unsigned long version;
   unsigned long hash;
@@ -3951,11 +3967,14 @@ storeAtts(XML_Parser parser, const ENCODING *enc, const char *attStr,
 
       /* figure out whether declared as other than CDATA */
       if (attId->maybeTokenized) {
-        for (size_t j = 0; j < nDefaultAtts; j++) {
-          if (attId == elementType->defaultAtts[j].id) {
-            isCdata = elementType->defaultAtts[j].isCdata;
-            break;
-          }
+        NAME_AND_DEFAULT_ATTRIBUTE *const nameAndDefaultAttribute
+            = (NAME_AND_DEFAULT_ATTRIBUTE *)lookup(
+                parser, &(elementType->defaultAttForName), attId->name, 0);
+        if (nameAndDefaultAttribute != NULL) {
+          assert(nameAndDefaultAttribute->attIndex < elementType->nDefaultAtts);
+          const DEFAULT_ATTRIBUTE *const att
+              = elementType->defaultAtts + nameAndDefaultAttribute->attIndex;
+          isCdata = att->isCdata;
         }
       }
 
@@ -7275,10 +7294,23 @@ defineAttribute(ELEMENT_TYPE *type, ATTRIBUTE_ID *attId, XML_Bool isCdata,
   if (! isCdata)
     attId->maybeTokenized = XML_TRUE;
 
-  NAMED *const nameAddedOrFound
-      = lookup(parser, &(type->defaultAttForName), attId->name, sizeof(NAMED));
-  if (! nameAddedOrFound)
+  NAME_AND_DEFAULT_ATTRIBUTE *const nameAndDefaultAttribute
+      = (NAME_AND_DEFAULT_ATTRIBUTE *)lookup(
+          parser, &(type->defaultAttForName), attId->name,
+          sizeof(NAME_AND_DEFAULT_ATTRIBUTE));
+  if (! nameAndDefaultAttribute)
     return 0;
+
+  assert(nameAndDefaultAttribute->name == attId->name);
+
+  // NOTE: The XML 1.0r4 spec says:
+  // "When more than one definition is provided for the same attribute of a
+  // given element type, the first declaration is binding and later
+  // declarations are ignored."
+  if (! nameAndDefaultAttribute->initialized) {
+    nameAndDefaultAttribute->attIndex = type->nDefaultAtts;
+    nameAndDefaultAttribute->initialized = true;
+  }
 
   type->nDefaultAtts += 1;
   return 1;


### PR DESCRIPTION
Everything after the next line is the original report Markdown…

----

# Quadratic CPU Complexity in storeAtts() isCdata Attribute Default Lookup

**Package:** libexpat/libexpat
**Tested Versions:** 2.8.2 / master 7d93af0

---

## Affected Files

`expat/lib/xmlparse.c` approximately lines 3931-3938 (`storeAtts()`)

---

## Root Cause

In `storeAtts()`, when a specified attribute value requires normalization and `attId->maybeTokenized` is set, the function determines whether the attribute is CDATA by linearly scanning `elementType->defaultAtts`. For N specified attributes that take this path, the inner loop may examine up to N default attribute entries, producing O(N²) work. PR #1216 (CVE-2026-45186) introduced `defaultAttsNames` for collision detection but left this `isCdata` lookup on the linear scan.

```c
if (attId->maybeTokenized) {
  for (size_t j = 0; j < nDefaultAtts; j++) {
    if (attId == elementType->defaultAtts[j].id) {
      isCdata = elementType->defaultAtts[j].isCdata;
      break;
    }
  }
}
```

---

## PoC

**1. Build stock libexpat tools:**
```bash
cmake -S expat -B build -DCMAKE_BUILD_TYPE=Release -DEXPAT_BUILD_TOOLS=ON
cmake --build build -j
```

**2. Generate malicious document:**
```python
#!/usr/bin/env python3
import sys
n = int(sys.argv[1]) if len(sys.argv) > 1 else 20000
defs = "".join(f'<!ATTLIST e a{i} NMTOKEN "x">\n' for i in range(n))
atts = " ".join(f'a{i}=" v "' for i in range(n))  # spaces => needs normalize
print(f"<!DOCTYPE e [\n{defs}]>\n<e {atts}/>")
```

```bash
python3 gen.py 20000 > dos.xml
```

**3. Parse:**
```bash
time ./build/xmlwf/xmlwf dos.xml
```

**4. Observed scaling (Debian 13 amd64, Release build, no sanitizers):**

| N (attrs) | Approx. file size | Wall time (stock xmlwf) |
|-----------|-------------------|-------------------------|
| 5,000 | ~0.21 MB | ~0.03 s |
| 10,000 | ~0.43 MB | ~0.07 s |
| 20,000 | ~0.88 MB | ~0.18 s |
| 60,000 | ~2.7 MB | ~1.68 s |

---

## Impact

An attacker who can supply XML to any application using libexpat can cause CPU exhaustion with a sub-3 MB payload, requiring no authentication, external entity resolution, or non-default parser options. CPU consumption scales quadratically with attribute count; tens of megabytes of attributes yield multi-second to multi-minute CPU consumption per request on a single core. Stock `xmlwf` and all applications using default element and attribute handling are affected.

---

## Suggested Remediation

Reuse the existing `elementType->defaultAttsNames` hash table introduced in PR #1216 for the `isCdata` lookup instead of scanning `defaultAtts[]`, or store `isCdata` directly on `ATTRIBUTE_ID` to make the per-attribute lookup O(1).