### PR TITLE
lib: Bulk-scan plain character data in 1-byte encodings

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -29,6 +29,9 @@ Release 2.8.4 XXX XXXXXX XX XXXX
                     AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (CVSS score: 7.5)
                     (Note the "AV:N" for network/remote.)
 
+        Other changes:
+           #1341  lib: Bulk-scan plain character data in 1-byte encodings
+
         Special thanks to:
             Fabian Wahle (Hap Security)
                  and

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -27,6 +27,7 @@
    Copyright (c) 2025      Alfonso Gregory <gfunni234@gmail.com>
    Copyright (c) 2026      Nick Begg <nick@stunttruck.net>
    Copyright (c) 2026      Kartik Kenchi <netliomax25@gmail.com>
+   Copyright (c) 2026      Artem Kulyk
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -208,6 +209,10 @@ struct normal_encoding {
   int(PTRFASTCALL *isInvalid2)(const ENCODING *, const char *);
   int(PTRFASTCALL *isInvalid3)(const ENCODING *, const char *);
   int(PTRFASTCALL *isInvalid4)(const ENCODING *, const char *);
+  /* Zero for the built-in encodings, whose type[] is one of the static
+     tables; set for encodings from XML_SetUnknownEncodingHandler, whose
+     type[] the application may have re-mapped. */
+  unsigned char appDefinedByteTypes;
 };
 
 #define AS_NORMAL_ENCODING(enc) ((const struct normal_encoding *)(enc))
@@ -1416,6 +1421,7 @@ XmlInitUnknownEncoding(void *mem, const int *table, CONVERTER convert,
   int i;
   struct unknown_encoding *e = (struct unknown_encoding *)mem;
   memcpy(mem, &latin1_encoding, sizeof(struct normal_encoding));
+  e->normal.appDefinedByteTypes = 1;
   for (i = 0; i < 128; i++)
     if (latin1_encoding.type[i] != BT_OTHER
         && latin1_encoding.type[i] != BT_NONXML && table[i] != i)

--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -18,6 +18,7 @@
    Copyright (c) 2020      Boris Kolpackov <boris@codesynthesis.com>
    Copyright (c) 2022      Martin Ettl <ettl.martin78@googlemail.com>
    Copyright (c) 2026      Nick Begg <nick@stunttruck.net>
+   Copyright (c) 2026      Artem Kulyk
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -46,6 +47,21 @@
 
 #  ifndef IS_INVALID_CHAR // i.e. for UTF-16 and XML_MIN_SIZE not defined
 #    define IS_INVALID_CHAR(enc, ptr, n) (0)
+#  endif
+
+/* Return non-zero if any of the eight bytes in x terminates a run of
+   plain character data for a 1-byte encoding, i.e. is a byte < 0x20, one
+   of '&' (0x26), '<' (0x3C), ']' (0x5D) or a byte >= 0x80.  All other
+   byte values are advanced over by the default case of the character
+   data scanning loops, so runs of them can be consumed in bulk.
+   Both helpers are defined only once at the end of this file (this file
+   is included multiple times per translation unit). */
+#  ifndef XML_TOK_IMPL_DEFINED_PLAIN_ASCII_DATA8
+#    define XML_TOK_IMPL_DEFINED_PLAIN_ASCII_DATA8
+static int data8HasStopByte(uint64_t x);
+/* Like data8HasStopByte but for CDATA sections, where '&' and '<' are
+   plain data and only ']' can terminate a run among the ASCII bytes. */
+static int data8HasCdataStopByte(uint64_t x);
 #  endif
 
 #  define INVALID_LEAD_CASE(n, ptr, nextTokPtr)                                \
@@ -398,6 +414,25 @@ PREFIX(cdataSectionTok)(const ENCODING *enc, const char *ptr, const char *end,
     break;
   }
   while (HAS_CHAR(enc, ptr, end)) {
+    /* bulk-consume plain data bytes (default case below).  skip the
+       8-byte scan when the first remaining byte is already a stop.
+       application-supplied encodings may re-type ASCII bytes. */
+    if (MINBPC(enc) == 1 && ! AS_NORMAL_ENCODING(enc)->appDefinedByteTypes
+        && end - ptr >= 8) {
+      const unsigned char first = (unsigned char)*ptr;
+      if (first >= 0x20 && first < 0x80 && first != ASCII_RSQB) {
+        while (end - ptr >= 8) {
+          uint64_t chunk;
+          memcpy(&chunk, ptr, sizeof(chunk));
+          if (data8HasCdataStopByte(chunk)) {
+            break;
+          }
+          ptr += 8;
+        }
+        if (! HAS_CHAR(enc, ptr, end))
+          break;
+      }
+    }
     switch (BYTE_TYPE(enc, ptr)) {
 #  define LEAD_CASE(n)                                                         \
   case BT_LEAD##n:                                                             \
@@ -873,6 +908,26 @@ PREFIX(contentTok)(const ENCODING *enc, const char *ptr, const char *end,
     break;
   }
   while (HAS_CHAR(enc, ptr, end)) {
+    /* bulk-consume plain data bytes (default case below).  skip the
+       8-byte scan when the first remaining byte is already a stop.
+       application-supplied encodings may re-type ASCII bytes. */
+    if (MINBPC(enc) == 1 && ! AS_NORMAL_ENCODING(enc)->appDefinedByteTypes
+        && end - ptr >= 8) {
+      const unsigned char first = (unsigned char)*ptr;
+      if (first >= 0x20 && first < 0x80 && first != ASCII_AMP
+          && first != ASCII_LT && first != ASCII_RSQB) {
+        while (end - ptr >= 8) {
+          uint64_t chunk;
+          memcpy(&chunk, ptr, sizeof(chunk));
+          if (data8HasStopByte(chunk)) {
+            break;
+          }
+          ptr += 8;
+        }
+        if (! HAS_CHAR(enc, ptr, end))
+          break;
+      }
+    }
     switch (BYTE_TYPE(enc, ptr)) {
 #  define LEAD_CASE(n)                                                         \
   case BT_LEAD##n:                                                             \
@@ -1818,5 +1873,34 @@ PREFIX(updatePosition)(const ENCODING *enc, const char *ptr, const char *end,
 #  undef CHECK_NAME_CASES
 #  undef CHECK_NMSTRT_CASE
 #  undef CHECK_NMSTRT_CASES
+
+#  ifndef XML_TOK_IMPL_DEFINED_PLAIN_ASCII_DATA8_HELPER
+#    define XML_TOK_IMPL_DEFINED_PLAIN_ASCII_DATA8_HELPER
+static int
+data8HasStopByte(uint64_t x) {
+  const uint64_t ones = 0x0101010101010101ULL;
+  const uint64_t high_bits = 0x8080808080808080ULL;
+  const uint64_t high_set = x & high_bits;
+  const uint64_t below_space = ((x - ones * 0x20) & ~x) & high_bits;
+  const uint64_t amp = x ^ (ones * 0x26);
+  const uint64_t lt = x ^ (ones * 0x3C);
+  const uint64_t rsqb = x ^ (ones * 0x5D);
+  const uint64_t amp_set = ((amp - ones) & ~amp) & high_bits;
+  const uint64_t lt_set = ((lt - ones) & ~lt) & high_bits;
+  const uint64_t rsqb_set = ((rsqb - ones) & ~rsqb) & high_bits;
+  return (high_set | below_space | amp_set | lt_set | rsqb_set) != 0;
+}
+
+static int
+data8HasCdataStopByte(uint64_t x) {
+  const uint64_t ones = 0x0101010101010101ULL;
+  const uint64_t high_bits = 0x8080808080808080ULL;
+  const uint64_t high_set = x & high_bits;
+  const uint64_t below_space = ((x - ones * 0x20) & ~x) & high_bits;
+  const uint64_t rsqb = x ^ (ones * 0x5D);
+  const uint64_t rsqb_set = ((rsqb - ones) & ~rsqb) & high_bits;
+  return (high_set | below_space | rsqb_set) != 0;
+}
+#  endif
 
 #endif /* XML_TOK_IMPL_C */

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -23,6 +23,7 @@
    Copyright (c) 2026      Francesco Bertolaccini
    Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
    Copyright (c) 2026      Kartik Kenchi <netliomax25@gmail.com>
+   Copyright (c) 2026      Artem Kulyk
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -2809,6 +2810,107 @@ START_TEST(test_duplicate_id_attribute_multiple_attlistdecl) {
 }
 END_TEST
 
+static void
+parse_document_in_chunks(XML_Parser parser, const char *text, int chunk) {
+  const int len = (int)strlen(text);
+  int off = 0;
+  while (off < len) {
+    int n = len - off;
+    if (n > chunk)
+      n = chunk;
+    if (XML_Parse(parser, text + off, n,
+                  (off + n >= len) ? XML_TRUE : XML_FALSE)
+        != XML_STATUS_OK)
+      xml_failure(parser);
+    off += n;
+  }
+}
+
+/* Feed long ASCII character data and a CDATA section at 8-byte window edges. */
+START_TEST(test_bulk_scan_chunk_boundaries) {
+  char text[160];
+  XML_Char expected[81];
+  int chunk, i;
+  CharData storage;
+
+  memset(text, 'a', 80);
+  text[80] = '\0';
+  for (i = 0; i < 80; i++)
+    expected[i] = (XML_Char)'a';
+  expected[80] = 0;
+
+  {
+    char doc[200];
+    strcpy(doc, "<doc>");
+    strcat(doc, text);
+    strcat(doc, "</doc>");
+    for (chunk = 7; chunk <= 9; chunk++) {
+      XML_Parser parser = XML_ParserCreate(NULL);
+      assert_true(parser != NULL);
+      CharData_Init(&storage);
+      XML_SetUserData(parser, &storage);
+      XML_SetCharacterDataHandler(parser, accumulate_characters);
+      parse_document_in_chunks(parser, doc, chunk);
+      CharData_CheckXMLChars(&storage, expected);
+      XML_ParserFree(parser);
+    }
+  }
+
+  {
+    char doc[220];
+    strcpy(doc, "<doc><![CDATA[");
+    strcat(doc, text);
+    strcat(doc, "]]></doc>");
+    for (chunk = 7; chunk <= 9; chunk++) {
+      XML_Parser parser = XML_ParserCreate(NULL);
+      assert_true(parser != NULL);
+      CharData_Init(&storage);
+      XML_SetUserData(parser, &storage);
+      XML_SetCharacterDataHandler(parser, accumulate_characters);
+      parse_document_in_chunks(parser, doc, chunk);
+      CharData_CheckXMLChars(&storage, expected);
+      XML_ParserFree(parser);
+    }
+  }
+}
+END_TEST
+
+/* ISO-8859-1 character data: attribute memo is off, bulk scan still runs. */
+START_TEST(test_iso8859_1_long_chardata) {
+  char doc[96];
+  XML_Char expected[129];
+  int i;
+  CharData storage;
+  XML_Parser parser = XML_ParserCreate("ISO-8859-1");
+  assert_true(parser != NULL);
+
+  strcpy(doc, "<e>");
+  for (i = 0; i < 64; i++)
+    doc[3 + i] = (char)0xE4;
+  strcpy(doc + 3 + 64, "</e>");
+
+#ifdef XML_UNICODE
+  for (i = 0; i < 64; i++)
+    expected[i] = 0x00e4;
+  expected[64] = 0;
+#else
+  for (i = 0; i < 64; i++) {
+    expected[2 * i] = (XML_Char)0xC3;
+    expected[2 * i + 1] = (XML_Char)0xA4;
+  }
+  expected[128] = 0;
+#endif
+
+  CharData_Init(&storage);
+  XML_SetUserData(parser, &storage);
+  XML_SetCharacterDataHandler(parser, accumulate_characters);
+  if (XML_Parse(parser, doc, (int)strlen(doc), XML_TRUE) != XML_STATUS_OK)
+    xml_failure(parser);
+  CharData_CheckXMLChars(&storage, expected);
+  XML_ParserFree(parser);
+}
+END_TEST
+
 static void XMLCALL
 check_second_attr_normalization(void *userData, const XML_Char *name,
                                 const XML_Char **atts) {
@@ -4949,6 +5051,34 @@ START_TEST(test_unknown_ascii_encoding_fail) {
 }
 END_TEST
 
+/* Application-supplied encodings may re-type ASCII bytes that the bulk
+   scan would otherwise skip.  Short and >8-byte runs must both reject. */
+START_TEST(test_unknown_encoding_retyped_ascii_in_long_text) {
+  const char *const cases[] = {
+      "<?xml version='1.0' encoding='invalid-ascii-malform'?>\n"
+      "<doc>ab$cd</doc>",
+      "<?xml version='1.0' encoding='invalid-ascii-malform'?>\n"
+      "<doc>aaaaaaaaaaaa$aaaaaaaaaaaa</doc>",
+      "<?xml version='1.0' encoding='invalid-ascii-malform'?>\n"
+      "<doc><![CDATA[aaaaaaaaaaaa$aaaaaaaaaaaa]]></doc>",
+      "<?xml version='1.0' encoding='invalid-ascii-nonxml'?>\n"
+      "<doc>ab~cd</doc>",
+      "<?xml version='1.0' encoding='invalid-ascii-nonxml'?>\n"
+      "<doc>aaaaaaaaaaaa~aaaaaaaaaaaa</doc>",
+      "<?xml version='1.0' encoding='invalid-ascii-nonxml'?>\n"
+      "<doc><![CDATA[aaaaaaaaaaaa~aaaaaaaaaaaa]]></doc>",
+  };
+  int i;
+  for (i = 0; i < (int)(sizeof(cases) / sizeof(cases[0])); i++) {
+    if (i > 0)
+      XML_ParserReset(g_parser, NULL);
+    XML_SetUnknownEncodingHandler(g_parser, MiscEncodingHandler, NULL);
+    expect_failure(cases[i], XML_ERROR_INVALID_TOKEN,
+                   "re-typed ASCII byte in unknown encoding not faulted");
+  }
+}
+END_TEST
+
 START_TEST(test_unknown_encoding_invalid_length) {
   const char *text = "<?xml version='1.0' encoding='invalid-len'?>\n"
                      "<doc>Hello, world</doc>";
@@ -6810,6 +6940,8 @@ make_basic_test_case(Suite *s) {
   tcase_add_test(tc_basic,
                  test_duplicate_cdata_attribute_multiple_attlistdecl_3);
   tcase_add_test(tc_basic, test_duplicate_id_attribute_multiple_attlistdecl);
+  tcase_add_test(tc_basic, test_bulk_scan_chunk_boundaries);
+  tcase_add_test(tc_basic, test_iso8859_1_long_chardata);
   tcase_add_test__if_xml_ge(tc_basic, test_default_attr_index_after_dtd_copy);
   tcase_add_test__if_xml_ge(tc_basic, test_reset_in_entity);
   tcase_add_test(tc_basic, test_resume_invalid_parse);
@@ -6913,6 +7045,7 @@ make_basic_test_case(Suite *s) {
   tcase_add_test(tc_basic, test_invalid_unknown_encoding);
   tcase_add_test(tc_basic, test_unknown_ascii_encoding_ok);
   tcase_add_test(tc_basic, test_unknown_ascii_encoding_fail);
+  tcase_add_test(tc_basic, test_unknown_encoding_retyped_ascii_in_long_text);
   tcase_add_test(tc_basic, test_unknown_encoding_invalid_length);
   tcase_add_test(tc_basic, test_unknown_encoding_invalid_topbit);
   tcase_add_test(tc_basic, test_unknown_encoding_invalid_surrogate);

--- a/expat/tests/handlers.c
+++ b/expat/tests/handlers.c
@@ -22,6 +22,7 @@
    Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
    Copyright (c) 2026      Berkay Eren Ürün <berkay.ueruen@siemens.com>
    Copyright (c) 2026      Kartik Kenchi <netliomax25@gmail.com>
+   Copyright (c) 2026      Artem Kulyk
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -364,7 +365,9 @@ MiscEncodingHandler(void *data, const XML_Char *encoding, XML_Encoding *info) {
       || ! xcstrcmp(encoding, XCS("invalid-len"))
       || ! xcstrcmp(encoding, XCS("invalid-a"))
       || ! xcstrcmp(encoding, XCS("invalid-surrogate"))
-      || ! xcstrcmp(encoding, XCS("invalid-high")))
+      || ! xcstrcmp(encoding, XCS("invalid-high"))
+      || ! xcstrcmp(encoding, XCS("invalid-ascii-malform"))
+      || ! xcstrcmp(encoding, XCS("invalid-ascii-nonxml")))
     high_map = -1;
 
   for (i = 0; i < 128; ++i)
@@ -389,6 +392,11 @@ MiscEncodingHandler(void *data, const XML_Char *encoding, XML_Encoding *info) {
   /* If required, give a top-bit set character too high a value */
   if (! xcstrcmp(encoding, XCS("invalid-high")))
     info->map[0x84] = 0x010101;
+  /* If required, re-type an ASCII byte that Latin-1 treats as BT_OTHER */
+  if (! xcstrcmp(encoding, XCS("invalid-ascii-malform")))
+    info->map[0x24] = -1; /* '$' */
+  if (! xcstrcmp(encoding, XCS("invalid-ascii-nonxml")))
+    info->map[0x7E] = 0xD800; /* '~' */
 
   info->data = data;
   info->release = NULL;


### PR DESCRIPTION
Independent first slice of #1341.

In `contentTok` / `cdataSectionTok`, skip 8-byte runs of bytes that the existing `default` case already accepts. Loads use `memcpy` into `uint64_t`. The scan is compiled out when `MINBPC != 1`.

Application-supplied encodings may re-type ASCII bytes, so the scan does not run when `XmlInitUnknownEncoding` has set `appDefinedByteTypes` on `struct normal_encoding`. Tests cover short and `>8`-byte runs, in content and CDATA.

Local checks: `runtests` 4920/4920. See #1341 for measurements and the other two slices.

This is a draft until #1341 has maintainer agreement.

Made with [Cursor](https://cursor.com)