### PR TITLE
xmlwf: handle errors when closing output files

### DIFF
--- a/expat/xmlwf/xmlwf.c
+++ b/expat/xmlwf/xmlwf.c
@@ -1195,6 +1195,7 @@ tmain(int argc, XML_Char **argv) {
   for (; i < argc; i++) {
     XML_Char *outName = 0;
     int result;
+    int outputError = 0;
     XML_Parser parser;
     if (useNamespaces)
       parser = XML_ParserCreateNS(encoding, NSSEP);
@@ -1354,8 +1355,13 @@ tmain(int argc, XML_Char **argv) {
     if (outputDir) {
       if (outputType == 'm')
         metaEndDocument(parser);
-      fclose(userData.fp);
-      if (! result) {
+      if (fclose(userData.fp) != 0) {
+        tperror(outName);
+        outputError = 1;
+        if (result && exitCode != XMLWF_EXIT_NOT_WELLFORMED)
+          exitCode = XMLWF_EXIT_OUTPUT_ERROR;
+      }
+      if (! result || outputError) {
         tremove(outName);
       }
       free(outName);
@@ -1367,6 +1373,8 @@ tmain(int argc, XML_Char **argv) {
       if (! continueOnError) {
         break;
       }
+    } else if (outputError && ! continueOnError) {
+      break;
     }
   }
   return exitCode;


### PR DESCRIPTION
### Problem

`xmlwf` ignored the return value from `fclose()` after generating an output file.

Because stdio output is buffered, write failures may only be reported while flushing or closing the stream. In that case, `xmlwf` could return success even though the requested output was not completely written.

### Fix

Check the result of `fclose()` and:

* report the affected output path;
* return `XMLWF_EXIT_OUTPUT_ERROR` for an output-only failure;
* remove incomplete output;
* preserve an existing not-well-formed result;
* respect `-k` when processing multiple input files.

### Testing

Verified manually using `/dev/full`:

* an output-only close failure returns exit status 3;
* a combined parse/output failure preserves exit status 2;
* with `-k`, processing continues to subsequent inputs and the final status reports the output error.

The existing CMake test suite also passes.
