### PR TITLE
[CVE-2026-76957] Protect custom encoding callbacks from parser re-entry

### DIFF
--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -755,6 +755,8 @@ struct XML_ParserStruct {
   void *m_unknownEncodingMem;
   void *m_unknownEncodingData;
   void *m_unknownEncodingHandlerData;
+  // Application callback invoked by callUnknownEncodingConvert.
+  int(XMLCALL *m_unknownEncodingConvert)(void *, const char *);
   void(XMLCALL *m_unknownEncodingRelease)(void *);
   PROLOG_STATE m_prologState;
   Processor *m_processor;
@@ -1177,6 +1179,25 @@ isCalledFromInsideHandler(XML_Parser parser) {
   return parser->m_handlerCallDepth > 0;
 }
 
+static void
+callUnknownEncodingRelease(XML_Parser parser) {
+  beforeHandler(parser);
+  parser->m_unknownEncodingRelease(parser->m_unknownEncodingData);
+  afterHandler(parser);
+  parser->m_unknownEncodingRelease = NULL;
+  parser->m_unknownEncodingData = NULL;
+}
+
+static int XMLCALL
+callUnknownEncodingConvert(void *data, const char *p) {
+  XML_Parser parser = data;
+  beforeHandler(parser);
+  const int result
+      = parser->m_unknownEncodingConvert(parser->m_unknownEncodingData, p);
+  afterHandler(parser);
+  return result;
+}
+
 static enum XML_Error
 callProcessor(XML_Parser parser, const char *start, const char *end,
               const char **endPtr) {
@@ -1524,6 +1545,7 @@ parserInit(XML_Parser parser, const XML_Char *encodingName) {
   parser->m_inheritedBindings = NULL;
   parser->m_nSpecifiedAtts = 0;
   parser->m_unknownEncodingMem = NULL;
+  parser->m_unknownEncodingConvert = NULL;
   parser->m_unknownEncodingRelease = NULL;
   parser->m_unknownEncodingData = NULL;
   parser->m_parsingStatus.parsing = XML_INITIALIZED;
@@ -1604,7 +1626,7 @@ XML_ParserReset(XML_Parser parser, const XML_Char *encodingName) {
   moveToFreeBindingList(parser, parser->m_inheritedBindings);
   FREE(parser, parser->m_unknownEncodingMem);
   if (parser->m_unknownEncodingRelease)
-    parser->m_unknownEncodingRelease(parser->m_unknownEncodingData);
+    callUnknownEncodingRelease(parser);
   poolClear(&parser->m_tempPool);
   poolClear(&parser->m_temp2Pool);
   FREE(parser, (void *)parser->m_protocolEncodingName);
@@ -1915,7 +1937,7 @@ XML_ParserFree(XML_Parser parser) {
   FREE(parser, parser->m_nsAtts);
   FREE(parser, parser->m_unknownEncodingMem);
   if (parser->m_unknownEncodingRelease)
-    parser->m_unknownEncodingRelease(parser->m_unknownEncodingData);
+    callUnknownEncodingRelease(parser);
   FREE(parser, parser);
 }
 
@@ -4946,25 +4968,34 @@ handleUnknownEncoding(XML_Parser parser, const XML_Char *encodingName) {
     const int status = parser->m_unknownEncodingHandler(
         parser->m_unknownEncodingHandlerData, encodingName, &info);
     afterHandler(parser);
+
+    parser->m_unknownEncodingRelease = info.release;
+    parser->m_unknownEncodingData = info.data;
+
     if (status) {
       ENCODING *enc;
       parser->m_unknownEncodingMem = MALLOC(parser, XmlSizeOfUnknownEncoding());
       if (! parser->m_unknownEncodingMem) {
-        if (info.release)
-          info.release(info.data);
+        if (parser->m_unknownEncodingRelease)
+          callUnknownEncodingRelease(parser);
+        else
+          parser->m_unknownEncodingData = NULL;
         return XML_ERROR_NO_MEMORY;
       }
+      parser->m_unknownEncodingConvert = info.convert;
       enc = (parser->m_ns ? XmlInitUnknownEncodingNS : XmlInitUnknownEncoding)(
-          parser->m_unknownEncodingMem, info.map, info.convert, info.data);
+          parser->m_unknownEncodingMem, info.map,
+          info.convert ? callUnknownEncodingConvert : NULL, parser);
       if (enc) {
-        parser->m_unknownEncodingData = info.data;
-        parser->m_unknownEncodingRelease = info.release;
         parser->m_encoding = enc;
         return XML_ERROR_NONE;
       }
+      parser->m_unknownEncodingConvert = NULL;
     }
-    if (info.release != NULL)
-      info.release(info.data);
+    if (parser->m_unknownEncodingRelease != NULL)
+      callUnknownEncodingRelease(parser);
+    else
+      parser->m_unknownEncodingData = NULL;
   }
   return XML_ERROR_UNKNOWN_ENCODING;
 }

--- a/expat/tests/misc_tests.c
+++ b/expat/tests/misc_tests.c
@@ -839,6 +839,60 @@ START_TEST(test_misc_resume_parser_forbidden_from_handler) {
 }
 END_TEST
 
+typedef struct {
+  XML_Parser parser;
+  int converterCallCount;
+  int releaseCallCount;
+} EncodingCallbackData;
+
+static int XMLCALL
+reentrant_encoding_converter(void *userData, const char *s) {
+  EncodingCallbackData *const data = userData;
+  UNUSED_P(s);
+  data->converterCallCount++;
+  forbidden_calls_character_handler(data->parser, NULL, 0);
+  return 'A';
+}
+
+static void XMLCALL
+reentrant_encoding_release(void *userData) {
+  EncodingCallbackData *const data = userData;
+  data->releaseCallCount++;
+  forbidden_calls_character_handler(data->parser, NULL, 0);
+}
+
+static int XMLCALL
+reentrant_encoding_handler(void *userData, const XML_Char *name,
+                           XML_Encoding *info) {
+  EncodingCallbackData *const data = userData;
+  UNUSED_P(name);
+
+  for (int i = 0; i < 256; i++)
+    info->map[i] = i;
+  info->map[0x80] = -2; // Route byte 0x80 through the custom converter.
+  info->data = data;
+  info->convert = reentrant_encoding_converter;
+  info->release = reentrant_encoding_release;
+  return XML_STATUS_OK;
+}
+
+START_TEST(test_misc_unknown_encoding_callbacks_protected) {
+  const char *const doc
+      = "<?xml version='1.0' encoding='reentrant-conv'?><doc>\x80\x80</doc>";
+  XML_Parser parser = XML_ParserCreate(NULL);
+  EncodingCallbackData data = {parser, 0, 0};
+  XML_SetUnknownEncodingHandler(parser, reentrant_encoding_handler, &data);
+
+  assert_true(XML_Parse(parser, doc, (int)strlen(doc), /*isFinal=*/XML_TRUE)
+              == XML_STATUS_OK);
+  assert_true(data.converterCallCount > 0);
+  assert_true(data.releaseCallCount == 0); // Released by XML_ParserFree below.
+
+  XML_ParserFree(parser);
+  assert_true(data.releaseCallCount == 1);
+}
+END_TEST
+
 // General attack payload idea by Jason Kratzer of Mozilla
 START_TEST(test_misc_low_surrogate_mozilla_bug_2053153) {
   const char doc_before[] = "<\0!\0D\0O\0C\0T\0Y\0P\0E\0 \0d\0 \0[\0\n\0"
@@ -936,6 +990,7 @@ make_miscellaneous_test_case(Suite *s) {
   tcase_add_test(tc_misc, test_misc_no_infinite_loop_issue_1161);
   tcase_add_test(tc_misc, test_misc_calls_forbidden_from_handlers);
   tcase_add_test(tc_misc, test_misc_resume_parser_forbidden_from_handler);
+  tcase_add_test(tc_misc, test_misc_unknown_encoding_callbacks_protected);
   tcase_add_test(tc_misc, test_misc_input_2gb);
   tcase_add_test(tc_misc, test_misc_low_surrogate_mozilla_bug_2053153);
 }


### PR DESCRIPTION
# Self-Diagnosis

- [ ] This pull request fixes #ISSUE_NUMBER.
- [x] This pull request is related to the custom-encoding callback reentrancy report shared privately with Sebastian Pipping.
- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [ ] I have enabled and run all GitHub Actions CI in my fork repository, and hence expect CI to be all-green for this pull request.
- [x] I have read the contribution guidelines, and this pull request meets these guidelines for contribution.
- [ ] I had trouble understanding parts of this questionnaire.

# Description

Protect application-provided `XML_Encoding.convert` and
`XML_Encoding.release` callbacks with Expat's existing handler reentrancy
counter. This makes same-parser calls from those callbacks follow the same
rejection rules as calls from registered parser handlers.

The converter wrapper receives the parser as its internal callback data and
forwards the original application data. This keeps the counter in
`xmlparse.c` and avoids changing tokenizer interfaces or storing a counter
pointer in the tokenizer's unknown-encoding object. The parser stores the
existing application-provided `XML_Encoding.convert` pointer only so this
internal trampoline can forward to it after incrementing the handler depth.

The regression invokes the currently forbidden same-parser APIs from both
callbacks, tracks converter and release calls independently, and verifies
that release runs exactly once.

## Testing

- Full debug test suite with warnings as errors: passed (1/1)
- Full ASan/UBSan test suite: passed (1/1)
- Original converter and release PoC modes under ASan/UBSan: both exit cleanly
- `clang-format --dry-run --Werror`: passed
- `git diff --check`: passed
