### PR TITLE
tests: Drop `__cplusplus` leftovers (follow-up to #1194)

### DIFF
--- a/expat/tests/acc_tests.h
+++ b/expat/tests/acc_tests.h
@@ -42,17 +42,9 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_ACC_TESTS_H
-#  define XML_ACC_TESTS_H
+#define XML_ACC_TESTS_H
 
 extern void make_accounting_test_case(Suite *s);
 
 #endif /* XML_ACC_TESTS_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/alloc_tests.h
+++ b/expat/tests/alloc_tests.h
@@ -42,17 +42,9 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_ALLOC_TESTS_H
-#  define XML_ALLOC_TESTS_H
+#define XML_ALLOC_TESTS_H
 
 extern void make_alloc_test_case(Suite *s);
 
 #endif /* XML_ALLOC_TESTS_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/basic_tests.h
+++ b/expat/tests/basic_tests.h
@@ -42,17 +42,9 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_BASIC_TESTS_H
-#  define XML_BASIC_TESTS_H
+#define XML_BASIC_TESTS_H
 
 extern void make_basic_test_case(Suite *s);
 
 #endif /* XML_BASIC_TESTS_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/chardata.h
+++ b/expat/tests/chardata.h
@@ -34,10 +34,6 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_CHARDATA_H
 #  define XML_CHARDATA_H 1
 
@@ -57,7 +53,3 @@ void CharData_AppendXMLChars(CharData *storage, const XML_Char *s, int len);
 int CharData_CheckXMLChars(CharData *storage, const XML_Char *s);
 
 #endif /* XML_CHARDATA_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/common.h
+++ b/expat/tests/common.h
@@ -43,42 +43,38 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
+#ifndef XML_COMMON_H
+#define XML_COMMON_H
+
+#include "expat_config.h"
+#include "minicheck.h"
+#include "chardata.h"
+
+#ifdef XML_LARGE_SIZE
+#  define XML_FMT_INT_MOD "ll"
+#else
+#  define XML_FMT_INT_MOD "l"
 #endif
 
-#ifndef XML_COMMON_H
-#  define XML_COMMON_H
-
-#  include "expat_config.h"
-#  include "minicheck.h"
-#  include "chardata.h"
-
-#  ifdef XML_LARGE_SIZE
-#    define XML_FMT_INT_MOD "ll"
+#ifdef XML_UNICODE_WCHAR_T
+#  define XML_FMT_STR "ls"
+#  include <wchar.h>
+#  define xcstrlen(s) wcslen(s)
+#  define xcstrcmp(s, t) wcscmp((s), (t))
+#  define xcstrncmp(s, t, n) wcsncmp((s), (t), (n))
+#  define XCS(s) _XCS(s)
+#  define _XCS(s) L##s
+#else
+#  ifdef XML_UNICODE
+#    error "No support for UTF-16 character without wchar_t in tests"
 #  else
-#    define XML_FMT_INT_MOD "l"
-#  endif
-
-#  ifdef XML_UNICODE_WCHAR_T
-#    define XML_FMT_STR "ls"
-#    include <wchar.h>
-#    define xcstrlen(s) wcslen(s)
-#    define xcstrcmp(s, t) wcscmp((s), (t))
-#    define xcstrncmp(s, t, n) wcsncmp((s), (t), (n))
-#    define XCS(s) _XCS(s)
-#    define _XCS(s) L##s
-#  else
-#    ifdef XML_UNICODE
-#      error "No support for UTF-16 character without wchar_t in tests"
-#    else
-#      define XML_FMT_STR "s"
-#      define xcstrlen(s) strlen(s)
-#      define xcstrcmp(s, t) strcmp((s), (t))
-#      define xcstrncmp(s, t, n) strncmp((s), (t), (n))
-#      define XCS(s) s
-#    endif /* XML_UNICODE */
-#  endif   /* XML_UNICODE_WCHAR_T */
+#    define XML_FMT_STR "s"
+#    define xcstrlen(s) strlen(s)
+#    define xcstrcmp(s, t) strcmp((s), (t))
+#    define xcstrncmp(s, t, n) strncmp((s), (t), (n))
+#    define XCS(s) s
+#  endif /* XML_UNICODE */
+#endif   /* XML_UNICODE_WCHAR_T */
 
 extern XML_Parser g_parser;
 
@@ -98,7 +94,7 @@ extern void basic_teardown(void);
 
 extern void _xml_failure(XML_Parser parser, const char *file, int line);
 
-#  define xml_failure(parser) _xml_failure((parser), __FILE__, __LINE__)
+#define xml_failure(parser) _xml_failure((parser), __FILE__, __LINE__)
 
 extern enum XML_Status _XML_Parse_SINGLE_BYTES(XML_Parser parser, const char *s,
                                                int len, int isFinal);
@@ -107,8 +103,8 @@ extern void _expect_failure(const char *text, enum XML_Error errorCode,
                             const char *errorMessage, const char *file,
                             int lineno);
 
-#  define expect_failure(text, errorCode, errorMessage)                        \
-    _expect_failure((text), (errorCode), (errorMessage), __FILE__, __LINE__)
+#define expect_failure(text, errorCode, errorMessage)                          \
+  _expect_failure((text), (errorCode), (errorMessage), __FILE__, __LINE__)
 
 /* Support functions for handlers to collect up character and attribute data.
  */
@@ -116,14 +112,14 @@ extern void _expect_failure(const char *text, enum XML_Error errorCode,
 extern void _run_character_check(const char *text, const XML_Char *expected,
                                  const char *file, int line);
 
-#  define run_character_check(text, expected)                                  \
-    _run_character_check(text, expected, __FILE__, __LINE__)
+#define run_character_check(text, expected)                                    \
+  _run_character_check(text, expected, __FILE__, __LINE__)
 
 extern void _run_attribute_check(const char *text, const XML_Char *expected,
                                  const char *file, int line);
 
-#  define run_attribute_check(text, expected)                                  \
-    _run_attribute_check(text, expected, __FILE__, __LINE__)
+#define run_attribute_check(text, expected)                                    \
+  _run_attribute_check(text, expected, __FILE__, __LINE__)
 
 typedef struct ExtTest {
   const char *parse_text;
@@ -135,11 +131,11 @@ extern void _run_ext_character_check(const char *text, ExtTest *test_data,
                                      const XML_Char *expected, const char *file,
                                      int line);
 
-#  define run_ext_character_check(text, test_data, expected)                   \
-    _run_ext_character_check(text, test_data, expected, __FILE__, __LINE__)
+#define run_ext_character_check(text, test_data, expected)                     \
+  _run_ext_character_check(text, test_data, expected, __FILE__, __LINE__)
 
-#  define ALLOC_ALWAYS_SUCCEED (-1)
-#  define REALLOC_ALWAYS_SUCCEED (-1)
+#define ALLOC_ALWAYS_SUCCEED (-1)
+#define REALLOC_ALWAYS_SUCCEED (-1)
 
 extern int g_allocation_count;
 extern int g_reallocation_count;
@@ -151,7 +147,3 @@ extern void *duff_reallocator(void *ptr, size_t size);
 extern char *portable_strndup(const char *s, size_t n);
 
 #endif /* XML_COMMON_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/dummy.h
+++ b/expat/tests/dummy.h
@@ -42,31 +42,27 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_DUMMY_H
-#  define XML_DUMMY_H
+#define XML_DUMMY_H
 
-#  define DUMMY_START_DOCTYPE_HANDLER_FLAG (1UL << 0)
-#  define DUMMY_END_DOCTYPE_HANDLER_FLAG (1UL << 1)
-#  define DUMMY_ENTITY_DECL_HANDLER_FLAG (1UL << 2)
-#  define DUMMY_NOTATION_DECL_HANDLER_FLAG (1UL << 3)
-#  define DUMMY_ELEMENT_DECL_HANDLER_FLAG (1UL << 4)
-#  define DUMMY_ATTLIST_DECL_HANDLER_FLAG (1UL << 5)
-#  define DUMMY_COMMENT_HANDLER_FLAG (1UL << 6)
-#  define DUMMY_PI_HANDLER_FLAG (1UL << 7)
-#  define DUMMY_START_ELEMENT_HANDLER_FLAG (1UL << 8)
-#  define DUMMY_START_CDATA_HANDLER_FLAG (1UL << 9)
-#  define DUMMY_END_CDATA_HANDLER_FLAG (1UL << 10)
-#  define DUMMY_UNPARSED_ENTITY_DECL_HANDLER_FLAG (1UL << 11)
-#  define DUMMY_START_NS_DECL_HANDLER_FLAG (1UL << 12)
-#  define DUMMY_END_NS_DECL_HANDLER_FLAG (1UL << 13)
-#  define DUMMY_START_DOCTYPE_DECL_HANDLER_FLAG (1UL << 14)
-#  define DUMMY_END_DOCTYPE_DECL_HANDLER_FLAG (1UL << 15)
-#  define DUMMY_SKIP_HANDLER_FLAG (1UL << 16)
-#  define DUMMY_DEFAULT_HANDLER_FLAG (1UL << 17)
+#define DUMMY_START_DOCTYPE_HANDLER_FLAG (1UL << 0)
+#define DUMMY_END_DOCTYPE_HANDLER_FLAG (1UL << 1)
+#define DUMMY_ENTITY_DECL_HANDLER_FLAG (1UL << 2)
+#define DUMMY_NOTATION_DECL_HANDLER_FLAG (1UL << 3)
+#define DUMMY_ELEMENT_DECL_HANDLER_FLAG (1UL << 4)
+#define DUMMY_ATTLIST_DECL_HANDLER_FLAG (1UL << 5)
+#define DUMMY_COMMENT_HANDLER_FLAG (1UL << 6)
+#define DUMMY_PI_HANDLER_FLAG (1UL << 7)
+#define DUMMY_START_ELEMENT_HANDLER_FLAG (1UL << 8)
+#define DUMMY_START_CDATA_HANDLER_FLAG (1UL << 9)
+#define DUMMY_END_CDATA_HANDLER_FLAG (1UL << 10)
+#define DUMMY_UNPARSED_ENTITY_DECL_HANDLER_FLAG (1UL << 11)
+#define DUMMY_START_NS_DECL_HANDLER_FLAG (1UL << 12)
+#define DUMMY_END_NS_DECL_HANDLER_FLAG (1UL << 13)
+#define DUMMY_START_DOCTYPE_DECL_HANDLER_FLAG (1UL << 14)
+#define DUMMY_END_DOCTYPE_DECL_HANDLER_FLAG (1UL << 15)
+#define DUMMY_SKIP_HANDLER_FLAG (1UL << 16)
+#define DUMMY_DEFAULT_HANDLER_FLAG (1UL << 17)
 
 extern void init_dummy_handlers(void);
 extern unsigned long get_dummy_handler_flags(void);
@@ -146,7 +142,3 @@ extern void XMLCALL dummy_skip_handler(void *userData,
                                        int is_parameter_entity);
 
 #endif /* XML_DUMMY_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/handlers.h
+++ b/expat/tests/handlers.h
@@ -45,16 +45,12 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_HANDLERS_H
-#  define XML_HANDLERS_H
+#define XML_HANDLERS_H
 
-#  include "expat_config.h"
+#include "expat_config.h"
 
-#  include "expat.h"
+#include "expat.h"
 
 /* Variable holding the expected handler userData */
 extern const void *g_handler_data;
@@ -74,8 +70,8 @@ extern void XMLCALL start_element_event_handler(void *userData,
 extern void XMLCALL end_element_event_handler(void *userData,
                                               const XML_Char *name);
 
-#  define STRUCT_START_TAG 0
-#  define STRUCT_END_TAG 1
+#define STRUCT_START_TAG 0
+#define STRUCT_END_TAG 1
 
 extern void XMLCALL start_element_event_handler2(void *userData,
                                                  const XML_Char *name,
@@ -516,22 +512,21 @@ extern const struct handler_record_entry *
 _handler_record_get(const struct handler_record_list *storage, int index,
                     const char *file, int line);
 
-#  define handler_record_get(storage, index)                                   \
-    _handler_record_get((storage), (index), __FILE__, __LINE__)
+#define handler_record_get(storage, index)                                     \
+  _handler_record_get((storage), (index), __FILE__, __LINE__)
 
-#  define assert_record_handler_called(storage, index, expected_name,          \
-                                       expected_arg)                           \
-    do {                                                                       \
-      const struct handler_record_entry *e                                     \
-          = handler_record_get(storage, index);                                \
-      assert_true(strcmp(e->name, expected_name) == 0);                        \
-      assert_true(e->arg == (expected_arg));                                   \
-    } while (0)
+#define assert_record_handler_called(storage, index, expected_name,            \
+                                     expected_arg)                             \
+  do {                                                                         \
+    const struct handler_record_entry *e = handler_record_get(storage, index); \
+    assert_true(strcmp(e->name, expected_name) == 0);                          \
+    assert_true(e->arg == (expected_arg));                                     \
+  } while (0)
 
 /* Entity Declaration Handlers */
-#  define ENTITY_MATCH_FAIL (-1)
-#  define ENTITY_MATCH_NOT_FOUND (0)
-#  define ENTITY_MATCH_SUCCESS (1)
+#define ENTITY_MATCH_FAIL (-1)
+#define ENTITY_MATCH_NOT_FOUND (0)
+#define ENTITY_MATCH_SUCCESS (1)
 
 extern void XMLCALL param_entity_match_handler(
     void *userData, const XML_Char *entityName, int is_parameter_entity,
@@ -630,7 +625,3 @@ extern void XMLCALL suspend_then_resume_character_handler(void *userData,
                                                           int len);
 
 #endif /* XML_HANDLERS_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/memcheck.h
+++ b/expat/tests/memcheck.h
@@ -33,10 +33,6 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_MEMCHECK_H
 #  define XML_MEMCHECK_H 1
 
@@ -53,7 +49,3 @@ void *tracking_realloc(void *ptr, size_t size);
 int tracking_report(void);
 
 #endif /* XML_MEMCHECK_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/minicheck.h
+++ b/expat/tests/minicheck.h
@@ -41,27 +41,23 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_MINICHECK_H
-#  define XML_MINICHECK_H
+#define XML_MINICHECK_H
 
-#  define CK_NOFORK 0
-#  define CK_FORK 1
+#define CK_NOFORK 0
+#define CK_FORK 1
 
-#  define CK_SILENT 0
-#  define CK_NORMAL 1
-#  define CK_VERBOSE 2
+#define CK_SILENT 0
+#define CK_NORMAL 1
+#define CK_VERBOSE 2
 
 /* Workaround for Microsoft's compiler and Tru64 Unix systems where the
    C compiler has a working __func__, but the C++ compiler only has a
    working __FUNCTION__.  This could be fixed in configure.in, but it's
    not worth it right now. */
-#  if defined(_MSC_VER) || (defined(__osf__) && defined(__cplusplus))
-#    define __func__ __FUNCTION__
-#  endif
+#if defined(_MSC_VER) || (defined(__osf__) && defined(__cplusplus))
+#  define __func__ __FUNCTION__
+#endif
 
 /* PRINTF_LIKE has two effects:
     1. Make clang's -Wformat-nonliteral stop warning about non-literal format
@@ -69,30 +65,30 @@ extern "C" {
     2. Make both clang and gcc's -Wformat-nonliteral warn about *callers* of
        the annotated function that use a non-literal format string.
 */
-#  if defined(__GNUC__)
-#    define PRINTF_LIKE(fmtpos, argspos)                                       \
-      __attribute__((format(printf, fmtpos, argspos)))
-#  else
-#    define PRINTF_LIKE(fmtpos, argspos)
-#  endif
+#if defined(__GNUC__)
+#  define PRINTF_LIKE(fmtpos, argspos)                                         \
+    __attribute__((format(printf, fmtpos, argspos)))
+#else
+#  define PRINTF_LIKE(fmtpos, argspos)
+#endif
 
-#  define START_TEST(testname)                                                 \
-    static void testname(void) {                                               \
-      _check_set_test_info(__func__, __FILE__, __LINE__);                      \
-      {
-#  define END_TEST                                                             \
-    }                                                                          \
-    }
+#define START_TEST(testname)                                                   \
+  static void testname(void) {                                                 \
+    _check_set_test_info(__func__, __FILE__, __LINE__);                        \
+    {
+#define END_TEST                                                               \
+  }                                                                            \
+  }
 
 void PRINTF_LIKE(1, 2) set_subtest(char const *fmt, ...);
 
-#  define fail(msg) _fail(__FILE__, __LINE__, msg)
-#  define assert_true(cond)                                                    \
-    do {                                                                       \
-      if (! (cond)) {                                                          \
-        _fail(__FILE__, __LINE__, "check failed: " #cond);                     \
-      }                                                                        \
-    } while (0)
+#define fail(msg) _fail(__FILE__, __LINE__, msg)
+#define assert_true(cond)                                                      \
+  do {                                                                         \
+    if (! (cond)) {                                                            \
+      _fail(__FILE__, __LINE__, "check failed: " #cond);                       \
+    }                                                                          \
+  } while (0)
 
 typedef void (*tcase_setup_function)(void);
 typedef void (*tcase_teardown_function)(void);
@@ -131,11 +127,11 @@ void _check_set_test_info(char const *function, char const *filename,
  * Prototypes for the actual implementation.
  */
 
-#  if defined(__has_attribute)
-#    if __has_attribute(noreturn)
+#if defined(__has_attribute)
+#  if __has_attribute(noreturn)
 __attribute__((noreturn))
-#    endif
 #  endif
+#endif
 void _fail(const char *file, int line, const char *msg);
 Suite *suite_create(const char *name);
 TCase *tcase_create(const char *name);
@@ -150,7 +146,3 @@ int srunner_ntests_failed(SRunner *runner);
 void srunner_free(SRunner *runner);
 
 #endif /* XML_MINICHECK_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/misc_tests.h
+++ b/expat/tests/misc_tests.h
@@ -42,17 +42,9 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_MISC_TESTS_H
-#  define XML_MISC_TESTS_H
+#define XML_MISC_TESTS_H
 
 extern void make_miscellaneous_test_case(Suite *s);
 
 #endif /* XML_MISC_TESTS_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/ns_tests.h
+++ b/expat/tests/ns_tests.h
@@ -42,17 +42,9 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_NS_TESTS_H
-#  define XML_NS_TESTS_H
+#define XML_NS_TESTS_H
 
 extern void make_namespace_test_case(Suite *s);
 
 #endif /* XML_NS_TESTS_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/nsalloc_tests.h
+++ b/expat/tests/nsalloc_tests.h
@@ -42,17 +42,9 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_NSALLOC_TESTS_H
-#  define XML_NSALLOC_TESTS_H
+#define XML_NSALLOC_TESTS_H
 
 extern void make_nsalloc_test_case(Suite *s);
 
 #endif /* XML_NSALLOC_TESTS_H */
-
-#ifdef __cplusplus
-}
-#endif

--- a/expat/tests/structdata.h
+++ b/expat/tests/structdata.h
@@ -32,10 +32,6 @@
    SPDX-License-Identifier: MIT
 */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #ifndef XML_STRUCTDATA_H
 #  define XML_STRUCTDATA_H 1
 
@@ -65,7 +61,3 @@ void StructData_CheckItems(StructData *storage, const StructDataEntry *expected,
 void StructData_Dispose(StructData *storage);
 
 #endif /* XML_STRUCTDATA_H */
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
Follow-up to #1194