### PR TITLE
CMake: Refrain from adding `/source-charset:utf-8` for MSVC (fixes #1352)

### DIFF
--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -230,15 +230,6 @@ if(MSVC)
             message(WARNING "Please use ${_EXPAT_MSVC_SUPPORTED_DISPLAY} or later.  Thank you!")
         endif()
     endif()
-
-    # Avoid clashing of /source-charset:utf-8 with incompatible /utf-8
-    if(NOT CMAKE_CXX_FLAGS MATCHES /utf-8)
-        # Stop MSVC from trying to decode the source files using
-        # the Windows system code page encoding that could e.g. be Windows-936
-        # on a Chinese Windows system rather than UTF-8.
-        # https://devblogs.microsoft.com/cppblog/new-options-for-managing-character-sets-in-the-microsoft-cc-compiler/
-        add_compile_options(/source-charset:utf-8)
-    endif()
 endif()
 
 macro(_expat_copy_bool_int source_ref dest_ref)


### PR DESCRIPTION
Fixes #1352