### PR TITLE
Turn the deprecation of `XML_SetHashSalt` into a compile time warning

### DIFF
--- a/expat/fuzz/xml_lpm_fuzzer.cpp
+++ b/expat/fuzz/xml_lpm_fuzzer.cpp
@@ -383,7 +383,9 @@ UnknownEncodingHandler(void *encodingHandlerData, const XML_Char *name,
 void
 InitializeParser(XML_Parser parser) {
   XML_SetUserData(parser, (void *)parser);
-  XML_SetHashSalt(parser, 0x41414141);
+  const uint8_t entropy[16] = {0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+                               0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41};
+  XML_SetHashSalt16Bytes(parser, entropy);
   XML_SetParamEntityParsing(parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
 
   XML_SetElementDeclHandler(parser, ElementDeclHandler);

--- a/expat/fuzz/xml_parse_fuzzer.c
+++ b/expat/fuzz/xml_parse_fuzzer.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <limits.h> // for INT_MAX
 #include <stdint.h>
+#include <string.h>
 
 #include "expat.h"
 #include "siphash.h"
@@ -34,7 +35,8 @@
 #endif
 
 // 16-byte deterministic hash key.
-static unsigned char hash_key[16] = "FUZZING IS FUN!";
+static unsigned char hash_key_1[16] = "FUZZING IS FUN?";
+static unsigned char hash_key_2[16] = "FUZZING IS FUN!";
 
 static void XMLCALL
 start(void *userData, const XML_Char *name, const XML_Char **atts) {
@@ -59,8 +61,14 @@ may_stop_character_handler(void *userData, const XML_Char *s, int len) {
 static void
 ParseOneInput(XML_Parser p, const uint8_t *data, size_t size) {
   // Set the hash salt using siphash to generate a deterministic hash.
-  struct sipkey *key = sip_keyof(hash_key);
-  XML_SetHashSalt(p, (unsigned long)siphash24(data, size, key));
+  // The salt is 16 bytes and siphash24 produces 8, so the input is hashed
+  // under two keys.
+  const uint64_t first = siphash24(data, size, sip_keyof(hash_key_1));
+  const uint64_t second = siphash24(data, size, sip_keyof(hash_key_2));
+  uint8_t entropy[16];
+  memcpy(entropy, &first, sizeof(first));
+  memcpy(entropy + sizeof(first), &second, sizeof(second));
+  XML_SetHashSalt16Bytes(p, entropy);
   (void)sip24_valid;
 
   XML_SetUserData(p, p);

--- a/expat/fuzz/xml_parsebuffer_fuzzer.c
+++ b/expat/fuzz/xml_parsebuffer_fuzzer.c
@@ -35,7 +35,8 @@
 #endif
 
 // 16-byte deterministic hash key.
-static unsigned char hash_key[16] = "FUZZING IS FUN!";
+static unsigned char hash_key_1[16] = "FUZZING IS FUN?";
+static unsigned char hash_key_2[16] = "FUZZING IS FUN!";
 
 static void XMLCALL
 start(void *userData, const XML_Char *name, const XML_Char **atts) {
@@ -60,8 +61,14 @@ may_stop_character_handler(void *userData, const XML_Char *s, int len) {
 static void
 ParseOneInput(XML_Parser p, const uint8_t *data, size_t size) {
   // Set the hash salt using siphash to generate a deterministic hash.
-  struct sipkey *key = sip_keyof(hash_key);
-  XML_SetHashSalt(p, (unsigned long)siphash24(data, size, key));
+  // The salt is 16 bytes and siphash24 produces 8, so the input is hashed
+  // under two keys.
+  const uint64_t first = siphash24(data, size, sip_keyof(hash_key_1));
+  const uint64_t second = siphash24(data, size, sip_keyof(hash_key_2));
+  uint8_t entropy[16];
+  memcpy(entropy, &first, sizeof(first));
+  memcpy(entropy + sizeof(first), &second, sizeof(second));
+  XML_SetHashSalt16Bytes(p, entropy);
   (void)sip24_valid;
 
   XML_SetUserData(p, p);

--- a/expat/lib/expat.h
+++ b/expat/lib/expat.h
@@ -921,7 +921,9 @@ XML_SetParamEntityParsing(XML_Parser parser,
    Returns 1 if successful, 0 when called after parsing has started.
    Note: If parser == NULL, the function will do nothing and return 0.
    DEPRECATED since Expat 2.8.0.
+   Please use XML_SetHashSalt16Bytes instead.
 */
+XML_ATTR_DEPRECATED("please use XML_SetHashSalt16Bytes instead")
 XMLPARSEAPI(int)
 XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt);
 

--- a/expat/lib/expat_external.h
+++ b/expat/lib/expat_external.h
@@ -125,6 +125,17 @@
 #    define XML_ATTR_ALLOC_SIZE(x)
 #  endif
 
+/* Marks a function that Expat still provides but that callers should move off
+   of. */
+#  if defined(__clang__) || defined(__GNUC__)
+#    define XML_ATTR_DEPRECATED(message)                                       \
+      __attribute__((__deprecated__(message)))
+#  elif defined(_MSC_VER)
+#    define XML_ATTR_DEPRECATED(message) __declspec(deprecated(message))
+#  else
+#    define XML_ATTR_DEPRECATED(message) // empty i.e. no deprecation
+#  endif
+
 #  define XMLPARSEAPI(type) XMLIMPORT type XMLCALL
 
 #  ifdef __cplusplus

--- a/expat/lib/internal.h
+++ b/expat/lib/internal.h
@@ -143,6 +143,9 @@ extern
 #endif
     XML_Bool g_reparseDeferralEnabledDefault; // written ONLY in runtests.c
 #if defined(XML_TESTING)
+
+int xmlSetHashSalt(XML_Parser parser, unsigned long hash_salt);
+
 void *expat_malloc(XML_Parser parser, size_t size, int sourceLine);
 void expat_free(XML_Parser parser, void *ptr, int sourceLine);
 void *expat_realloc(XML_Parser parser, void *ptr, size_t size, int sourceLine);

--- a/expat/lib/xmlparse.c
+++ b/expat/lib/xmlparse.c
@@ -2236,9 +2236,10 @@ XML_SetParamEntityParsing(XML_Parser parser,
 #endif
 }
 
-// DEPRECATED since Expat 2.8.0.
-int XMLCALL
-XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
+/* The body of XML_SetHashSalt, so that Expat's own tests can reach it
+   without tripping the deprecation of the public function. */
+XML_NONTESTING_STATIC int
+xmlSetHashSalt(XML_Parser parser, unsigned long hash_salt) {
   if (parser == NULL)
     return 0;
 
@@ -2262,6 +2263,12 @@ XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
   }
 
   return 1;
+}
+
+// DEPRECATED since Expat 2.8.0.
+int XMLCALL
+XML_SetHashSalt(XML_Parser parser, unsigned long hash_salt) {
+  return xmlSetHashSalt(parser, hash_salt);
 }
 
 XML_Bool XMLCALL

--- a/expat/tests/basic_tests.c
+++ b/expat/tests/basic_tests.c
@@ -214,7 +214,7 @@ START_TEST(test_hash_collision) {
         "<d8>This triggers the table growth and collides with b2</d8>\n"
         "</doc>\n";
 
-  XML_SetHashSalt(g_parser, COLLIDING_HASH_SALT);
+  xmlSetHashSalt(g_parser, COLLIDING_HASH_SALT);
   if (_XML_Parse_SINGLE_BYTES(g_parser, text, (int)strlen(text), XML_TRUE)
       == XML_STATUS_ERROR)
     xml_failure(g_parser);
@@ -2402,7 +2402,7 @@ START_TEST(test_set_foreign_dtd) {
   ExtTest test_data = {"<!ELEMENT doc (#PCDATA)*>", NULL, NULL};
 
   /* Check hash salt is passed through too */
-  XML_SetHashSalt(g_parser, 0x12345678);
+  xmlSetHashSalt(g_parser, 0x12345678);
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetUserData(g_parser, &test_data);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader);
@@ -2421,7 +2421,7 @@ START_TEST(test_set_foreign_dtd) {
       != XML_ERROR_CANT_CHANGE_FEATURE_ONCE_PARSING)
     fail("Failed to reject late foreign DTD setting");
   /* Ditto for the hash salt */
-  if (XML_SetHashSalt(g_parser, 0x23456789))
+  if (xmlSetHashSalt(g_parser, 0x23456789))
     fail("Failed to reject late hash salt change");
 
   /* Now finish the parse */
@@ -2472,7 +2472,7 @@ START_TEST(test_foreign_dtd_with_doctype) {
   ExtTest test_data = {"<!ELEMENT doc (#PCDATA)*>", NULL, NULL};
 
   /* Check hash salt is passed through too */
-  XML_SetHashSalt(g_parser, 0x12345678);
+  xmlSetHashSalt(g_parser, 0x12345678);
   XML_SetParamEntityParsing(g_parser, XML_PARAM_ENTITY_PARSING_ALWAYS);
   XML_SetUserData(g_parser, &test_data);
   XML_SetExternalEntityRefHandler(g_parser, external_entity_loader);
@@ -2491,7 +2491,7 @@ START_TEST(test_foreign_dtd_with_doctype) {
       != XML_ERROR_CANT_CHANGE_FEATURE_ONCE_PARSING)
     fail("Failed to reject late foreign DTD setting");
   /* Ditto for the hash salt */
-  if (XML_SetHashSalt(g_parser, 0x23456789))
+  if (xmlSetHashSalt(g_parser, 0x23456789))
     fail("Failed to reject late hash salt change");
 
   /* Now finish the parse */


### PR DESCRIPTION
`XML_SetHashSalt` has been deprecated since 2.8.0, but nothing tells a caller unless they read the header. This puts the deprecation in front of the compiler, as discussed in #1324.

Three commits, following the shape @hartwork asked for in review:

1. `XML_ATTR_DEPRECATED(message)` joins the other `XML_ATTR_*` macros in `expat_external.h` and goes on that one declaration, the only thing marked deprecated in `expat.h` today. Clang and GCC get `__attribute__((__deprecated__(message)))`, MSVC gets `__declspec(deprecated(message))`. It sits in front of `XMLPARSEAPI(int)` rather than after it, because `__declspec` has to come before the calling convention.
2. The body of `XML_SetHashSalt` moves into an internal `xmlSetHashSalt` and the public function becomes a one line wrapper. The five call sites in `basic_tests.c` use the internal one, so Expat keeps testing that code without tripping its own deprecation.
3. The three fuzzers move to `XML_SetHashSalt16Bytes`. The two C ones need 16 bytes where siphash24 gives 8, so they hash the input under two keys and take a half from each; the lpm one passes the sixteen 0x41 bytes its old constant stood for.

A caller outside Expat now gets:

```
user.c:6:3: warning: 'XML_SetHashSalt' is deprecated: please use XML_SetHashSalt16Bytes instead [-Wdeprecated-declarations]
```

Checked on Debian with GCC 14 and clang-format 23: format clean on all eight touched files, `-DEXPAT_WARNINGS_AS_ERRORS=ON -DEXPAT_BUILD_TESTS=ON` builds without a warning, `runtests` passes, both C fuzzers compile under `-Wall -Wextra -Werror`, and the same program using `XML_SetHashSalt16Bytes` stays quiet under `-Werror`.

Closes #1324
