### PR TITLE
Make CI cover compilation and execution on riscv64

### DIFF
--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -1,0 +1,89 @@
+#                          __  __            _
+#                       ___\ \/ /_ __   __ _| |_
+#                      / _ \\  /| '_ \ / _` | __|
+#                     |  __//  \| |_) | (_| | |_
+#                      \___/_/\_\ .__/ \__,_|\__|
+#                               |_| XML parser
+#
+# Copyright (c) 2026 Matteo Forzan <matteo.forzan95@gmail.com>
+# Licensed under the MIT license:
+#
+# Permission is  hereby granted,  free of charge,  to any  person obtaining
+# a  copy  of  this  software   and  associated  documentation  files  (the
+# "Software"),  to  deal in  the  Software  without restriction,  including
+# without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+# distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons  to whom  the Software  is  furnished to  do so,  subject to  the
+# following conditions:
+#
+# The above copyright  notice and this permission notice  shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+# EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+# NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+# USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+name: Build and test on riscv64 (emulated)
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 2 * * 5'  # Every Friday at 2am
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  riscv64:
+    name: Build and test on riscv64 (emulated)
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        persist-credentials: false
+
+    - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+      with:
+        platforms: riscv64
+
+    - name: Build and run the test suite on riscv64 in a container
+      run: |
+        docker run \
+            --platform linux/riscv64 \
+            --rm \
+            --volume "${PWD}:/workspace" \
+            --workdir /workspace \
+            debian:trixie-slim \
+            bash -c '
+          set -e -u -x
+
+          uname -m
+
+          apt-get update
+          timeout 10m apt-get install --yes --no-install-recommends -V \
+              ca-certificates \
+              cmake \
+              g++ \
+              gcc \
+              make \
+              python3 \
+              unzip \
+              wget
+
+          cmake_args=(
+            -DCMAKE_{C,CXX}_FLAGS="-O1 -pipe -Wall -Wextra -pedantic -Wno-overlength-strings"
+            -DEXPAT_BUILD_DOCS=OFF
+            -DEXPAT_WARNINGS_AS_ERRORS=ON
+          )
+          cmake "${cmake_args[@]}" -S expat/ -B build/
+          make -C build -j$(nproc) VERBOSE=1 all
+
+          make -C build/ test run-xmltest
+        '


### PR DESCRIPTION
# Self-Diagnosis

- [x] This pull request is small, uncontroversial, complete, and easy to review.
- [x] I have enabled and run all GitHub Actions CI in my fork repository,
  and hence expect CI to be all-green for this pull request.
- [x] I have read the [contribution guidelines](https://github.com/libexpat/libexpat/blob/HEAD/CONTRIBUTING.md), and this pull request meets these guidelines for contribution.

# Description

This pull request adds a workflow that builds Expat and runs the test suite on riscv64 Linux, using QEMU user emulation and a Debian trixie container on a regular x86-64 runner.
CI already covers musl, FreeBSD, Solaris, WASI and Fil-C, but so far no non-x86 Linux architecture.
The job runs both `make test` and `make run-xmltest` (with `uname -m` reporting `riscv64`) and takes about 8 minutes.
Green run in my fork: https://github.com/darkavatar23/libexpat/actions/runs/32850541612
