### PR TITLE
tests: Propagate `xmltest.sh` failures via exit status

### DIFF
--- a/expat/tests/xmltest.sh
+++ b/expat/tests/xmltest.sh
@@ -172,3 +172,4 @@ done
 
 echo "Passed: $SUCCESS"
 echo "Failed: $ERROR"
+test "$ERROR" -eq 0


### PR DESCRIPTION
### Problem

`xmltest.sh` tracks failed W3C conformance tests in `ERROR`, but the script previously ended with an `echo` command.

As a result, the script normally returned success even when one or more tests had failed.

### Fix

Make the script return success only when the accumulated failure count is zero.

### Testing

Verified the resulting exit-status behavior:

* `ERROR=0` returns success;
* a nonzero `ERROR` returns failure.

The existing Expat test suite also passes.
