### PR TITLE
lib: Memoize interned element and UTF-8 attribute names

### DIFF
--- a/expat/Changes
+++ b/expat/Changes
@@ -29,6 +29,9 @@ Release 2.8.4 XXX XXXXXX XX XXXX
                     AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (CVSS score: 7.5)
                     (Note the "AV:N" for network/remote.)
 
+        Other changes:
+           #1341  lib: Memoize interned element and UTF-8 attribute names
+
         Special thanks to:
             Fabian Wahle (Hap Security)
                  and

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -52,6 +52,7 @@
    Copyright (c) 2026      Haris Hussain <hextheshadow0x@gmail.com>
    Copyright (c) 2026      Evgeny Kotkov <kotkov@apache.org>
    Copyright (c) 2026      Alberto Maschietto <albertomaschietto9@gmail.com>
+   Copyright (c) 2026      Artem Kulyk
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -376,6 +377,22 @@ typedef struct attribute_id {
   XML_Bool xmlns;
 } ATTRIBUTE_ID;
 
+#ifndef XML_UNICODE
+/* Number of slots of the raw attribute name memo, must be a power of two. */
+#  define RAW_ATT_ID_MEMO_SLOTS 64
+
+/* Raw attribute names longer than this many bytes are not memoized. */
+#  define RAW_ATT_ID_MEMO_MAX_LEN 128
+
+/* Direct-mapped memo from raw UTF-8 attribute name bytes to interned
+   ATTRIBUTE_ID (conversion is the identity; see MUST_CONVERT). */
+typedef struct {
+  ATTRIBUTE_ID *id;     /* interned attribute id */
+  unsigned int hash;    /* FNV-1a of the raw name, index and tag */
+  unsigned int nameLen; /* strlen of id->name */
+} RAW_ATT_ID_MEMO;
+#endif /* ! XML_UNICODE */
+
 typedef struct {
   const ATTRIBUTE_ID *id;
   XML_Bool isCdata;
@@ -413,6 +430,31 @@ typedef struct {
   DEFAULT_ATTRIBUTE *defaultAtts;
   HASH_TABLE defaultAttForName;
 } ELEMENT_TYPE;
+
+/* Number of slots of the element type memo, must be a power of two. */
+#define ELEMENT_TYPE_MEMO_SLOTS 64
+
+/* Element names longer than this many XML_Char units are not memoized
+   because hashing them costs more than the lookup it would save. */
+#define ELEMENT_TYPE_MEMO_MAX_LEN 128
+
+/* Direct-mapped memo from element name to interned ELEMENT_TYPE.
+   The stored name is interned in the DTD pool. */
+typedef struct {
+  ELEMENT_TYPE *elemType; /* interned element type */
+  unsigned int hash;      /* FNV-1a of the name, index and tag */
+  unsigned int nameLen;   /* strlen of elemType->name */
+} ELEMENT_TYPE_MEMO;
+
+/* Name memos of a parser, allocated on first use so that parsers that
+   never see a start tag do not pay for them.  Kept even under
+   XML_MIN_SIZE; first-use allocation is the size control. */
+typedef struct {
+#ifndef XML_UNICODE
+  RAW_ATT_ID_MEMO attIds[RAW_ATT_ID_MEMO_SLOTS];
+#endif
+  ELEMENT_TYPE_MEMO elemTypes[ELEMENT_TYPE_MEMO_SLOTS];
+} NAME_MEMOS;
 
 typedef struct {
   HASH_TABLE generalEntities;
@@ -819,6 +861,7 @@ struct XML_ParserStruct {
   POSITION m_position;
   STRING_POOL m_tempPool;
   STRING_POOL m_temp2Pool;
+  NAME_MEMOS *m_nameMemos;
   char *m_groupConnector;
   size_t m_groupSize;
   XML_Char m_namespaceSeparator;
@@ -1417,6 +1460,7 @@ parserCreate(const XML_Char *encodingName,
     FREE(parser, parser);
     return NULL;
   }
+  parser->m_nameMemos = NULL;
 #ifdef XML_ATTR_INFO
   parser->m_attInfo = MALLOC(parser, parser->m_attsSize * sizeof(XML_AttrInfo));
   if (parser->m_attInfo == NULL) {
@@ -1563,6 +1607,8 @@ parserInit(XML_Parser parser, const XML_Char *encodingName) {
   parser->m_tagStack = NULL;
   parser->m_inheritedBindings = NULL;
   parser->m_nSpecifiedAtts = 0;
+  if (parser->m_nameMemos != NULL)
+    memset(parser->m_nameMemos, 0, sizeof(NAME_MEMOS));
   parser->m_unknownEncodingMem = NULL;
   parser->m_unknownEncodingConvert = NULL;
   parser->m_unknownEncodingRelease = NULL;
@@ -1944,6 +1990,7 @@ XML_ParserFree(XML_Parser parser) {
 #endif /* XML_DTD */
     dtdDestroy(parser->m_dtd, (XML_Bool)! parser->m_parentParser, parser);
   FREE(parser, parser->m_atts);
+  FREE(parser, parser->m_nameMemos);
 #ifdef XML_ATTR_INFO
   FREE(parser, parser->m_attInfo);
 #endif
@@ -3846,6 +3893,20 @@ freeBindings(XML_Parser parser, BINDING *bindings) {
   }
 }
 
+/* FNV-1a, used as a cheap tag for the name memos. */
+static unsigned int
+fnv1a_bytes(const char *p, const char *end) {
+  unsigned int fold = 2166136261u;
+  for (; p != end; p++)
+    fold = (fold ^ (unsigned char)*p) * 16777619u;
+  return fold;
+}
+
+static unsigned int
+fnv1a_chars(const XML_Char *s, size_t n) {
+  return fnv1a_bytes((const char *)s, (const char *)s + n * sizeof(XML_Char));
+}
+
 /* Precondition: all arguments must be non-NULL;
    Purpose:
    - normalize attributes
@@ -3867,21 +3928,60 @@ storeAtts(XML_Parser parser, const ENCODING *enc, const char *attStr,
   BINDING *binding;
   const XML_Char *localPart;
 
+  /* the name memos are allocated on first use, see NAME_MEMOS */
+  if (parser->m_nameMemos == NULL) {
+    parser->m_nameMemos = MALLOC(parser, sizeof(NAME_MEMOS));
+    if (parser->m_nameMemos == NULL)
+      return XML_ERROR_NO_MEMORY;
+    memset(parser->m_nameMemos, 0, sizeof(NAME_MEMOS));
+  }
+
   /* lookup the element type name */
-  ELEMENT_TYPE *elementType
-      = (ELEMENT_TYPE *)lookup(parser, &dtd->elementTypes, tagNamePtr->str, 0);
-  if (! elementType) {
-    const XML_Char *name = poolCopyString(&dtd->pool, tagNamePtr->str);
-    if (! name)
-      return XML_ERROR_NO_MEMORY;
-    elementType = (ELEMENT_TYPE *)lookup(parser, &dtd->elementTypes, name,
-                                         sizeof(ELEMENT_TYPE));
-    if (! elementType)
-      return XML_ERROR_NO_MEMORY;
-    if (! elementType->defaultAttForName.parser)
-      hashTableInit(&(elementType->defaultAttForName), parser);
-    if (parser->m_ns && ! setElementTypePrefix(parser, elementType))
-      return XML_ERROR_NO_MEMORY;
+  ELEMENT_TYPE *elementType = NULL;
+  {
+    const XML_Char *const elemName = tagNamePtr->str;
+    const size_t elemNameLen = xcslen(elemName);
+    unsigned int fold = 0;
+    XML_Bool memoEligible = XML_FALSE;
+    if (elemNameLen <= ELEMENT_TYPE_MEMO_MAX_LEN) {
+      memoEligible = XML_TRUE;
+      fold = fnv1a_chars(elemName, elemNameLen);
+      ELEMENT_TYPE_MEMO *const slot
+          = &parser->m_nameMemos
+                 ->elemTypes[fold & (ELEMENT_TYPE_MEMO_SLOTS - 1)];
+      /* the name length check before memcmp keeps both reads in bounds */
+      if (slot->elemType && slot->hash == fold && slot->nameLen == elemNameLen
+          && memcmp(elemName, slot->elemType->name,
+                    elemNameLen * sizeof(XML_Char))
+                 == 0) {
+        elementType = slot->elemType;
+      }
+    }
+    if (! elementType) {
+      elementType
+          = (ELEMENT_TYPE *)lookup(parser, &dtd->elementTypes, elemName, 0);
+      if (! elementType) {
+        const XML_Char *name = poolCopyString(&dtd->pool, elemName);
+        if (! name)
+          return XML_ERROR_NO_MEMORY;
+        elementType = (ELEMENT_TYPE *)lookup(parser, &dtd->elementTypes, name,
+                                             sizeof(ELEMENT_TYPE));
+        if (! elementType)
+          return XML_ERROR_NO_MEMORY;
+        if (! elementType->defaultAttForName.parser)
+          hashTableInit(&(elementType->defaultAttForName), parser);
+        if (parser->m_ns && ! setElementTypePrefix(parser, elementType))
+          return XML_ERROR_NO_MEMORY;
+      }
+      if (memoEligible) {
+        ELEMENT_TYPE_MEMO *const slot
+            = &parser->m_nameMemos
+                   ->elemTypes[fold & (ELEMENT_TYPE_MEMO_SLOTS - 1)];
+        slot->hash = fold;
+        slot->elemType = elementType;
+        slot->nameLen = (unsigned int)xcslen(elementType->name);
+      }
+    }
   }
   const size_t nDefaultAtts = elementType->nDefaultAtts;
 
@@ -7385,6 +7485,24 @@ getAttributeId(XML_Parser parser, const ENCODING *enc, const char *start,
   DTD *const dtd = parser->m_dtd; /* save one level of indirection */
   ATTRIBUTE_ID *id;
   const XML_Char *name;
+#ifndef XML_UNICODE
+  /* reuse a recently interned attribute id for a raw UTF-8 name */
+  unsigned int fold = 0;
+  const XML_Bool memoEligible
+      = (XML_Bool)(parser->m_nameMemos != NULL && enc->isUtf8
+                   && (size_t)(end - start) <= RAW_ATT_ID_MEMO_MAX_LEN);
+  if (memoEligible) {
+    const unsigned int rawLen = (unsigned int)(end - start);
+    fold = fnv1a_bytes(start, end);
+    const RAW_ATT_ID_MEMO *const m
+        = &parser->m_nameMemos->attIds[fold & (RAW_ATT_ID_MEMO_SLOTS - 1)];
+    /* the name length check before memcmp keeps both reads in bounds */
+    if (m->id && m->hash == fold && m->nameLen == rawLen
+        && memcmp(start, m->id->name, rawLen) == 0) {
+      return m->id;
+    }
+  }
+#endif
   if (! poolAppendChar(&dtd->pool, XML_T('\0')))
     return NULL;
   name = poolStoreString(&dtd->pool, enc, start, end);
@@ -7438,6 +7556,15 @@ getAttributeId(XML_Parser parser, const ENCODING *enc, const char *start,
       }
     }
   }
+#ifndef XML_UNICODE
+  if (memoEligible) {
+    RAW_ATT_ID_MEMO *const m
+        = &parser->m_nameMemos->attIds[fold & (RAW_ATT_ID_MEMO_SLOTS - 1)];
+    m->hash = fold;
+    m->id = id;
+    m->nameLen = (unsigned int)xcslen(id->name);
+  }
+#endif
   return id;
 }
 
@@ -7676,6 +7803,9 @@ dtdReset(DTD *p, XML_Parser parser) {
   hashTableClear(&(p->prefixes));
   poolClear(&(p->pool));
   poolClear(&(p->entityValuePool));
+  /* the memoized attribute ids and element types were freed above */
+  if (parser->m_nameMemos != NULL)
+    memset(parser->m_nameMemos, 0, sizeof(NAME_MEMOS));
   p->defaultPrefix.name = NULL;
   p->defaultPrefix.binding = NULL;
 

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -23,6 +23,7 @@
    Copyright (c) 2026      Francesco Bertolaccini
    Copyright (c) 2026      Matthew Fernandez <matthew.fernandez@gmail.com>
    Copyright (c) 2026      Kartik Kenchi <netliomax25@gmail.com>
+   Copyright (c) 2026      Artem Kulyk
    Licensed under the MIT license:
 
    Permission is  hereby granted,  free of charge,  to any  person obtaining
@@ -2806,6 +2807,156 @@ START_TEST(test_duplicate_id_attribute_multiple_attlistdecl) {
     xml_failure(parser);
 
   XML_ParserFree(parser);
+}
+END_TEST
+
+/* Exercise the attribute name interning fast path with attribute names
+   that repeat across many elements. */
+START_TEST(test_attribute_interning_repeated_names) {
+  const int repetitions = 200;
+  char *text;
+  char *text_end;
+  int i;
+  AttrInfo e_info[]
+      = {{XCS("a"), XCS("x")}, {XCS("b"), XCS("y")}, {NULL, NULL}};
+  ElementInfo info[] = {{XCS("doc"), 0, 0, NULL, NULL},
+                        {XCS("e"), 2, 0, NULL, e_info},
+                        {NULL, 0, 0, NULL, NULL}};
+  XML_Parser parser;
+  ParserAndElementInfo parserAndElementInfos;
+
+  /* <doc><e a='x' b='y'/>(repetitions times)</doc> */
+  text = (char *)malloc((size_t)repetitions * 20 + 16);
+  assert_true(text != NULL);
+  strcpy(text, "<doc>");
+  text_end = text + strlen(text);
+  for (i = 0; i < repetitions; i++) {
+    strcpy(text_end, "<e a='x' b='y'/>");
+    text_end += strlen(text_end);
+  }
+  strcpy(text_end, "</doc>");
+
+  parser = XML_ParserCreate(NULL);
+  assert_true(parser != NULL);
+
+  parserAndElementInfos.parser = parser;
+  parserAndElementInfos.info = info;
+
+  XML_SetStartElementHandler(parser, counting_start_element_handler);
+  XML_SetUserData(parser, &parserAndElementInfos);
+
+  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text), XML_TRUE)
+      != XML_STATUS_OK)
+    xml_failure(parser);
+
+  XML_ParserFree(parser);
+  free(text);
+}
+END_TEST
+
+/* Detect a duplicate attribute after other attributes of the same name
+   have been seen (and memoized) on earlier elements. */
+START_TEST(test_duplicate_attribute_after_interning) {
+  const char *text
+      = "<doc><e a='x' b='y'/><e a='1' b='2'/><e a='3' a='4'/></doc>";
+  XML_Parser parser = XML_ParserCreate(NULL);
+  assert_true(parser != NULL);
+
+  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text), XML_TRUE)
+      != XML_STATUS_ERROR)
+    xml_failure(parser);
+
+  if (XML_GetErrorCode(parser) != XML_ERROR_DUPLICATE_ATTRIBUTE)
+    xml_failure(parser);
+
+  XML_ParserFree(parser);
+}
+END_TEST
+
+/* Exercise parsing of names longer than the interning memo length limit. */
+START_TEST(test_oversize_attribute_and_element_names) {
+  const int name_len = 300; /* more than the memo length limit of 128 */
+  char *text;
+  char *elem_bytes;
+  char *attr_bytes;
+  XML_Char *elem_name;
+  XML_Char *attr_name;
+  int i;
+  AttrInfo *e_info;
+  ElementInfo info[3];
+  XML_Parser parser;
+  ParserAndElementInfo parserAndElementInfos;
+
+  text = (char *)malloc((size_t)2 * name_len + 32);
+  elem_bytes = (char *)malloc((size_t)name_len + 1);
+  attr_bytes = (char *)malloc((size_t)name_len + 1);
+  elem_name = (XML_Char *)malloc(((size_t)name_len + 1) * sizeof(XML_Char));
+  attr_name = (XML_Char *)malloc(((size_t)name_len + 1) * sizeof(XML_Char));
+  e_info = (AttrInfo *)malloc(2 * sizeof(AttrInfo));
+  assert_true(text != NULL);
+  assert_true(elem_bytes != NULL);
+  assert_true(attr_bytes != NULL);
+  assert_true(elem_name != NULL);
+  assert_true(attr_name != NULL);
+  assert_true(e_info != NULL);
+
+  for (i = 0; i < name_len; i++) {
+    elem_bytes[i] = (char)('a' + (i % 26));
+    attr_bytes[i] = (char)('A' + (i % 26));
+    elem_name[i] = (XML_Char)('a' + (i % 26));
+    attr_name[i] = (XML_Char)('A' + (i % 26));
+  }
+  elem_bytes[name_len] = '\0';
+  attr_bytes[name_len] = '\0';
+  elem_name[name_len] = 0;
+  attr_name[name_len] = 0;
+
+  strcpy(text, "<doc><");
+  strcat(text, elem_bytes);
+  strcat(text, " ");
+  strcat(text, attr_bytes);
+  strcat(text, "='v'/></doc>");
+
+  e_info[0].name = attr_name;
+  e_info[0].value = XCS("v");
+  e_info[1].name = NULL;
+  e_info[1].value = NULL;
+  info[0].name = XCS("doc");
+  info[0].attr_count = 0;
+  info[0].default_attr_count = 0;
+  info[0].id_name = NULL;
+  info[0].attributes = NULL;
+  info[1].name = elem_name;
+  info[1].attr_count = 1;
+  info[1].default_attr_count = 0;
+  info[1].id_name = NULL;
+  info[1].attributes = e_info;
+  info[2].name = NULL;
+  info[2].attr_count = 0;
+  info[2].default_attr_count = 0;
+  info[2].id_name = NULL;
+  info[2].attributes = NULL;
+
+  parser = XML_ParserCreate(NULL);
+  assert_true(parser != NULL);
+
+  parserAndElementInfos.parser = parser;
+  parserAndElementInfos.info = info;
+
+  XML_SetStartElementHandler(parser, counting_start_element_handler);
+  XML_SetUserData(parser, &parserAndElementInfos);
+
+  if (_XML_Parse_SINGLE_BYTES(parser, text, (int)strlen(text), XML_TRUE)
+      != XML_STATUS_OK)
+    xml_failure(parser);
+
+  XML_ParserFree(parser);
+  free(text);
+  free(elem_bytes);
+  free(attr_bytes);
+  free(elem_name);
+  free(attr_name);
+  free(e_info);
 }
 END_TEST
 
@@ -6810,6 +6961,9 @@ make_basic_test_case(Suite *s) {
   tcase_add_test(tc_basic,
                  test_duplicate_cdata_attribute_multiple_attlistdecl_3);
   tcase_add_test(tc_basic, test_duplicate_id_attribute_multiple_attlistdecl);
+  tcase_add_test(tc_basic, test_attribute_interning_repeated_names);
+  tcase_add_test(tc_basic, test_duplicate_attribute_after_interning);
+  tcase_add_test(tc_basic, test_oversize_attribute_and_element_names);
   tcase_add_test__if_xml_ge(tc_basic, test_default_attr_index_after_dtd_copy);
   tcase_add_test__if_xml_ge(tc_basic, test_reset_in_entity);
   tcase_add_test(tc_basic, test_resume_invalid_parse);


### PR DESCRIPTION
Independent second slice of #1341. Does not depend on the tokenizer PR.

Per-parser `NAME_MEMOS`, allocated on first start tag. Direct-mapped FNV-1a, 64 element slots + 64 UTF-8 attribute slots, max name length 128. Hits require hash + length + `memcmp`. Cleared in `parserInit` / `dtdReset`, freed in `XML_ParserFree`. The existing 4096-byte extra-alloc guard in `test_bypass_heuristic_when_close_to_bufsize` is unchanged.

Local checks: `runtests` 4920/4920. See #1341 for measurements.

This is a draft until #1341 has maintainer agreement.

Made with [Cursor](https://cursor.com)