### PR TITLE
lib: Drop internal macros `FASTCALL`, `PTRCALL`, `PTRFASTCALL`

### DIFF
--- a/expat/lib/internal.h
+++ b/expat/lib/internal.h
@@ -6,13 +6,6 @@
    The following calling convention macros are defined for frequently
    called functions:
 
-   FASTCALL    - Used for those internal functions that have a simple
-                 body and a low number of arguments and local variables.
-
-   PTRCALL     - Used for functions called though function pointers.
-
-   PTRFASTCALL - Like PTRCALL, but for low number of arguments.
-
    inline      - Used for selected internal functions for which inlining
                  may improve performance on some platforms.
 
@@ -57,42 +50,6 @@
 
    SPDX-License-Identifier: MIT
 */
-
-#if defined(__GNUC__) && defined(__i386__) && ! defined(__MINGW32__)
-/* We'll use this version by default only where we know it helps.
-
-   regparm() generates warnings on Solaris boxes.   See SF bug #692878.
-
-   Instability reported with egcs on a RedHat Linux 7.3.
-   Let's comment out:
-   #define FASTCALL __attribute__((stdcall, regparm(3)))
-   and let's try this:
-*/
-#  define FASTCALL __attribute__((regparm(3)))
-#  define PTRFASTCALL __attribute__((regparm(3)))
-#endif
-
-/* Using __fastcall seems to have an unexpected negative effect under
-   MS VC++, especially for function pointers, so we won't use it for
-   now on that platform. It may be reconsidered for a future release
-   if it can be made more effective.
-   Likely reason: __fastcall on Windows is like stdcall, therefore
-   the compiler cannot perform stack optimizations for call clusters.
-*/
-
-/* Make sure all of these are defined if they aren't already. */
-
-#ifndef FASTCALL
-#  define FASTCALL
-#endif
-
-#ifndef PTRCALL
-#  define PTRCALL
-#endif
-
-#ifndef PTRFASTCALL
-#  define PTRFASTCALL
-#endif
 
 #ifndef XML_MIN_SIZE
 #  if ! defined(__cplusplus) && ! defined(inline)

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -495,8 +495,8 @@ typedef struct entity_stats {
 } ENTITY_STATS;
 #endif /* XML_GE == 1 */
 
-typedef enum XML_Error PTRCALL Processor(XML_Parser parser, const char *start,
-                                         const char *end, const char **endPtr);
+typedef enum XML_Error Processor(XML_Parser parser, const char *start,
+                                 const char *end, const char **endPtr);
 
 static Processor prologProcessor;
 static Processor prologInitProcessor;
@@ -588,7 +588,7 @@ static void reportDefault(XML_Parser parser, const ENCODING *enc,
 static const XML_Char *getContext(XML_Parser parser);
 static XML_Bool setContext(XML_Parser parser, const XML_Char *context);
 
-static void FASTCALL normalizePublicId(XML_Char *s);
+static void normalizePublicId(XML_Char *s);
 
 static DTD *dtdCreate(XML_Parser parser);
 /* do not call if m_parentParser != NULL */
@@ -602,32 +602,29 @@ static NAMED *lookupWithLength(XML_Parser parser, HASH_TABLE *table, KEY name,
                                size_t nameLen, size_t createSize);
 static NAMED *lookup(XML_Parser parser, HASH_TABLE *table, KEY name,
                      size_t createSize);
-static void FASTCALL hashTableInit(HASH_TABLE *table, XML_Parser parser);
-static void FASTCALL hashTableClear(HASH_TABLE *table);
-static void FASTCALL hashTableDestroy(HASH_TABLE *table);
-static void FASTCALL hashTableIterInit(HASH_TABLE_ITER *iter,
-                                       const HASH_TABLE *table);
-static NAMED *FASTCALL hashTableIterNext(HASH_TABLE_ITER *iter);
+static void hashTableInit(HASH_TABLE *table, XML_Parser parser);
+static void hashTableClear(HASH_TABLE *table);
+static void hashTableDestroy(HASH_TABLE *table);
+static void hashTableIterInit(HASH_TABLE_ITER *iter, const HASH_TABLE *table);
+static NAMED *hashTableIterNext(HASH_TABLE_ITER *iter);
 
-static void FASTCALL poolInit(STRING_POOL *pool, XML_Parser parser);
-static void FASTCALL poolClear(STRING_POOL *pool);
-static void FASTCALL poolDestroy(STRING_POOL *pool);
+static void poolInit(STRING_POOL *pool, XML_Parser parser);
+static void poolClear(STRING_POOL *pool);
+static void poolDestroy(STRING_POOL *pool);
 static XML_Char *poolAppend(STRING_POOL *pool, const ENCODING *enc,
                             const char *ptr, const char *end);
 static XML_Char *poolStoreString(STRING_POOL *pool, const ENCODING *enc,
                                  const char *ptr, const char *end);
-static XML_Bool FASTCALL poolGrow(STRING_POOL *pool);
-static bool FASTCALL poolGrowUntil(STRING_POOL *pool, size_t needed);
-static const XML_Char *FASTCALL poolCopyString(STRING_POOL *pool,
-                                               const XML_Char *s);
-static const XML_Char *FASTCALL poolCopyStringNoFinish(STRING_POOL *pool,
-                                                       const XML_Char *s);
+static XML_Bool poolGrow(STRING_POOL *pool);
+static bool poolGrowUntil(STRING_POOL *pool, size_t needed);
+static const XML_Char *poolCopyString(STRING_POOL *pool, const XML_Char *s);
+static const XML_Char *poolCopyStringNoFinish(STRING_POOL *pool,
+                                              const XML_Char *s);
 static const XML_Char *poolCopyStringN(STRING_POOL *pool, const XML_Char *s,
                                        int n);
-static const XML_Char *FASTCALL poolAppendString(STRING_POOL *pool,
-                                                 const XML_Char *s);
+static const XML_Char *poolAppendString(STRING_POOL *pool, const XML_Char *s);
 
-static int FASTCALL nextScaffoldPart(XML_Parser parser);
+static int nextScaffoldPart(XML_Parser parser);
 static XML_Content *build_model(XML_Parser parser);
 static ELEMENT_TYPE *getElementType(XML_Parser parser, const ENCODING *enc,
                                     const char *ptr, const char *end);
@@ -1596,7 +1593,7 @@ parserInit(XML_Parser parser, const XML_Char *encodingName) {
 }
 
 /* moves list of bindings to m_freeBindingList */
-static void FASTCALL
+static void
 moveToFreeBindingList(XML_Parser parser, BINDING *bindings) {
   while (bindings) {
     BINDING *b = bindings;
@@ -1869,7 +1866,7 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
   return parser;
 }
 
-static void FASTCALL
+static void
 destroyBindings(BINDING *bindings, XML_Parser parser) {
   for (;;) {
     BINDING *b = bindings;
@@ -3168,7 +3165,7 @@ storeRawNames(XML_Parser parser) {
   return XML_TRUE;
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 contentProcessor(XML_Parser parser, const char *start, const char *end,
                  const char **endPtr) {
   enum XML_Error result = doContent(
@@ -3182,7 +3179,7 @@ contentProcessor(XML_Parser parser, const char *start, const char *end,
   return result;
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 externalEntityInitProcessor(XML_Parser parser, const char *start,
                             const char *end, const char **endPtr) {
   enum XML_Error result = initializeEncoding(parser);
@@ -3192,7 +3189,7 @@ externalEntityInitProcessor(XML_Parser parser, const char *start,
   return externalEntityInitProcessor2(parser, start, end, endPtr);
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 externalEntityInitProcessor2(XML_Parser parser, const char *start,
                              const char *end, const char **endPtr) {
   const char *next = start; /* XmlContentTok doesn't always set the last arg */
@@ -3237,7 +3234,7 @@ externalEntityInitProcessor2(XML_Parser parser, const char *start,
   return externalEntityInitProcessor3(parser, start, end, endPtr);
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 externalEntityInitProcessor3(XML_Parser parser, const char *start,
                              const char *end, const char **endPtr) {
   int tok;
@@ -3289,7 +3286,7 @@ externalEntityInitProcessor3(XML_Parser parser, const char *start,
   return externalEntityContentProcessor(parser, start, end, endPtr);
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 externalEntityContentProcessor(XML_Parser parser, const char *start,
                                const char *end, const char **endPtr) {
   enum XML_Error result
@@ -4589,7 +4586,7 @@ addBinding(XML_Parser parser, PREFIX *prefix, const ATTRIBUTE_ID *attId,
 /* The idea here is to avoid using stack for each CDATA section when
    the whole file is parsed with one call.
 */
-static enum XML_Error PTRCALL
+static enum XML_Error
 cdataSectionProcessor(XML_Parser parser, const char *start, const char *end,
                       const char **endPtr) {
   enum XML_Error result = doCdataSection(
@@ -4755,7 +4752,7 @@ doCdataSection(XML_Parser parser, const ENCODING *enc, const char **startPtr,
 /* The idea here is to avoid using stack for each IGNORE section when
    the whole file is parsed with one call.
 */
-static enum XML_Error PTRCALL
+static enum XML_Error
 ignoreSectionProcessor(XML_Parser parser, const char *start, const char *end,
                        const char **endPtr) {
   enum XML_Error result
@@ -5025,7 +5022,7 @@ handleUnknownEncoding(XML_Parser parser, const XML_Char *encodingName) {
   return XML_ERROR_UNKNOWN_ENCODING;
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 prologInitProcessor(XML_Parser parser, const char *s, const char *end,
                     const char **nextPtr) {
   enum XML_Error result = initializeEncoding(parser);
@@ -5037,7 +5034,7 @@ prologInitProcessor(XML_Parser parser, const char *s, const char *end,
 
 #ifdef XML_DTD
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 externalParEntInitProcessor(XML_Parser parser, const char *s, const char *end,
                             const char **nextPtr) {
   enum XML_Error result = initializeEncoding(parser);
@@ -5057,7 +5054,7 @@ externalParEntInitProcessor(XML_Parser parser, const char *s, const char *end,
   }
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 entityValueInitProcessor(XML_Parser parser, const char *s, const char *end,
                          const char **nextPtr) {
   int tok;
@@ -5141,7 +5138,7 @@ entityValueInitProcessor(XML_Parser parser, const char *s, const char *end,
   }
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 externalParEntProcessor(XML_Parser parser, const char *s, const char *end,
                         const char **nextPtr) {
   const char *next = s;
@@ -5187,7 +5184,7 @@ externalParEntProcessor(XML_Parser parser, const char *s, const char *end,
                   XML_ACCOUNT_DIRECT);
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 entityValueProcessor(XML_Parser parser, const char *s, const char *end,
                      const char **nextPtr) {
   const char *start = s;
@@ -5234,7 +5231,7 @@ entityValueProcessor(XML_Parser parser, const char *s, const char *end,
 
 #endif /* XML_DTD */
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 prologProcessor(XML_Parser parser, const char *s, const char *end,
                 const char **nextPtr) {
   const char *next = s;
@@ -6370,7 +6367,7 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
   /* not reached */
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 epilogProcessor(XML_Parser parser, const char *s, const char *end,
                 const char **nextPtr) {
   parser->m_processor = epilogProcessor;
@@ -6507,7 +6504,7 @@ processEntity(XML_Parser parser, ENTITY *entity, bool betweenDecl,
   return XML_ERROR_NONE;
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
                         const char **nextPtr) {
   UNUSED_P(s);
@@ -6589,7 +6586,7 @@ internalEntityProcessor(XML_Parser parser, const char *s, const char *end,
   return XML_ERROR_NONE;
 }
 
-static enum XML_Error PTRCALL
+static enum XML_Error
 errorProcessor(XML_Parser parser, const char *s, const char *end,
                const char **nextPtr) {
   UNUSED_P(s);
@@ -7162,7 +7159,7 @@ storeSelfEntityValue(XML_Parser parser, ENTITY *entity) {
 
 #endif /* XML_GE == 0 */
 
-static void FASTCALL
+static void
 normalizeLines(XML_Char *s) {
   XML_Char *p;
   for (;; s++) {
@@ -7603,7 +7600,7 @@ setContext(XML_Parser parser, const XML_Char *context) {
   return XML_TRUE;
 }
 
-static void FASTCALL
+static void
 normalizePublicId(XML_Char *publicId) {
   XML_Char *p = publicId;
   XML_Char *s;
@@ -7949,7 +7946,7 @@ copyEntityTable(XML_Parser oldParser, HASH_TABLE *newTable,
 // Compares two strings `s1` and `s2` whereas:
 // - `s2` is zero-terminated but
 // - `s1` is made up of exactly (not just up to) `s1len` non-zero characters.
-static XML_Bool FASTCALL
+static XML_Bool
 keyeq(KEY s1, size_t s1len, KEY s2) {
 #ifdef XML_UNICODE
 #  ifdef XML_UNICODE_WCHAR_T
@@ -7979,7 +7976,7 @@ copy_salt_to_sipkey(XML_Parser parser, struct sipkey *key) {
   *key = rootParser->m_hash_secret_salt_128;
 }
 
-static unsigned long FASTCALL
+static unsigned long
 hash(XML_Parser parser, KEY s, size_t keyLen) {
   struct siphash state;
   struct sipkey key;
@@ -8121,7 +8118,7 @@ lookup(XML_Parser parser, HASH_TABLE *table, KEY name, size_t createSize) {
   return lookupWithLength(parser, table, name, keylen(name), createSize);
 }
 
-static void FASTCALL
+static void
 hashTableClear(HASH_TABLE *table) {
   size_t i;
   for (i = 0; i < table->size; i++) {
@@ -8131,7 +8128,7 @@ hashTableClear(HASH_TABLE *table) {
   table->used = 0;
 }
 
-static void FASTCALL
+static void
 hashTableDestroy(HASH_TABLE *table) {
   size_t i;
   for (i = 0; i < table->size; i++)
@@ -8139,7 +8136,7 @@ hashTableDestroy(HASH_TABLE *table) {
   FREE(table->parser, table->v);
 }
 
-static void FASTCALL
+static void
 hashTableInit(HASH_TABLE *p, XML_Parser parser) {
   p->power = 0;
   p->size = 0;
@@ -8148,13 +8145,13 @@ hashTableInit(HASH_TABLE *p, XML_Parser parser) {
   p->parser = parser;
 }
 
-static void FASTCALL
+static void
 hashTableIterInit(HASH_TABLE_ITER *iter, const HASH_TABLE *table) {
   iter->p = table->v;
   iter->end = iter->p ? iter->p + table->size : NULL;
 }
 
-static NAMED *FASTCALL
+static NAMED *
 hashTableIterNext(HASH_TABLE_ITER *iter) {
   while (iter->p != iter->end) {
     NAMED *tem = *(iter->p)++;
@@ -8164,7 +8161,7 @@ hashTableIterNext(HASH_TABLE_ITER *iter) {
   return NULL;
 }
 
-static void FASTCALL
+static void
 poolInit(STRING_POOL *pool, XML_Parser parser) {
   pool->blocks = NULL;
   pool->freeBlocks = NULL;
@@ -8174,7 +8171,7 @@ poolInit(STRING_POOL *pool, XML_Parser parser) {
   pool->parser = parser;
 }
 
-static void FASTCALL
+static void
 poolClear(STRING_POOL *pool) {
   if (! pool->freeBlocks)
     pool->freeBlocks = pool->blocks;
@@ -8193,7 +8190,7 @@ poolClear(STRING_POOL *pool) {
   pool->end = NULL;
 }
 
-static void FASTCALL
+static void
 poolDestroy(STRING_POOL *pool) {
   BLOCK *p = pool->blocks;
   while (p) {
@@ -8226,7 +8223,7 @@ poolAppend(STRING_POOL *pool, const ENCODING *enc, const char *ptr,
   return pool->start;
 }
 
-static const XML_Char *FASTCALL
+static const XML_Char *
 poolCopyString(STRING_POOL *pool, const XML_Char *s) {
   if (! poolAppendChars(pool, s, xcslen(s) + /*null terminator*/ 1))
     return NULL;
@@ -8237,7 +8234,7 @@ poolCopyString(STRING_POOL *pool, const XML_Char *s) {
 
 // A version of `poolCopyString` that does not call `poolFinish`
 // and reverts any partial advancement upon failure.
-static const XML_Char *FASTCALL
+static const XML_Char *
 poolCopyStringNoFinish(STRING_POOL *pool, const XML_Char *s) {
   const XML_Char *const original = s;
   do {
@@ -8275,7 +8272,7 @@ poolCopyStringN(STRING_POOL *pool, const XML_Char *s, int n) {
   return s;
 }
 
-static const XML_Char *FASTCALL
+static const XML_Char *
 poolAppendString(STRING_POOL *pool, const XML_Char *s) {
   if (! poolAppendChars(pool, s, xcslen(s)))
     return NULL;
@@ -8320,7 +8317,7 @@ poolBytesToAllocateFor(int blockSize) {
   }
 }
 
-static XML_Bool FASTCALL
+static XML_Bool
 poolGrow(STRING_POOL *pool) {
   if (pool->freeBlocks) {
     if (pool->start == NULL) {
@@ -8425,7 +8422,7 @@ poolGrow(STRING_POOL *pool) {
   return XML_TRUE;
 }
 
-static bool FASTCALL
+static bool
 poolGrowUntil(STRING_POOL *pool, size_t needed) {
   for (;;) {
     const size_t available = pool->end - pool->ptr;
@@ -8438,7 +8435,7 @@ poolGrowUntil(STRING_POOL *pool, size_t needed) {
   }
 }
 
-static int FASTCALL
+static int
 nextScaffoldPart(XML_Parser parser) {
   DTD *const dtd = parser->m_dtd; /* save one level of indirection */
   CONTENT_SCAFFOLD *me;

--- a/expat/lib/xmlrole.c
+++ b/expat/lib/xmlrole.c
@@ -121,9 +121,8 @@ static const char KW_SYSTEM[]
 #  define setTopLevel(state) ((state)->handler = internalSubset)
 #endif /* not XML_DTD */
 
-typedef int PTRCALL PROLOG_HANDLER(PROLOG_STATE *state, int tok,
-                                   const char *ptr, const char *end,
-                                   const ENCODING *enc);
+typedef int PROLOG_HANDLER(PROLOG_STATE *state, int tok, const char *ptr,
+                           const char *end, const ENCODING *enc);
 
 static PROLOG_HANDLER prolog0, prolog1, prolog2, doctype0, doctype1, doctype2,
     doctype3, doctype4, doctype5, internalSubset, entity0, entity1, entity2,
@@ -137,9 +136,9 @@ static PROLOG_HANDLER prolog0, prolog1, prolog2, doctype0, doctype1, doctype2,
 #endif /* XML_DTD */
     declClose, error;
 
-static int FASTCALL common(PROLOG_STATE *state, int tok);
+static int common(PROLOG_STATE *state, int tok);
 
-static int PTRCALL
+static int
 prolog0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   switch (tok) {
@@ -170,7 +169,7 @@ prolog0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 prolog1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   switch (tok) {
@@ -202,7 +201,7 @@ prolog1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 prolog2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -222,7 +221,7 @@ prolog2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 doctype0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -239,7 +238,7 @@ doctype0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 doctype1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   switch (tok) {
@@ -265,7 +264,7 @@ doctype1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 doctype2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -281,7 +280,7 @@ doctype2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 doctype3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -297,7 +296,7 @@ doctype3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 doctype4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -316,7 +315,7 @@ doctype4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 doctype5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -332,7 +331,7 @@ doctype5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 internalSubset(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
                const ENCODING *enc) {
   switch (tok) {
@@ -377,7 +376,7 @@ internalSubset(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 
 #ifdef XML_DTD
 
-static int PTRCALL
+static int
 externalSubset0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
                 const ENCODING *enc) {
   state->handler = externalSubset1;
@@ -386,7 +385,7 @@ externalSubset0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return externalSubset1(state, tok, ptr, end, enc);
 }
 
-static int PTRCALL
+static int
 externalSubset1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
                 const ENCODING *enc) {
   switch (tok) {
@@ -414,7 +413,7 @@ externalSubset1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 
 #endif /* XML_DTD */
 
-static int PTRCALL
+static int
 entity0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -433,7 +432,7 @@ entity0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -449,7 +448,7 @@ entity1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   switch (tok) {
@@ -473,7 +472,7 @@ entity2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -489,7 +488,7 @@ entity3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -505,7 +504,7 @@ entity4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   switch (tok) {
@@ -524,7 +523,7 @@ entity5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -541,7 +540,7 @@ entity6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   switch (tok) {
@@ -565,7 +564,7 @@ entity7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity8(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -581,7 +580,7 @@ entity8(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity9(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
         const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -597,7 +596,7 @@ entity9(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 entity10(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -613,7 +612,7 @@ entity10(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 notation0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -629,7 +628,7 @@ notation0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 notation1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   switch (tok) {
@@ -649,7 +648,7 @@ notation1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 notation2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -665,7 +664,7 @@ notation2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 notation3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -682,7 +681,7 @@ notation3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 notation4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -702,7 +701,7 @@ notation4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -719,7 +718,7 @@ attlist0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -739,7 +738,7 @@ attlist1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   switch (tok) {
@@ -769,7 +768,7 @@ attlist2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -787,7 +786,7 @@ attlist3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -806,7 +805,7 @@ attlist4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -822,7 +821,7 @@ attlist5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -838,7 +837,7 @@ attlist6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -858,7 +857,7 @@ attlist7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 
 /* default value */
-static int PTRCALL
+static int
 attlist8(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   switch (tok) {
@@ -888,7 +887,7 @@ attlist8(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 attlist9(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -904,7 +903,7 @@ attlist9(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 element0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -921,7 +920,7 @@ element0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 element1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   switch (tok) {
@@ -947,7 +946,7 @@ element1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 element2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   switch (tok) {
@@ -981,7 +980,7 @@ element2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 element3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -1005,7 +1004,7 @@ element3(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 element4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -1022,7 +1021,7 @@ element4(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 element5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -1042,7 +1041,7 @@ element5(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 element6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -1071,7 +1070,7 @@ element6(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 element7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
          const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -1120,7 +1119,7 @@ element7(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 
 #ifdef XML_DTD
 
-static int PTRCALL
+static int
 condSect0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   switch (tok) {
@@ -1140,7 +1139,7 @@ condSect0(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 condSect1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -1157,7 +1156,7 @@ condSect1(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
   return common(state, tok);
 }
 
-static int PTRCALL
+static int
 condSect2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -1175,7 +1174,7 @@ condSect2(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 
 #endif /* XML_DTD */
 
-static int PTRCALL
+static int
 declClose(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
           const ENCODING *enc) {
   UNUSED_P(ptr);
@@ -1211,7 +1210,7 @@ declClose(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
  *
  * LCOV_EXCL_START
  */
-static int PTRCALL
+static int
 error(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
       const ENCODING *enc) {
   UNUSED_P(state);
@@ -1223,7 +1222,7 @@ error(PROLOG_STATE *state, int tok, const char *ptr, const char *end,
 }
 /* LCOV_EXCL_STOP */
 
-static int FASTCALL
+static int
 common(PROLOG_STATE *state, int tok) {
 #ifdef XML_DTD
   if (! state->documentEntity && tok == XML_TOK_PARAM_ENTITY_REF)

--- a/expat/lib/xmlrole.h
+++ b/expat/lib/xmlrole.h
@@ -112,8 +112,8 @@ enum {
 };
 
 typedef struct prolog_state {
-  int(PTRCALL *handler)(struct prolog_state *state, int tok, const char *ptr,
-                        const char *end, const ENCODING *enc);
+  int (*handler)(struct prolog_state *state, int tok, const char *ptr,
+                 const char *end, const ENCODING *enc);
   unsigned level;
   int role_none;
 #  ifdef XML_DTD

--- a/expat/lib/xmltok.c
+++ b/expat/lib/xmltok.c
@@ -136,20 +136,20 @@
            : ((p)[1] & 0x80) == 0                                              \
                  || ((*p) == 0xF4 ? (p)[1] > 0x8F : ((p)[1] & 0xC0) == 0xC0)))
 
-static int PTRFASTCALL
+static int
 isNever(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   UNUSED_P(p);
   return 0;
 }
 
-static int PTRFASTCALL
+static int
 utf8_isName2(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return UTF8_GET_NAMING2(namePages, (const unsigned char *)p);
 }
 
-static int PTRFASTCALL
+static int
 utf8_isName3(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return UTF8_GET_NAMING3(namePages, (const unsigned char *)p);
@@ -157,13 +157,13 @@ utf8_isName3(const ENCODING *enc, const char *p) {
 
 #define utf8_isName4 isNever
 
-static int PTRFASTCALL
+static int
 utf8_isNmstrt2(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return UTF8_GET_NAMING2(nmstrtPages, (const unsigned char *)p);
 }
 
-static int PTRFASTCALL
+static int
 utf8_isNmstrt3(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return UTF8_GET_NAMING3(nmstrtPages, (const unsigned char *)p);
@@ -171,19 +171,19 @@ utf8_isNmstrt3(const ENCODING *enc, const char *p) {
 
 #define utf8_isNmstrt4 isNever
 
-static int PTRFASTCALL
+static int
 utf8_isInvalid2(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return UTF8_INVALID2((const unsigned char *)p);
 }
 
-static int PTRFASTCALL
+static int
 utf8_isInvalid3(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return UTF8_INVALID3((const unsigned char *)p);
 }
 
-static int PTRFASTCALL
+static int
 utf8_isInvalid4(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return UTF8_INVALID4((const unsigned char *)p);
@@ -193,21 +193,21 @@ struct normal_encoding {
   ENCODING enc;
   unsigned char type[256];
 #ifdef XML_MIN_SIZE
-  int(PTRFASTCALL *byteType)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isNameMin)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isNmstrtMin)(const ENCODING *, const char *);
-  int(PTRFASTCALL *byteToAscii)(const ENCODING *, const char *);
-  int(PTRCALL *charMatches)(const ENCODING *, const char *, int);
+  int (*byteType)(const ENCODING *, const char *);
+  int (*isNameMin)(const ENCODING *, const char *);
+  int (*isNmstrtMin)(const ENCODING *, const char *);
+  int (*byteToAscii)(const ENCODING *, const char *);
+  int (*charMatches)(const ENCODING *, const char *, int);
 #endif /* XML_MIN_SIZE */
-  int(PTRFASTCALL *isName2)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isName3)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isName4)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isNmstrt2)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isNmstrt3)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isNmstrt4)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isInvalid2)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isInvalid3)(const ENCODING *, const char *);
-  int(PTRFASTCALL *isInvalid4)(const ENCODING *, const char *);
+  int (*isName2)(const ENCODING *, const char *);
+  int (*isName3)(const ENCODING *, const char *);
+  int (*isName4)(const ENCODING *, const char *);
+  int (*isNmstrt2)(const ENCODING *, const char *);
+  int (*isNmstrt3)(const ENCODING *, const char *);
+  int (*isNmstrt4)(const ENCODING *, const char *);
+  int (*isInvalid2)(const ENCODING *, const char *);
+  int (*isInvalid3)(const ENCODING *, const char *);
+  int (*isInvalid4)(const ENCODING *, const char *);
 };
 
 #define AS_NORMAL_ENCODING(enc) ((const struct normal_encoding *)(enc))
@@ -232,7 +232,7 @@ struct normal_encoding {
       /* isNmstrt2 */ NULL, /* isNmstrt3 */ NULL, /* isNmstrt4 */ NULL,        \
       /* isInvalid2 */ NULL, /* isInvalid3 */ NULL, /* isInvalid4 */ NULL
 
-static int FASTCALL checkCharRefNumber(int result);
+static int checkCharRefNumber(int result);
 
 #include "xmltok_impl.h"
 #include "ascii.h"
@@ -253,7 +253,7 @@ static int FASTCALL checkCharRefNumber(int result);
   (((const struct normal_encoding *)(enc))->type[(unsigned char)*(p)])
 
 #ifdef XML_MIN_SIZE
-static int PTRFASTCALL
+static int
 sb_byteType(const ENCODING *enc, const char *p) {
   return SB_BYTE_TYPE(enc, p);
 }
@@ -264,7 +264,7 @@ sb_byteType(const ENCODING *enc, const char *p) {
 
 #ifdef XML_MIN_SIZE
 #  define BYTE_TO_ASCII(enc, p) (AS_NORMAL_ENCODING(enc)->byteToAscii(enc, p))
-static int PTRFASTCALL
+static int
 sb_byteToAscii(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return *p;
@@ -297,7 +297,7 @@ sb_byteToAscii(const ENCODING *enc, const char *p) {
 #ifdef XML_MIN_SIZE
 #  define CHAR_MATCHES(enc, p, c)                                              \
     (AS_NORMAL_ENCODING(enc)->charMatches(enc, p, c))
-static int PTRCALL
+static int
 sb_charMatches(const ENCODING *enc, const char *p, int c) {
   UNUSED_P(enc);
   return *p == c;
@@ -368,7 +368,7 @@ _INTERNAL_trim_to_complete_utf8_characters(const char *from,
   *fromLimRef = fromLim;
 }
 
-static enum XML_Convert_Result PTRCALL
+static enum XML_Convert_Result
 utf8_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
             char **toP, const char *toLim) {
   bool input_incomplete = false;
@@ -407,7 +407,7 @@ utf8_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
     return XML_CONVERT_COMPLETED;
 }
 
-static enum XML_Convert_Result PTRCALL
+static enum XML_Convert_Result
 utf8_toUtf16(const ENCODING *enc, const char **fromP, const char *fromLim,
              unsigned short **toP, const unsigned short *toLim) {
   enum XML_Convert_Result res = XML_CONVERT_COMPLETED;
@@ -505,7 +505,7 @@ static const struct normal_encoding internal_utf8_encoding
        },
        STANDARD_VTABLE(sb_) NORMAL_VTABLE(utf8_)};
 
-static enum XML_Convert_Result PTRCALL
+static enum XML_Convert_Result
 latin1_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
               char **toP, const char *toLim) {
   UNUSED_P(enc);
@@ -528,7 +528,7 @@ latin1_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
   }
 }
 
-static enum XML_Convert_Result PTRCALL
+static enum XML_Convert_Result
 latin1_toUtf16(const ENCODING *enc, const char **fromP, const char *fromLim,
                unsigned short **toP, const unsigned short *toLim) {
   UNUSED_P(enc);
@@ -563,7 +563,7 @@ static const struct normal_encoding latin1_encoding
        },
        STANDARD_VTABLE(sb_) NULL_VTABLE};
 
-static enum XML_Convert_Result PTRCALL
+static enum XML_Convert_Result
 ascii_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
              char **toP, const char *toLim) {
   UNUSED_P(enc);
@@ -598,7 +598,7 @@ static const struct normal_encoding ascii_encoding
        },
        STANDARD_VTABLE(sb_) NULL_VTABLE};
 
-static int PTRFASTCALL
+static int
 unicode_byte_type(char hi, char lo) {
   switch ((unsigned char)hi) {
   /* 0xD800-0xDBFF first 16-bit code unit or high surrogate (W1) */
@@ -625,7 +625,7 @@ unicode_byte_type(char hi, char lo) {
 }
 
 #define DEFINE_UTF16_TO_UTF8(E)                                                \
-  static enum XML_Convert_Result PTRCALL E##toUtf8(                            \
+  static enum XML_Convert_Result E##toUtf8(                                    \
       const ENCODING *enc, const char **fromP, const char *fromLim,            \
       char **toP, const char *toLim) {                                         \
     const char *from = *fromP;                                                 \
@@ -702,7 +702,7 @@ unicode_byte_type(char hi, char lo) {
   }
 
 #define DEFINE_UTF16_TO_UTF16(E)                                               \
-  static enum XML_Convert_Result PTRCALL E##toUtf16(                           \
+  static enum XML_Convert_Result E##toUtf16(                                   \
       const ENCODING *enc, const char **fromP, const char *fromLim,            \
       unsigned short **toP, const unsigned short *toLim) {                     \
     enum XML_Convert_Result res = XML_CONVERT_COMPLETED;                       \
@@ -752,30 +752,30 @@ DEFINE_UTF16_TO_UTF16(big2_)
 
 #ifdef XML_MIN_SIZE
 
-static int PTRFASTCALL
+static int
 little2_byteType(const ENCODING *enc, const char *p) {
   return LITTLE2_BYTE_TYPE(enc, p);
 }
 
-static int PTRFASTCALL
+static int
 little2_byteToAscii(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return LITTLE2_BYTE_TO_ASCII(p);
 }
 
-static int PTRCALL
+static int
 little2_charMatches(const ENCODING *enc, const char *p, int c) {
   UNUSED_P(enc);
   return LITTLE2_CHAR_MATCHES(p, c);
 }
 
-static int PTRFASTCALL
+static int
 little2_isNameMin(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return LITTLE2_IS_NAME_CHAR_MINBPC(p);
 }
 
-static int PTRFASTCALL
+static int
 little2_isNmstrtMin(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return LITTLE2_IS_NMSTRT_CHAR_MINBPC(p);
@@ -885,30 +885,30 @@ static const struct normal_encoding internal_little2_encoding
 
 #ifdef XML_MIN_SIZE
 
-static int PTRFASTCALL
+static int
 big2_byteType(const ENCODING *enc, const char *p) {
   return BIG2_BYTE_TYPE(enc, p);
 }
 
-static int PTRFASTCALL
+static int
 big2_byteToAscii(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return BIG2_BYTE_TO_ASCII(p);
 }
 
-static int PTRCALL
+static int
 big2_charMatches(const ENCODING *enc, const char *p, int c) {
   UNUSED_P(enc);
   return BIG2_CHAR_MATCHES(p, c);
 }
 
-static int PTRFASTCALL
+static int
 big2_isNameMin(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return BIG2_IS_NAME_CHAR_MINBPC(p);
 }
 
-static int PTRFASTCALL
+static int
 big2_isNmstrtMin(const ENCODING *enc, const char *p) {
   UNUSED_P(enc);
   return BIG2_IS_NMSTRT_CHAR_MINBPC(p);
@@ -1009,7 +1009,7 @@ static const struct normal_encoding internal_big2_encoding
 
 #undef PREFIX
 
-static int FASTCALL
+static int
 streqci(const char *s1, const char *s2) {
   for (;;) {
     char c1 = *s1++;
@@ -1030,7 +1030,7 @@ streqci(const char *s1, const char *s2) {
   return 1;
 }
 
-static void PTRCALL
+static void
 initUpdatePosition(const ENCODING *enc, const char *ptr, const char *end,
                    POSITION *pos) {
   UNUSED_P(enc);
@@ -1048,7 +1048,7 @@ toAscii(const ENCODING *enc, const char *ptr, const char *end) {
     return buf[0];
 }
 
-static int FASTCALL
+static int
 isSpace(int c) {
   switch (c) {
   case 0x20:
@@ -1242,7 +1242,7 @@ doParseXmlDecl(const ENCODING *(*encodingFinder)(const ENCODING *, const char *,
   return 1;
 }
 
-static int FASTCALL
+static int
 checkCharRefNumber(int result) {
   switch (result >> 8) {
   case 0xD8:
@@ -1266,7 +1266,7 @@ checkCharRefNumber(int result) {
   return result;
 }
 
-int FASTCALL
+int
 XmlUtf8Encode(int c, char *buf) {
   enum {
     /* minN is minimum legal resulting value for N byte sequence */
@@ -1302,7 +1302,7 @@ XmlUtf8Encode(int c, char *buf) {
   return 0; /* LCOV_EXCL_LINE: this case too is eliminated before calling */
 }
 
-int FASTCALL
+int
 XmlUtf16Encode(int charNum, unsigned short *buf) {
   if (charNum < 0)
     return 0;
@@ -1334,7 +1334,7 @@ XmlSizeOfUnknownEncoding(void) {
   return sizeof(struct unknown_encoding);
 }
 
-static int PTRFASTCALL
+static int
 unknown_isName(const ENCODING *enc, const char *p) {
   const struct unknown_encoding *uenc = AS_UNKNOWN_ENCODING(enc);
   int c = uenc->convert(uenc->userData, p);
@@ -1343,7 +1343,7 @@ unknown_isName(const ENCODING *enc, const char *p) {
   return UCS2_GET_NAMING(namePages, c >> 8, c & 0xFF);
 }
 
-static int PTRFASTCALL
+static int
 unknown_isNmstrt(const ENCODING *enc, const char *p) {
   const struct unknown_encoding *uenc = AS_UNKNOWN_ENCODING(enc);
   int c = uenc->convert(uenc->userData, p);
@@ -1352,14 +1352,14 @@ unknown_isNmstrt(const ENCODING *enc, const char *p) {
   return UCS2_GET_NAMING(nmstrtPages, c >> 8, c & 0xFF);
 }
 
-static int PTRFASTCALL
+static int
 unknown_isInvalid(const ENCODING *enc, const char *p) {
   const struct unknown_encoding *uenc = AS_UNKNOWN_ENCODING(enc);
   int c = uenc->convert(uenc->userData, p);
   return (c & ~0xFFFF) || checkCharRefNumber(c) < 0;
 }
 
-static enum XML_Convert_Result PTRCALL
+static enum XML_Convert_Result
 unknown_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
                char **toP, const char *toLim) {
   const struct unknown_encoding *uenc = AS_UNKNOWN_ENCODING(enc);
@@ -1389,7 +1389,7 @@ unknown_toUtf8(const ENCODING *enc, const char **fromP, const char *fromLim,
   }
 }
 
-static enum XML_Convert_Result PTRCALL
+static enum XML_Convert_Result
 unknown_toUtf16(const ENCODING *enc, const char **fromP, const char *fromLim,
                 unsigned short **toP, const unsigned short *toLim) {
   const struct unknown_encoding *uenc = AS_UNKNOWN_ENCODING(enc);
@@ -1513,7 +1513,7 @@ static const char KW_UTF_16LE[]
     = {ASCII_U, ASCII_T, ASCII_F, ASCII_MINUS, ASCII_1,
        ASCII_6, ASCII_L, ASCII_E, '\0'};
 
-static int FASTCALL
+static int
 getEncodingIndex(const char *name) {
   static const char *const encodingNames[] = {
       KW_ISO_8859_1, KW_US_ASCII, KW_UTF_8, KW_UTF_16, KW_UTF_16BE, KW_UTF_16LE,

--- a/expat/lib/xmltok.h
+++ b/expat/lib/xmltok.h
@@ -163,8 +163,8 @@ typedef struct {
 struct encoding;
 typedef struct encoding ENCODING;
 
-typedef int(PTRCALL *SCANNER)(const ENCODING *, const char *, const char *,
-                              const char **);
+typedef int (*SCANNER)(const ENCODING *, const char *, const char *,
+                       const char **);
 
 enum XML_Convert_Result {
   XML_CONVERT_COMPLETED = 0,
@@ -176,28 +176,27 @@ enum XML_Convert_Result {
 struct encoding {
   SCANNER scanners[XML_N_STATES];
   SCANNER literalScanners[XML_N_LITERAL_TYPES];
-  int(PTRCALL *nameMatchesAscii)(const ENCODING *, const char *, const char *,
-                                 const char *);
-  int(PTRFASTCALL *nameLength)(const ENCODING *, const char *);
-  const char *(PTRFASTCALL *skipS)(const ENCODING *, const char *);
-  int(PTRCALL *getAtts)(const ENCODING *enc, const char *ptr, int attsMax,
-                        ATTRIBUTE *atts);
-  int(PTRFASTCALL *charRefNumber)(const ENCODING *enc, const char *ptr);
-  int(PTRCALL *predefinedEntityName)(const ENCODING *, const char *,
-                                     const char *);
-  void(PTRCALL *updatePosition)(const ENCODING *, const char *ptr,
-                                const char *end, POSITION *);
-  int(PTRCALL *isPublicId)(const ENCODING *enc, const char *ptr,
-                           const char *end, const char **badPtr);
-  enum XML_Convert_Result(PTRCALL *utf8Convert)(const ENCODING *enc,
-                                                const char **fromP,
-                                                const char *fromLim, char **toP,
-                                                const char *toLim);
-  enum XML_Convert_Result(PTRCALL *utf16Convert)(const ENCODING *enc,
-                                                 const char **fromP,
-                                                 const char *fromLim,
-                                                 unsigned short **toP,
-                                                 const unsigned short *toLim);
+  int (*nameMatchesAscii)(const ENCODING *, const char *, const char *,
+                          const char *);
+  int (*nameLength)(const ENCODING *, const char *);
+  const char *(*skipS)(const ENCODING *, const char *);
+  int (*getAtts)(const ENCODING *enc, const char *ptr, int attsMax,
+                 ATTRIBUTE *atts);
+  int (*charRefNumber)(const ENCODING *enc, const char *ptr);
+  int (*predefinedEntityName)(const ENCODING *, const char *, const char *);
+  void (*updatePosition)(const ENCODING *, const char *ptr, const char *end,
+                         POSITION *);
+  int (*isPublicId)(const ENCODING *enc, const char *ptr, const char *end,
+                    const char **badPtr);
+  enum XML_Convert_Result (*utf8Convert)(const ENCODING *enc,
+                                         const char **fromP,
+                                         const char *fromLim, char **toP,
+                                         const char *toLim);
+  enum XML_Convert_Result (*utf16Convert)(const ENCODING *enc,
+                                          const char **fromP,
+                                          const char *fromLim,
+                                          unsigned short **toP,
+                                          const unsigned short *toLim);
   int minBytesPerChar;
   char isUtf8;
   char isUtf16;
@@ -297,8 +296,8 @@ int XmlInitEncoding(INIT_ENCODING *p, const ENCODING **encPtr,
                     const char *name);
 const ENCODING *XmlGetUtf8InternalEncoding(void);
 const ENCODING *XmlGetUtf16InternalEncoding(void);
-int FASTCALL XmlUtf8Encode(int charNumber, char *buf);
-int FASTCALL XmlUtf16Encode(int charNumber, unsigned short *buf);
+int XmlUtf8Encode(int charNumber, char *buf);
+int XmlUtf16Encode(int charNumber, unsigned short *buf);
 int XmlSizeOfUnknownEncoding(void);
 
 typedef int(XMLCALL *CONVERTER)(void *userData, const char *p);

--- a/expat/lib/xmltok_impl.c
+++ b/expat/lib/xmltok_impl.c
@@ -144,7 +144,7 @@
 
 /* ptr points to character following "<!-" */
 
-static int PTRCALL
+static int
 PREFIX(scanComment)(const ENCODING *enc, const char *ptr, const char *end,
                     const char **nextTokPtr) {
   if (HAS_CHAR(enc, ptr, end)) {
@@ -181,7 +181,7 @@ PREFIX(scanComment)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following "<!" */
 
-static int PTRCALL
+static int
 PREFIX(scanDecl)(const ENCODING *enc, const char *ptr, const char *end,
                  const char **nextTokPtr) {
   REQUIRE_CHAR(enc, ptr, end);
@@ -230,7 +230,7 @@ PREFIX(scanDecl)(const ENCODING *enc, const char *ptr, const char *end,
   return XML_TOK_PARTIAL;
 }
 
-static int PTRCALL
+static int
 PREFIX(checkPiTarget)(const ENCODING *enc, const char *ptr, const char *end,
                       int *tokPtr) {
   int upper = 0;
@@ -275,7 +275,7 @@ PREFIX(checkPiTarget)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following "<?" */
 
-static int PTRCALL
+static int
 PREFIX(scanPi)(const ENCODING *enc, const char *ptr, const char *end,
                const char **nextTokPtr) {
   int tok;
@@ -335,7 +335,7 @@ PREFIX(scanPi)(const ENCODING *enc, const char *ptr, const char *end,
   return XML_TOK_PARTIAL;
 }
 
-static int PTRCALL
+static int
 PREFIX(scanCdataSection)(const ENCODING *enc, const char *ptr, const char *end,
                          const char **nextTokPtr) {
   static const char CDATA_LSQB[]
@@ -354,7 +354,7 @@ PREFIX(scanCdataSection)(const ENCODING *enc, const char *ptr, const char *end,
   return XML_TOK_CDATA_SECT_OPEN;
 }
 
-static int PTRCALL
+static int
 PREFIX(cdataSectionTok)(const ENCODING *enc, const char *ptr, const char *end,
                         const char **nextTokPtr) {
   if (ptr >= end)
@@ -430,7 +430,7 @@ PREFIX(cdataSectionTok)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following "</" */
 
-static int PTRCALL
+static int
 PREFIX(scanEndTag)(const ENCODING *enc, const char *ptr, const char *end,
                    const char **nextTokPtr) {
   REQUIRE_CHAR(enc, ptr, end);
@@ -481,7 +481,7 @@ PREFIX(scanEndTag)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following "&#X" */
 
-static int PTRCALL
+static int
 PREFIX(scanHexCharRef)(const ENCODING *enc, const char *ptr, const char *end,
                        const char **nextTokPtr) {
   if (HAS_CHAR(enc, ptr, end)) {
@@ -512,7 +512,7 @@ PREFIX(scanHexCharRef)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following "&#" */
 
-static int PTRCALL
+static int
 PREFIX(scanCharRef)(const ENCODING *enc, const char *ptr, const char *end,
                     const char **nextTokPtr) {
   if (HAS_CHAR(enc, ptr, end)) {
@@ -543,7 +543,7 @@ PREFIX(scanCharRef)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following "&" */
 
-static int PTRCALL
+static int
 PREFIX(scanRef)(const ENCODING *enc, const char *ptr, const char *end,
                 const char **nextTokPtr) {
   REQUIRE_CHAR(enc, ptr, end);
@@ -571,7 +571,7 @@ PREFIX(scanRef)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following first character of attribute name */
 
-static int PTRCALL
+static int
 PREFIX(scanAtts)(const ENCODING *enc, const char *ptr, const char *end,
                  const char **nextTokPtr) {
 #  ifdef XML_NS
@@ -724,7 +724,7 @@ PREFIX(scanAtts)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following "<" */
 
-static int PTRCALL
+static int
 PREFIX(scanLt)(const ENCODING *enc, const char *ptr, const char *end,
                const char **nextTokPtr) {
 #  ifdef XML_NS
@@ -822,7 +822,7 @@ PREFIX(scanLt)(const ENCODING *enc, const char *ptr, const char *end,
   return XML_TOK_PARTIAL;
 }
 
-static int PTRCALL
+static int
 PREFIX(contentTok)(const ENCODING *enc, const char *ptr, const char *end,
                    const char **nextTokPtr) {
   if (ptr >= end)
@@ -922,7 +922,7 @@ PREFIX(contentTok)(const ENCODING *enc, const char *ptr, const char *end,
 
 /* ptr points to character following "%" */
 
-static int PTRCALL
+static int
 PREFIX(scanPercent)(const ENCODING *enc, const char *ptr, const char *end,
                     const char **nextTokPtr) {
   REQUIRE_CHAR(enc, ptr, end);
@@ -952,7 +952,7 @@ PREFIX(scanPercent)(const ENCODING *enc, const char *ptr, const char *end,
   return XML_TOK_PARTIAL;
 }
 
-static int PTRCALL
+static int
 PREFIX(scanPoundName)(const ENCODING *enc, const char *ptr, const char *end,
                       const char **nextTokPtr) {
   REQUIRE_CHAR(enc, ptr, end);
@@ -982,7 +982,7 @@ PREFIX(scanPoundName)(const ENCODING *enc, const char *ptr, const char *end,
   return -XML_TOK_POUND_NAME;
 }
 
-static int PTRCALL
+static int
 PREFIX(scanLit)(int open, const ENCODING *enc, const char *ptr, const char *end,
                 const char **nextTokPtr) {
   while (HAS_CHAR(enc, ptr, end)) {
@@ -1016,7 +1016,7 @@ PREFIX(scanLit)(int open, const ENCODING *enc, const char *ptr, const char *end,
   return XML_TOK_PARTIAL;
 }
 
-static int PTRCALL
+static int
 PREFIX(prologTok)(const ENCODING *enc, const char *ptr, const char *end,
                   const char **nextTokPtr) {
   int tok;
@@ -1260,7 +1260,7 @@ PREFIX(prologTok)(const ENCODING *enc, const char *ptr, const char *end,
   return -tok;
 }
 
-static int PTRCALL
+static int
 PREFIX(attributeValueTok)(const ENCODING *enc, const char *ptr, const char *end,
                           const char **nextTokPtr) {
   const char *start;
@@ -1329,7 +1329,7 @@ PREFIX(attributeValueTok)(const ENCODING *enc, const char *ptr, const char *end,
   return XML_TOK_DATA_CHARS;
 }
 
-static int PTRCALL
+static int
 PREFIX(entityValueTok)(const ENCODING *enc, const char *ptr, const char *end,
                        const char **nextTokPtr) {
   const char *start;
@@ -1396,7 +1396,7 @@ PREFIX(entityValueTok)(const ENCODING *enc, const char *ptr, const char *end,
 
 #  ifdef XML_DTD
 
-static int PTRCALL
+static int
 PREFIX(ignoreSectionTok)(const ENCODING *enc, const char *ptr, const char *end,
                          const char **nextTokPtr) {
   int level = 0;
@@ -1448,7 +1448,7 @@ PREFIX(ignoreSectionTok)(const ENCODING *enc, const char *ptr, const char *end,
 
 #  endif /* XML_DTD */
 
-static int PTRCALL
+static int
 PREFIX(isPublicId)(const ENCODING *enc, const char *ptr, const char *end,
                    const char **badPtr) {
   ptr += MINBPC(enc);
@@ -1508,7 +1508,7 @@ PREFIX(isPublicId)(const ENCODING *enc, const char *ptr, const char *end,
    first attsMax attributes are stored in atts.
 */
 
-static int PTRCALL
+static int
 PREFIX(getAtts)(const ENCODING *enc, const char *ptr, int attsMax,
                 ATTRIBUTE *atts) {
   enum { other, inName, inValue } state = inName;
@@ -1601,7 +1601,7 @@ PREFIX(getAtts)(const ENCODING *enc, const char *ptr, int attsMax,
   /* not reached */
 }
 
-static int PTRFASTCALL
+static int
 PREFIX(charRefNumber)(const ENCODING *enc, const char *ptr) {
   int result = 0;
   /* skip &# */
@@ -1659,7 +1659,7 @@ PREFIX(charRefNumber)(const ENCODING *enc, const char *ptr) {
   return checkCharRefNumber(result);
 }
 
-static int PTRCALL
+static int
 PREFIX(predefinedEntityName)(const ENCODING *enc, const char *ptr,
                              const char *end) {
   UNUSED_P(enc);
@@ -1713,7 +1713,7 @@ PREFIX(predefinedEntityName)(const ENCODING *enc, const char *ptr,
   return 0;
 }
 
-static int PTRCALL
+static int
 PREFIX(nameMatchesAscii)(const ENCODING *enc, const char *ptr1,
                          const char *end1, const char *ptr2) {
   UNUSED_P(enc);
@@ -1732,7 +1732,7 @@ PREFIX(nameMatchesAscii)(const ENCODING *enc, const char *ptr1,
   return ptr1 == end1;
 }
 
-static int PTRFASTCALL
+static int
 PREFIX(nameLength)(const ENCODING *enc, const char *ptr) {
   const char *start = ptr;
   for (;;) {
@@ -1762,7 +1762,7 @@ PREFIX(nameLength)(const ENCODING *enc, const char *ptr) {
   }
 }
 
-static const char *PTRFASTCALL
+static const char *
 PREFIX(skipS)(const ENCODING *enc, const char *ptr) {
   for (;;) {
     switch (BYTE_TYPE(enc, ptr)) {
@@ -1777,7 +1777,7 @@ PREFIX(skipS)(const ENCODING *enc, const char *ptr) {
   }
 }
 
-static void PTRCALL
+static void
 PREFIX(updatePosition)(const ENCODING *enc, const char *ptr, const char *end,
                        POSITION *pos) {
   while (HAS_CHAR(enc, ptr, end)) {

--- a/expat/lib/xmltok_ns.c
+++ b/expat/lib/xmltok_ns.c
@@ -64,14 +64,14 @@ static const ENCODING *const NS(encodings)[] = {
     &ns(utf8_encoding).enc /* NO_ENC */
 };
 
-static int PTRCALL
+static int
 NS(initScanProlog)(const ENCODING *enc, const char *ptr, const char *end,
                    const char **nextTokPtr) {
   return initScan(NS(encodings), (const INIT_ENCODING *)enc, XML_PROLOG_STATE,
                   ptr, end, nextTokPtr);
 }
 
-static int PTRCALL
+static int
 NS(initScanContent)(const ENCODING *enc, const char *ptr, const char *end,
                     const char **nextTokPtr) {
   return initScan(NS(encodings), (const INIT_ENCODING *)enc, XML_CONTENT_STATE,


### PR DESCRIPTION
This effectively stops suggesting `__attribute__((regparm(3)))` to the C compiler.

Related documentation:
https://gcc.gnu.org/onlinedocs/gcc/x86-Attributes.html#index-regparm_002c-x86
