### PR TITLE
[CVE-2026-76956] lib: Fix inverted `getentropy()` return in `writeRandomBytes_getentropy`

### DIFF
--- a/expat/lib/random_getentropy.c
+++ b/expat/lib/random_getentropy.c
@@ -54,7 +54,7 @@
 bool
 writeRandomBytes_getentropy(void *target, size_t count) {
   errno = 0;
-  const bool success = getentropy(target, count);
+  const bool success = (getentropy(target, count) == 0);
   // MSan does not understand `getentropy`, so explain its effects
   if (success)
     MSAN_UNPOISON(target, count);


### PR DESCRIPTION
getentropy() returns 0 on success, but writeRandomBytes_getentropy() stores that straight into a bool — so the check is inverted. A good read looks like a failure and the entropy gets thrown away (salt falls back to time+pid), and the failure path ends up using an uninitialized buffer. This puts back the `== 0` from the #1275 review that got dropped.

Introduced in c90f80c1. Thanks @hartwork for confirming and tracing it.